### PR TITLE
fix(sdk): use snake_case property names for Anthropic SDK response objects

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "AIquila - MCP server for Nextcloud integration with Claude AI",
   "type": "module",
   "main": "dist/index.js",

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -28,7 +28,7 @@
 
 Built with [Claude](https://www.anthropic.com/claude) by [Anthropic](https://www.anthropic.com). Made possible by the [Nextcloud](https://nextcloud.com) platform and its open-source community. Thank you.
     ]]></description>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/lib/Service/ClaudeSDKService.php
+++ b/nextcloud-app/lib/Service/ClaudeSDKService.php
@@ -120,10 +120,10 @@ class ClaudeSDKService {
             }
 
             $this->logger->info('AIquila SDK: Successful response', [
-                'stop_reason' => $response->stopReason ?? 'unknown',
+                'stop_reason' => $response->stop_reason ?? 'unknown',
                 'usage' => [
-                    'input_tokens' => $response->usage->inputTokens ?? 0,
-                    'output_tokens' => $response->usage->outputTokens ?? 0,
+                    'input_tokens' => $response->usage->input_tokens ?? 0,
+                    'output_tokens' => $response->usage->output_tokens ?? 0,
                 ]
             ]);
 
@@ -244,10 +244,10 @@ class ClaudeSDKService {
             }
 
             $this->logger->info('AIquila SDK: Image analysis response', [
-                'stop_reason' => $response->stopReason ?? 'unknown',
+                'stop_reason' => $response->stop_reason ?? 'unknown',
                 'usage' => [
-                    'input_tokens' => $response->usage->inputTokens ?? 0,
-                    'output_tokens' => $response->usage->outputTokens ?? 0,
+                    'input_tokens' => $response->usage->input_tokens ?? 0,
+                    'output_tokens' => $response->usage->output_tokens ?? 0,
                 ]
             ]);
 

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
## Summary

- The Anthropic PHP SDK exposes `stop_reason`, `input_tokens`, and `output_tokens` in **snake_case**
- `ClaudeSDKService` was accessing them as `stopReason`, `inputTokens`, `outputTokens` (camelCase)
- The SDK's `__get()` magic method throws a `RuntimeException` for unknown properties, bypassing the `?? 'unknown'` null-coalescing guards
- This caused the test connection to always fail with *"Property 'stopReason' does not exist"*
- Fixed by using the correct snake_case property names throughout `ClaudeSDKService.php`
- Bumps version to **0.1.15**

Closes #23
Closes #24
Closes #25

## Test plan

- [ ] Settings → AIquila → Test Connection returns a success response without errors
- [ ] Verify `stop_reason`, `input_tokens`, `output_tokens` are logged correctly in the connection test output
- [ ] Confirm no regression in chat functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)