### PR TITLE
fix(hetzner): add node to PATH for claude-agent-sdk subprocess

### DIFF
--- a/.github/workflows/hetzner-integration-test.yml
+++ b/.github/workflows/hetzner-integration-test.yml
@@ -83,13 +83,18 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Install script dependencies
         working-directory: hetzner/scripts
         run: npm install
 
       - name: Run integration test agent
         working-directory: hetzner/scripts
-        run: npx tsx integration-test.ts
+        run: |
+          export PATH="$(dirname "$(which node)"):$PATH"
+          npx tsx integration-test.ts
 
       - name: Safety-net destroy (always runs)
         if: always()


### PR DESCRIPTION
## Summary

- The `claude-agent-sdk` spawns the `claude` CLI via `node <path>`, but `node` wasn't on PATH for child processes in the Actions runner
- Prepend the node bin dir to PATH before running `npx tsx integration-test.ts` so the spawn succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)