### PR TITLE
fix(hetzner): symlink /workspace to GITHUB_WORKSPACE in CI

### DIFF
--- a/.github/workflows/hetzner-integration-test.yml
+++ b/.github/workflows/hetzner-integration-test.yml
@@ -90,6 +90,9 @@ jobs:
         working-directory: hetzner/scripts
         run: npm install
 
+      - name: Create /workspace symlink
+        run: sudo ln -s "$GITHUB_WORKSPACE" /workspace
+
       - name: Run integration test agent
         working-directory: hetzner/scripts
         run: npx tsx integration-test.ts


### PR DESCRIPTION
## Summary

- The `claude-agent-sdk` spawns the `claude` CLI with `cwd: "/workspace"`, which doesn't exist on the GitHub Actions runner (code lives at `$GITHUB_WORKSPACE`)
- The `ENOENT` on spawn was caused by the missing working directory, not the binary itself
- Creating a symlink `sudo ln -s "$GITHUB_WORKSPACE" /workspace` keeps all hardcoded `/workspace` paths in the agent prompt working correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)