### PR TITLE
fix(nextcloud): replace old aiquila-v tag prefix with nc-v

The old tag format aiquila-v* (e.g. aiquila-v0.1.15) was cleaned up.
Update nc-release.yml to use nc-v prefix consistent with other
component tags (mcp-v, hetzner-v).

https://claude.ai/code/session_01QpZPXvZxDHspb3fdorXtaR

### DIFF
--- a/.github/workflows/nc-release.yml
+++ b/.github/workflows/nc-release.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Create Git tag
         run: |
           VERSION=${{ needs.check-version.outputs.version }}
-          TAG_NAME="aiquila-v${VERSION}"
+          TAG_NAME="nc-v${VERSION}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -198,7 +198,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: aiquila-v${{ needs.check-version.outputs.version }}
+          tag_name: nc-v${{ needs.check-version.outputs.version }}
           name: Nextcloud App v${{ needs.check-version.outputs.version }}
           body: |
             ## AIquila Nextcloud App Release v${{ needs.check-version.outputs.version }}
@@ -266,7 +266,7 @@ jobs:
       - name: Get release assets
         run: |
           VERSION=${{ needs.check-version.outputs.version }}
-          TAG_NAME="aiquila-v${VERSION}"
+          TAG_NAME="nc-v${VERSION}"
 
           # Get the release download URL
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/${TAG_NAME}/aiquila.tar.gz"


### PR DESCRIPTION
## Description
Brief description of the changes.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Component
- [ ] MCP Server
- [ ] Nextcloud App
- [ ] Documentation
- [ ] CI/CD

## Checklist
- [ ] I have tested my changes locally
- [ ] I have added tests for new functionality
- [ ] I have updated the documentation if needed
- [ ] My code follows the project's style guidelines

## Related Issues
Fixes #

## Screenshots (if applicable)
