### PR TITLE
feat(hetzner): add test group system with MCP protocol + NC app checks

### DIFF
--- a/hetzner/scripts/integration-test.ts
+++ b/hetzner/scripts/integration-test.ts
@@ -1,4 +1,4 @@
-import { query } from "@anthropic-ai/claude-code-sdk";
+import { query } from "@anthropic-ai/claude-agent-sdk";
 
 const testConfig = {
   oauth: process.env.RUN_OAUTH_TEST !== "false",
@@ -186,6 +186,7 @@ for await (const message of query({
     allowedTools: ["Bash"],
     permissionMode: "bypassPermissions",
     cwd: "/workspace",
+    systemPrompt: { type: "preset", preset: "claude_code" },
   },
 })) {
   if (message.type === "assistant") {

--- a/hetzner/scripts/package.json
+++ b/hetzner/scripts/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-code-sdk": "latest"
+    "@anthropic-ai/claude-agent-sdk": "latest"
   },
   "devDependencies": {
     "@types/node": "latest",


### PR DESCRIPTION
## Summary

- Adds configurable test group system to the Hetzner integration test, allowing individual test steps (OAuth, tools, MCP protocol, NC app, connector, infra) to be enabled/disabled via env vars
- Adds MCP protocol conformance check (step 10) and Nextcloud app REST endpoint verification (step 11)
- Migrates `hetzner/scripts` from the non-existent `@anthropic-ai/claude-code-sdk` to the renamed `@anthropic-ai/claude-agent-sdk`, and adds the `claude_code` system prompt preset required by v0.1.0
- Bumps `@modelcontextprotocol/sdk` and MCP server version

## Test plan

- [ ] CI Hetzner integration test passes with the fixed npm install step
- [ ] Test groups can be skipped via `RUN_*_TEST=false` env vars in the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)