### PR TITLE
feat(hetzner): add test group system with MCP protocol + NC app checks

### DIFF
--- a/.github/workflows/hetzner-integration-test.yml
+++ b/.github/workflows/hetzner-integration-test.yml
@@ -20,6 +20,30 @@ on:
         description: 'Hetzner server type for MCP server'
         required: false
         default: 'cpx11'
+      run_oauth_test:
+        description: 'Run OAuth PKCE flow test'
+        type: boolean
+        default: true
+      run_tools_test:
+        description: 'Run MCP tools functional test'
+        type: boolean
+        default: true
+      run_mcp_protocol_test:
+        description: 'Run MCP protocol conformance check'
+        type: boolean
+        default: true
+      run_nc_app_test:
+        description: 'Run Nextcloud AIquila app API check'
+        type: boolean
+        default: true
+      run_connector_test:
+        description: 'Run MCP-Connector test (uses Anthropic API)'
+        type: boolean
+        default: false
+      run_infra_test:
+        description: 'Run infrastructure checks (TLS, CrowdSec)'
+        type: boolean
+        default: true
 
 jobs:
   integration-test:
@@ -33,9 +57,21 @@ jobs:
       DNS_ZONE: ${{ inputs.dns_zone }}
       NC_SERVER_TYPE: ${{ inputs.nc_server_type }}
       MCP_SERVER_TYPE: ${{ inputs.mcp_server_type }}
+      RUN_OAUTH_TEST: ${{ inputs.run_oauth_test }}
+      RUN_TOOLS_TEST: ${{ inputs.run_tools_test }}
+      RUN_MCP_PROTOCOL_TEST: ${{ inputs.run_mcp_protocol_test }}
+      RUN_NC_APP_TEST: ${{ inputs.run_nc_app_test }}
+      RUN_CONNECTOR_TEST: ${{ inputs.run_connector_test }}
+      RUN_INFRA_TEST: ${{ inputs.run_infra_test }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Mask sensitive inputs
+        run: |
+          echo "::add-mask::${{ inputs.nc_domain }}"
+          echo "::add-mask::${{ inputs.mcp_domain }}"
+          echo "::add-mask::${{ inputs.dns_zone }}"
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/docs/hetzner/ci-flow.md
+++ b/docs/hetzner/ci-flow.md
@@ -33,12 +33,14 @@ a named reviewer before secrets are exposed.
 | AIquila OCC install | ~1 min | tarball download + `occ app:enable` |
 | Poll NC ready (`/status.php`) | 0–5 min | Usually done during MCP provision |
 | Poll MCP ready (`/.well-known`) | 0–2 min | |
-| OAuth test | ~1 min | Full PKCE flow |
-| Tools test | ~2 min | 8 tool operations |
-| MCP-Connector test | ~2 min | Claude API round-trip |
-| TLS + CrowdSec verification | ~1 min | |
+| OAuth test _(group: oauth)_ | ~1 min | Full PKCE flow |
+| Tools test _(group: tools)_ | ~2 min | 8 tool operations |
+| MCP protocol conformance _(group: mcp_protocol)_ | ~1 min | Raw JSON-RPC assertions on `initialize` + `tools/list` |
+| NC app API check _(group: nc_app)_ | <1 min | REST endpoint smoke test |
+| MCP-Connector test _(group: connector, off by default)_ | ~2 min | Anthropic API round-trip |
+| TLS + CrowdSec _(group: infra)_ | ~1 min | |
 | Destroy both servers | ~2 min | Always runs (cleanup step) |
-| **Total** | **~25 min** | NC + MCP provision can be parallelised |
+| **Total** | **~27 min** | NC + MCP provision can be parallelised |
 
 > **Parallelism opportunity:** NC and MCP servers can be provisioned concurrently since they are
 > independent. The integration-test script currently provisions them sequentially; a future
@@ -52,11 +54,13 @@ a named reviewer before secrets are exposed.
 |--------|----------|
 | `HCLOUD_TOKEN` | Server provisioning and destroy |
 | `HETZNER_DNS_TOKEN` | DNS A/AAAA record creation |
-| `ANTHROPIC_API_KEY` | MCP-Connector test (Claude API round-trip) |
+| `ANTHROPIC_API_KEY` | Drives the Claude agent; also used by the connector test if enabled |
 
 ---
 
 ### Inputs
+
+#### Infrastructure
 
 | Input | Default | Description |
 |-------|---------|-------------|
@@ -66,6 +70,17 @@ a named reviewer before secrets are exposed.
 | `nc_server_type` | `cpx21` | NC server — 4 vCPU, 8 GB RAM |
 | `mcp_server_type` | `cpx11` | MCP server — 2 vCPU, 2 GB RAM |
 
+#### Test group toggles (boolean)
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `run_oauth_test` | `true` | OAuth PKCE flow (step 8) |
+| `run_tools_test` | `true` | MCP tools functional test (step 9) |
+| `run_mcp_protocol_test` | `true` | MCP JSON-RPC conformance assertions (step 10) |
+| `run_nc_app_test` | `true` | NC AIquila app REST smoke test (step 11) |
+| `run_connector_test` | `false` | MCP-Connector round-trip — uses Anthropic API (step 12) |
+| `run_infra_test` | `true` | TLS certificate + CrowdSec checks (steps 13–14) |
+
 ---
 
 ### Cost per run
@@ -74,11 +89,13 @@ a named reviewer before secrets are exposed.
 |----------|------|-------------------|
 | Hetzner cpx21 (NC) | ~€0.004/h | < €0.003 |
 | Hetzner cpx11 (MCP) | ~€0.002/h | < €0.002 |
-| Anthropic API (MCP-Connector test) | ~$0.10–$0.50 | varies |
+| Anthropic API — Claude agent | ~$0.10–$0.50 | varies; dominates |
+| Anthropic API — connector test | ~$0.05–$0.20 | only when `run_connector_test=true` |
 | **Total** | | **< €0.01 infra; API costs dominate** |
 
-Infrastructure costs are essentially negligible. The Anthropic API call for the MCP-Connector
-test is the dominant cost (~$0.10–$0.50 per run depending on prompt complexity).
+Infrastructure costs are essentially negligible. The Anthropic API call that drives the Claude
+agent is the dominant cost (~$0.10–$0.50 per run). Enabling the connector test adds a further
+~$0.05–$0.20 for the Anthropic API round-trip.
 
 ---
 

--- a/docs/hetzner/integration-test.md
+++ b/docs/hetzner/integration-test.md
@@ -2,62 +2,113 @@
 
 ## Overview
 
-The integration test is a Claude Agent SDK runner (`hetzner/scripts/integration-test.ts`)
-that provisions a real Hetzner Cloud server, deploys AIquila on it, runs the full OAuth
-and MCP tools test suite against the live HTTPS endpoint, verifies Traefik TLS and CrowdSec
-health, then destroys the server. It uses the `@anthropic-ai/claude-code-sdk` `query()` API
-so a Claude agent drives every step via bash commands, streaming progress to stderr for
-human-readable CI logs.
+The integration test provisions two real Hetzner Cloud servers — a Nextcloud server with the
+AIquila app installed and an MCP server pointing at it — runs a full test suite against the live
+HTTPS endpoint, then destroys both servers.
+
+It is driven by `hetzner/scripts/integration-test.ts`, which uses the
+`@anthropic-ai/claude-code-sdk` `query()` API so a Claude agent executes every step via bash
+commands, streaming progress to stderr for human-readable CI logs.
+
+---
+
+## Test groups
+
+The suite is split into six independently togglable groups. Five are **on by default**; the
+connector test (which calls the Anthropic API a second time) is **off by default**.
+
+| Group | Env var | Default | Steps |
+|-------|---------|---------|-------|
+| `oauth` | `RUN_OAUTH_TEST` | `true` | 8 — full OAuth PKCE flow |
+| `tools` | `RUN_TOOLS_TEST` | `true` | 9 — MCP tool operations |
+| `mcp_protocol` | `RUN_MCP_PROTOCOL_TEST` | `true` | 10 — raw JSON-RPC conformance assertions |
+| `nc_app` | `RUN_NC_APP_TEST` | `true` | 11 — AIquila app REST endpoint smoke test |
+| `connector` | `RUN_CONNECTOR_TEST` | `false` | 12 — MCP-Connector round-trip (Anthropic API) |
+| `infra` | `RUN_INFRA_TEST` | `true` | 13–14 — TLS certificate + CrowdSec container |
+
+Groups that are disabled emit `SKIP — <label>` so the agent marks them in the final summary.
+The PASS/FAIL/SKIP summary determines the workflow exit code.
 
 ---
 
 ## Test steps
 
 1. Build the `aiquila-hetzner` binary from source.
-2. Provision a test server named `aiquila-inttest-<timestamp>` using `aiquila-hetzner create`.
-3. Poll `https://<domain>/.well-known/oauth-authorization-server` until it responds (up to 5 minutes).
-4. Run the OAuth PKCE flow via `docker/standalone/scripts/test-oauth.sh https://<domain>`.
-5. Run the MCP tools end-to-end suite via `docker/standalone/scripts/test-tools.sh https://<domain>`.
-6. Verify Traefik TLS: `curl -sI https://<domain>/mcp` must return an HTTP 4xx with a valid certificate.
-7. Verify CrowdSec: SSH into the server and confirm `docker ps | grep crowdsec` shows a running container.
-8. Destroy the server and its DNS record (always runs, even when earlier steps fail).
+2. Choose a shared timestamp suffix (`nc-inttest-<ts>`, `mcp-inttest-<ts>`).
+3. Provision the **Nextcloud server** (`--stack nextcloud`, server type `NC_SERVER_TYPE`).
+4. Provision the **MCP server** (`--stack mcp`, server type `MCP_SERVER_TYPE`), pointed at the NC server.
+5. Poll `https://<NC_DOMAIN>/status.php` until `{"installed":true}` (up to 5 min).
+6. Verify AIquila app is installed on NC via OCS API.
+7. Poll `https://<MCP_DOMAIN>/.well-known/oauth-authorization-server` until ready (up to 5 min).
+8. **[oauth]** Run `docker/standalone/scripts/test-oauth.sh` — full PKCE flow.
+9. **[tools]** Run `docker/standalone/scripts/test-tools.sh` — end-to-end MCP tool operations.
+10. **[mcp_protocol]** Send raw JSON-RPC requests and assert on response fields:
+    - `initialize` → assert `protocolVersion == "2025-03-26"`, `serverInfo.name == "aiquila"`, `capabilities.tools` exists
+    - `tools/list` → assert non-empty array containing `system_status`, `list_files`, `create_folder`, `write_file`, `read_file`, `delete`
+11. **[nc_app]** Verify AIquila app REST endpoints with NC basic auth:
+    - `GET /apps/aiquila/api/settings` → HTTP 200 with JSON body
+    - `GET /ocs/v2.php/apps/aiquila` → HTTP 200 containing `"aiquila"`
+12. **[connector]** Run `mcp-server/scripts/test-mcp-connector.ts` — Anthropic API round-trip via MCP.
+13. **[infra]** `curl -sI https://<MCP_DOMAIN>/mcp` → HTTP 4xx with valid TLS (no cert error).
+14. **[infra]** SSH into MCP server → confirm `aiq-crowdsec` container is running.
+15. Destroy both servers and their DNS records — **always runs, even if earlier steps fail**.
 
 ---
 
 ## How it works
 
-`integration-test.ts` passes a detailed prompt to the `query()` API with:
+`integration-test.ts` builds the prompt at runtime:
 
-- `allowedTools: ["Bash"]` — the agent may only run shell commands.
+1. Each step body (`STEP_8_TEXT` … `STEP_13_14_TEXT`) is inserted via `.replace()` — or
+   replaced with a `SKIP` message based on `testConfig`.
+2. Domain and zone placeholders (`NC_DOMAIN`, `MCP_DOMAIN`, `DNS_ZONE`, …) are expanded via
+   `.replaceAll()` over the fully assembled prompt.
+
+The step texts are inserted **before** domain substitution so that domain placeholders inside
+step bodies are also expanded correctly.
+
+The agent is called with:
+
+- `allowedTools: ["Bash"]` — shell commands only.
 - `permissionMode: "bypassPermissions"` — no interactive confirmations.
 - `cwd: "/workspace"` — the GitHub Actions checkout root.
 
-The runner processes the streamed message events:
+Streamed message events:
 
-- `assistant` messages — `text` blocks are written to stderr so CI logs are human-readable.
-- `result` message — checked for success:
-  - `is_error: true` → exit 1
-  - result text containing `FAIL` (case-insensitive) → exit 1
-  - otherwise → exit 0
+- `assistant` → `text` blocks written to stderr (human-readable CI logs).
+- `result` → `is_error: true` or result text containing `FAIL` → exit 1; otherwise exit 0.
 
-A separate safety-net step in the workflow (`if: always()`) calls `aiquila-hetzner list`
-and destroys any `aiquila-inttest-*` servers that the agent may have failed to clean up.
+A safety-net step in the workflow (`if: always()`) calls `aiquila-hetzner list` and destroys
+any lingering `nc-inttest-*` / `mcp-inttest-*` servers in case the agent step crashes mid-run.
 
 ---
 
 ## Triggering via GitHub Actions
 
-The workflow is triggered manually via `workflow_dispatch`:
-
 ```
 Actions → Hetzner Integration Test → Run workflow
 ```
 
-| Input | Required | Default | Example |
-|-------|----------|---------|---------|
-| `test_domain` | yes | — | `inttest.example.com` |
-| `dns_zone` | yes | — | `example.com` |
-| `server_type` | no | `cpx11` | `cpx21` |
+### Infrastructure inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `nc_domain` | yes | — | FQDN for the Nextcloud test server |
+| `mcp_domain` | yes | — | FQDN for the MCP test server |
+| `dns_zone` | yes | — | Hetzner DNS zone (e.g. `example.com`) |
+| `nc_server_type` | no | `cpx21` | Hetzner server type for NC (4 vCPU / 8 GB) |
+| `mcp_server_type` | no | `cpx11` | Hetzner server type for MCP (2 vCPU / 2 GB) |
+
+### Test group toggles
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `run_oauth_test` | `true` | OAuth PKCE flow |
+| `run_tools_test` | `true` | MCP tools functional test |
+| `run_mcp_protocol_test` | `true` | MCP JSON-RPC conformance assertions |
+| `run_nc_app_test` | `true` | NC AIquila app REST smoke test |
+| `run_connector_test` | `false` | MCP-Connector (requires Anthropic API; adds cost) |
+| `run_infra_test` | `true` | TLS certificate + CrowdSec checks |
 
 ---
 
@@ -66,11 +117,8 @@ Actions → Hetzner Integration Test → Run workflow
 | Secret | Description |
 |--------|-------------|
 | `HCLOUD_TOKEN` | Hetzner Cloud API token |
-| `HETZNER_DNS_TOKEN` | Hetzner DNS token (for A record creation/deletion) |
-| `NEXTCLOUD_URL` | Existing Nextcloud instance URL |
-| `NEXTCLOUD_USER` | Nextcloud username |
-| `NEXTCLOUD_PASSWORD` | Nextcloud app password |
-| `ANTHROPIC_API_KEY` | Anthropic API key (for the Claude agent) |
+| `HETZNER_DNS_TOKEN` | Hetzner DNS token (A record creation/deletion) |
+| `ANTHROPIC_API_KEY` | Drives the Claude agent; also used by the connector test if enabled |
 
 ---
 
@@ -79,28 +127,34 @@ Actions → Hetzner Integration Test → Run workflow
 ```bash
 export HCLOUD_TOKEN=...
 export HETZNER_DNS_TOKEN=...
-export NEXTCLOUD_URL=...
-export NEXTCLOUD_USER=...
-export NEXTCLOUD_PASSWORD=...
 export ANTHROPIC_API_KEY=...
-export TEST_DOMAIN=inttest.example.com
+export NC_DOMAIN=nc-inttest.example.com
+export MCP_DOMAIN=mcp-inttest.example.com
 export DNS_ZONE=example.com
-export SERVER_TYPE=cpx11
+export NC_SERVER_TYPE=cpx21   # optional, default cpx21
+export MCP_SERVER_TYPE=cpx11  # optional, default cpx11
+
+# Override group defaults if needed
+export RUN_CONNECTOR_TEST=true   # off by default
+export RUN_INFRA_TEST=false      # skip for quick dev runs
 
 cd hetzner/scripts
 npm install
 npx tsx integration-test.ts
 ```
 
-> **Note:** The agent's `cwd` is set to `/workspace` (the GitHub Actions checkout path).
-> When running locally, the agent has bash access and will adapt — run the command from the
-> repository root so that relative paths like `docker/standalone/scripts/test-oauth.sh` resolve
-> correctly, or set a `WORKSPACE` environment variable pointing to the repo root if you need
-> to run from a different directory.
+> **Note:** The agent's `cwd` is hard-coded to `/workspace` (the GitHub Actions checkout path).
+> When running locally, run the command from the repository root so that relative paths like
+> `docker/standalone/scripts/test-oauth.sh` resolve correctly, or temporarily adjust `cwd` in
+> `integration-test.ts`.
 
 ---
 
 ## Cost
 
-- **Hetzner:** a `cpx11` server runs for roughly 10 minutes ≈ €0.001.
-- **Anthropic API:** one agent run ≈ $0.10–$0.50 depending on the number of turns the agent takes.
+| Resource | Notes |
+|----------|-------|
+| Hetzner cpx21 (NC, ~25 min) | < €0.003 |
+| Hetzner cpx11 (MCP, ~25 min) | < €0.002 |
+| Anthropic API — Claude agent | ~$0.10–$0.50 per run (dominant cost) |
+| Anthropic API — connector test | additional ~$0.05–$0.20 if `run_connector_test=true` |

--- a/hetzner/scripts/integration-test.ts
+++ b/hetzner/scripts/integration-test.ts
@@ -1,5 +1,64 @@
 import { query } from "@anthropic-ai/claude-code-sdk";
 
+const testConfig = {
+  oauth: process.env.RUN_OAUTH_TEST !== "false",
+  tools: process.env.RUN_TOOLS_TEST !== "false",
+  mcpProtocol: process.env.RUN_MCP_PROTOCOL_TEST !== "false",
+  ncApp: process.env.RUN_NC_APP_TEST !== "false",
+  connector: process.env.RUN_CONNECTOR_TEST === "true",
+  infra: process.env.RUN_INFRA_TEST !== "false",
+};
+
+function step(enabled: boolean, instruction: string, label: string): string {
+  return enabled ? instruction : `SKIP — ${label}. Mark as SKIP in summary.`;
+}
+
+const STEP_8_TEXT = `Run OAuth test:
+   cd /workspace && bash docker/standalone/scripts/test-oauth.sh https://MCP_DOMAIN`;
+
+const STEP_9_TEXT = `Run tools test:
+   cd /workspace && bash docker/standalone/scripts/test-tools.sh https://MCP_DOMAIN`;
+
+const STEP_10_TEXT = `Run MCP protocol conformance check:
+   Obtain an access token via PKCE (reuse from step 8 if available, or perform a fresh flow).
+   Then send two MCP JSON-RPC requests directly:
+
+   a) POST https://MCP_DOMAIN/mcp
+      Headers: Authorization: Bearer <token>, Content-Type: application/json
+      Body: {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"conformance-test","version":"1.0"}}}
+      Assert (using jq or python3 -mjson.tool):
+        - .result.protocolVersion == "2025-03-26"
+        - .result.serverInfo.name == "aiquila"
+        - .result.capabilities.tools exists (not null)
+      Save mcp-session-id from response header.
+
+   b) POST https://MCP_DOMAIN/mcp
+      Headers: Authorization: Bearer <token>, Mcp-Session-Id: <session-id>, Content-Type: application/json
+      Body: {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+      Assert:
+        - .result.tools is a non-empty array
+        - array contains tools named: system_status, list_files, create_folder, write_file, read_file, delete`;
+
+const STEP_11_TEXT = `Verify AIquila Nextcloud app REST endpoints with basic auth (admin:<nc-admin-password>):
+
+   a) GET https://NC_DOMAIN/apps/aiquila/api/settings
+      Assert: HTTP 200 with JSON body (app endpoints accessible)
+
+   b) GET https://NC_DOMAIN/ocs/v2.php/apps/aiquila
+      -H "OCS-APIRequest: true"
+      Assert: HTTP 200 and response contains "aiquila"`;
+
+const STEP_12_TEXT = `Run MCP-Connector test:
+   cd /workspace/mcp-server/scripts && npm install --silent
+   MCP_URL=https://MCP_DOMAIN tsx test-mcp-connector.ts
+   (ANTHROPIC_API_KEY is available in the environment)`;
+
+const STEP_13_14_TEXT = `13. Verify Traefik TLS on MCP:
+    curl -sI https://MCP_DOMAIN/mcp → HTTP 4xx with valid TLS (no cert error)
+
+14. Verify CrowdSec running on MCP server:
+    SSH into MCP server and run: docker ps | grep aiq-crowdsec → confirm Up`;
+
 const PROMPT = `
 You are an integration test agent for AIquila on Hetzner Cloud.
 
@@ -57,38 +116,67 @@ Your job:
 7. Wait for MCP ready:
    Poll https://MCP_DOMAIN/.well-known/oauth-authorization-server up to 5 minutes
 
-8. Run OAuth test:
-   cd /workspace && bash docker/standalone/scripts/test-oauth.sh https://MCP_DOMAIN
+8. STEP_8
 
-9. Run tools test:
-   cd /workspace && bash docker/standalone/scripts/test-tools.sh https://MCP_DOMAIN
+9. STEP_9
 
-10. Run MCP-Connector test:
-    cd /workspace/mcp-server/scripts && npm install --silent
-    MCP_URL=https://MCP_DOMAIN tsx test-mcp-connector.ts
-    (ANTHROPIC_API_KEY is available in the environment)
+10. STEP_10
 
-11. Verify Traefik TLS on MCP:
-    curl -sI https://MCP_DOMAIN/mcp → HTTP 4xx with valid TLS (no cert error)
+11. STEP_11
 
-12. Verify CrowdSec running on MCP server:
-    SSH into MCP server and run: docker ps | grep aiq-crowdsec → confirm Up
+12. STEP_12
 
-13. Destroy both servers (ALWAYS run this, even if tests fail):
+STEP_13_14
+
+15. Destroy both servers (ALWAYS run this, even if tests fail):
     /tmp/aiquila-hetzner destroy --name "${NC_NAME}" --dns-zone DNS_ZONE
     /tmp/aiquila-hetzner destroy --name "${MCP_NAME}" --dns-zone DNS_ZONE
 
 CRITICAL: Always destroy both servers at the end, even if tests fail.
-Report PASS/FAIL for each step and a final summary.
+Report PASS/FAIL/SKIP for each step and a final summary.
 `;
 
-// Substitute env vars into the prompt at runtime.
-const prompt = PROMPT
+// Build the prompt: insert step bodies first so domain placeholders inside
+// step texts are also expanded by the subsequent replaceAll calls.
+const prompt = PROMPT.replace(
+  "STEP_8",
+  step(testConfig.oauth, STEP_8_TEXT, "OAuth PKCE test"),
+)
+  .replace(
+    "STEP_9",
+    step(testConfig.tools, STEP_9_TEXT, "Tools functional test"),
+  )
+  .replace(
+    "STEP_10",
+    step(testConfig.mcpProtocol, STEP_10_TEXT, "MCP protocol conformance"),
+  )
+  .replace("STEP_11", step(testConfig.ncApp, STEP_11_TEXT, "NC app API check"))
+  .replace(
+    "STEP_12",
+    step(testConfig.connector, STEP_12_TEXT, "MCP-Connector test"),
+  )
+  .replace(
+    "STEP_13_14",
+    step(testConfig.infra, STEP_13_14_TEXT, "Infrastructure checks"),
+  )
   .replaceAll("NC_DOMAIN", process.env.NC_DOMAIN ?? "")
   .replaceAll("MCP_DOMAIN", process.env.MCP_DOMAIN ?? "")
   .replaceAll("DNS_ZONE", process.env.DNS_ZONE ?? "")
   .replaceAll("NC_SERVER_TYPE", process.env.NC_SERVER_TYPE ?? "cpx21")
   .replaceAll("MCP_SERVER_TYPE", process.env.MCP_SERVER_TYPE ?? "cpx11");
+
+const seenIPs = new Set<string>();
+const IPv4_RE = /\b(\d{1,3}\.){3}\d{1,3}\b/g;
+
+function maskNewIPs(text: string): void {
+  for (const match of text.matchAll(IPv4_RE)) {
+    const ip = match[0];
+    if (!seenIPs.has(ip)) {
+      seenIPs.add(ip);
+      process.stdout.write(`::add-mask::${ip}\n`);
+    }
+  }
+}
 
 let exitCode = 1; // pessimistic default
 
@@ -103,12 +191,15 @@ for await (const message of query({
   if (message.type === "assistant") {
     for (const block of message.message.content) {
       if (block.type === "text") {
+        maskNewIPs(block.text);
         process.stderr.write(block.text);
       }
     }
   } else if (message.type === "result") {
     process.stderr.write(`\n--- Agent result: ${message.subtype} ---\n`);
-    process.stderr.write(`Turns: ${message.num_turns}, Cost: $${message.total_cost_usd?.toFixed(4)}\n`);
+    process.stderr.write(
+      `Turns: ${message.num_turns}, Cost: $${message.total_cost_usd?.toFixed(4)}\n`,
+    );
 
     if (!message.is_error) {
       const resultText = (message as any).result ?? "";


### PR DESCRIPTION
## Summary

- Replaces the single `run_connector_test` flag with **six independently togglable test groups** (`oauth`, `tools`, `mcp_protocol`, `nc_app`, `connector`, `infra`) — five on by default, connector off by default
- **New step 10 — MCP protocol conformance:** raw JSON-RPC assertions on `initialize` (`protocolVersion`, `serverInfo.name`, `capabilities.tools`) and `tools/list` (non-empty array, expected tool names present)
- **New step 11 — NC app API check:** smoke-tests AIquila app REST endpoints (`/apps/aiquila/api/settings`, OCS path) with basic auth
- Existing steps renumbered: connector → 12, infra → 13–14, destroy → 15
- Docs updated: `integration-test.md` fully rewritten for two-server model and group system; `ci-flow.md` inputs/timeline/secrets updated

## Test plan

- [ ] Trigger workflow with all defaults → groups oauth/tools/mcp_protocol/nc_app/infra run, connector shows SKIP in summary
- [ ] Trigger with `run_mcp_protocol_test=false` → step 10 shows SKIP
- [ ] Trigger with `run_connector_test=true` → step 12 runs (requires `ANTHROPIC_API_KEY`)
- [ ] Trigger with `run_infra_test=false` → steps 13–14 skipped (quick dev run)
- [ ] Final summary shows PASS/SKIP/FAIL per group

🤖 Generated with [Claude Code](https://claude.com/claude-code)