### PR TITLE
fix(hetzner): use process.execPath for claude-agent-sdk subprocess

### DIFF
--- a/.github/workflows/hetzner-integration-test.yml
+++ b/.github/workflows/hetzner-integration-test.yml
@@ -92,9 +92,7 @@ jobs:
 
       - name: Run integration test agent
         working-directory: hetzner/scripts
-        run: |
-          export PATH="$(dirname "$(which node)"):$PATH"
-          npx tsx integration-test.ts
+        run: npx tsx integration-test.ts
 
       - name: Safety-net destroy (always runs)
         if: always()

--- a/hetzner/scripts/integration-test.ts
+++ b/hetzner/scripts/integration-test.ts
@@ -207,6 +207,7 @@ for await (const message of query({
     permissionMode: "bypassPermissions",
     cwd: "/workspace",
     maxTurns: 200,
+    executable: process.execPath,
     systemPrompt: { type: "preset", preset: "claude_code" },
     hooks: {
       PreToolUse: [{ hooks: [logAndMaskCommand] }],


### PR DESCRIPTION
## Summary

- The SDK spawns the `claude` CLI using the string `"node"` as the command, which fails with `ENOENT` when node isn't on PATH for child processes in the GitHub Actions runner
- Fix: pass `executable: process.execPath` so the SDK uses the absolute path to the currently-running Node binary, bypassing PATH resolution entirely
- Reverts the ineffective workflow PATH workaround from the previous fix attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)