### PR TITLE
fix(nextcloud): bump to 0.1.17, declare PHP 8.4 minimum in info.xml

### DIFF
--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -28,7 +28,7 @@
 
 Built with [Claude](https://www.anthropic.com/claude) by [Anthropic](https://www.anthropic.com). Made possible by the [Nextcloud](https://nextcloud.com) platform and its open-source community. Thank you.
     ]]></description>
-    <version>0.1.16</version>
+    <version>0.1.17</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>
@@ -45,6 +45,7 @@ Built with [Claude](https://www.anthropic.com/claude) by [Anthropic](https://www
     <repository>https://github.com/elgorro/aiquila</repository>
     <donation>https://liberapay.com/elgorro/donate</donation>
     <dependencies>
+        <php min-version="8.4"/>
         <nextcloud min-version="31" max-version="33"/>
     </dependencies>
     <settings>

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
Add <php min-version="8.4"/> to the dependencies block so Nextcloud's app manager blocks installation on PHP < 8.4 with a clear error instead of silently installing and returning a 500 on /settings/apps/installed.

## Description
Brief description of the changes.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Component
- [ ] MCP Server
- [ ] Nextcloud App
- [ ] Documentation
- [ ] CI/CD

## Checklist
- [ ] I have tested my changes locally
- [ ] I have added tests for new functionality
- [ ] I have updated the documentation if needed
- [ ] My code follows the project's style guidelines

## Related Issues
Fixes #

## Screenshots (if applicable)
