### PR TITLE
feat(hetzner): improve integration-test agent with SDK patterns

### DIFF
--- a/hetzner/scripts/integration-test.ts
+++ b/hetzner/scripts/integration-test.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { query } from "@anthropic-ai/claude-agent-sdk";
+import { query, type HookCallback } from "@anthropic-ai/claude-agent-sdk";
 
 const testConfig = {
   oauth: process.env.RUN_OAUTH_TEST !== "false",
@@ -188,6 +188,16 @@ function maskNewIPs(text: string): void {
   }
 }
 
+const logAndMaskCommand: HookCallback = async (input) => {
+  const cmd =
+    (((input as any).tool_input as Record<string, unknown>)
+      ?.command as string) ?? "";
+  maskNewIPs(cmd);
+  const firstLine = cmd.split("\n")[0].trim();
+  process.stderr.write(`\n[${new Date().toISOString()}] $ ${firstLine}\n`);
+  return {};
+};
+
 let exitCode = 1; // pessimistic default
 
 for await (const message of query({
@@ -196,14 +206,24 @@ for await (const message of query({
     allowedTools: ["Bash"],
     permissionMode: "bypassPermissions",
     cwd: "/workspace",
+    maxTurns: 200,
     systemPrompt: { type: "preset", preset: "claude_code" },
+    hooks: {
+      PreToolUse: [{ hooks: [logAndMaskCommand] }],
+    },
   },
 })) {
-  if (message.type === "assistant") {
+  if (message.type === "system" && (message as any).subtype === "init") {
+    process.stderr.write(`[session] ${(message as any).session_id}\n`);
+  } else if (message.type === "assistant") {
     for (const block of message.message.content) {
       if (block.type === "text") {
         maskNewIPs(block.text);
         process.stderr.write(block.text);
+      } else if (block.type === "tool_use") {
+        const cmd =
+          ((block.input as Record<string, unknown>)?.command as string) ?? "";
+        maskNewIPs(cmd);
       }
     }
   } else if (message.type === "result") {


### PR DESCRIPTION
## Summary

- Add `maxTurns: 200` to cap runaway agent execution and prevent unbounded Anthropic billing
- Add `PreToolUse` hook for real-time bash command logging with ISO timestamps in CI output
- Log `session_id` from the SDK `system` init message for correlating CI runs with Anthropic usage
- Mask IPs found in `tool_use` content blocks before streamed output appears (edge case coverage)

## Test plan

- [ ] Trigger the Hetzner integration test workflow and verify `[session] <uuid>` appears at the top of the "Run integration test agent" step
- [ ] Verify each bash command appears with a `[ISO timestamp] $` prefix before Claude's text output
- [ ] Verify no bare IPv4 addresses appear unmasked in the log
- [ ] Verify agent completes within 200 turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)