### PR TITLE
fix(mcp): retry TLS check on startup instead of crash-looping

### DIFF
--- a/hetzner/cmd/aiquila-hetzner/main.go
+++ b/hetzner/cmd/aiquila-hetzner/main.go
@@ -929,7 +929,12 @@ docker compose -f /opt/aiquila/docker-compose.yml exec -T nc bash -c \
   'mkdir -p /var/www/html/custom_apps && \
    tar -xzf /tmp/aiquila.tar.gz -C /var/www/html/custom_apps/ && \
    php occ app:enable aiquila && \
-   php occ app:enable metrics'
+   php occ app:enable metrics && \
+   php occ config:system:set trusted_proxies 0 --value="172.16.0.0/12" && \
+   php occ config:system:set forwarded_for_headers 0 --value="HTTP_X_FORWARDED_FOR" && \
+   php occ config:system:set maintenance_window_start --type=integer --value=1 && \
+   php occ db:add-missing-indices && \
+   php occ maintenance:repair --include-expensive'
 echo "AIquila app enabled."
 `, tarURL)
 

--- a/hetzner/docker/full/docker-compose.yml
+++ b/hetzner/docker/full/docker-compose.yml
@@ -172,6 +172,7 @@ services:
     environment:
       CONTAINERS: 1
       NETWORKS: 1
+      EVENTS: 1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
@@ -193,7 +194,6 @@ services:
     container_name: aiq-traefik
     restart: unless-stopped
     depends_on:
-      - mcp
       - socket-proxy
       - crowdsec
     ports:

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "description": "AIquila - MCP server for Nextcloud integration with Claude AI",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/elgorro/aiquila.git",
     "source": "github"
   },
-  "version": "0.1.46",
+  "version": "0.1.47",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -41,7 +41,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.1.46",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.1.47",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/transports/http.ts
+++ b/mcp-server/src/transports/http.ts
@@ -26,7 +26,10 @@ const TLS_CERT_ERROR_CODES = new Set([
   'ERR_TLS_CERT_ALTNAME_INVALID',
 ]);
 
-async function checkIssuerTls(issuerUrl: string): Promise<void> {
+const MAX_TLS_ATTEMPTS = 6;
+const TLS_RETRY_DELAY_MS = 15_000;
+
+async function attemptTlsCheck(issuerUrl: string): Promise<'ok' | 'skip' | 'retry'> {
   return new Promise((resolve) => {
     let url: URL;
     try {
@@ -34,7 +37,7 @@ async function checkIssuerTls(issuerUrl: string): Promise<void> {
     } catch {
       logger.error({ issuer: issuerUrl }, '[startup] MCP_AUTH_ISSUER is not a valid URL');
       if (process.env.MCP_TLS_STRICT === 'true') process.exit(1);
-      resolve();
+      resolve('skip');
       return;
     }
 
@@ -44,7 +47,7 @@ async function checkIssuerTls(issuerUrl: string): Promise<void> {
         '[startup] MCP_AUTH_ISSUER must use https:// — plain http exposes OAuth tokens'
       );
       if (process.env.MCP_TLS_STRICT === 'true') process.exit(1);
-      resolve();
+      resolve('skip');
       return;
     }
 
@@ -58,7 +61,7 @@ async function checkIssuerTls(issuerUrl: string): Promise<void> {
       },
       () => {
         logger.info({ issuer: issuerUrl }, '[startup] TLS certificate valid and trusted');
-        resolve();
+        resolve('ok');
       }
     );
 
@@ -72,13 +75,14 @@ async function checkIssuerTls(issuerUrl: string): Promise<void> {
           `will cause Claude to refuse the connection. Use Let's Encrypt (via Traefik or Caddy ` +
           `with a real domain) or mount a CA-signed cert.`;
         if (strict) {
-          logger.fatal({ issuer: issuerUrl, code }, msg);
-          process.exit(1);
+          logger.warn({ issuer: issuerUrl, code }, msg);
+          resolve('retry');
         } else {
           logger.error(
             { issuer: issuerUrl, code },
             msg + ' Set MCP_TLS_STRICT=true to make this a hard failure.'
           );
+          resolve('skip');
         }
       } else {
         // Transient network error — proxy may not be ready yet; do not fail
@@ -86,12 +90,33 @@ async function checkIssuerTls(issuerUrl: string): Promise<void> {
           { issuer: issuerUrl, code: err.code },
           '[startup] TLS check skipped — could not reach issuer (proxy not ready?)'
         );
+        resolve('skip');
       }
-      resolve();
     });
 
     req.end();
   });
+}
+
+async function checkIssuerTls(issuerUrl: string): Promise<void> {
+  for (let attempt = 1; attempt <= MAX_TLS_ATTEMPTS; attempt++) {
+    const result = await attemptTlsCheck(issuerUrl);
+    if (result !== 'retry') return;
+    if (attempt < MAX_TLS_ATTEMPTS) {
+      logger.warn(
+        { issuer: issuerUrl, attempt, maxAttempts: MAX_TLS_ATTEMPTS },
+        `[startup] TLS cert not yet trusted, retrying in ${TLS_RETRY_DELAY_MS / 1000}s ` +
+          `(${attempt}/${MAX_TLS_ATTEMPTS}) — waiting for Let's Encrypt cert`
+      );
+      await new Promise((resolve) => setTimeout(resolve, TLS_RETRY_DELAY_MS));
+    } else {
+      logger.fatal(
+        { issuer: issuerUrl },
+        '[startup] TLS certificate still rejected after all retries — giving up'
+      );
+      process.exit(1);
+    }
+  }
 }
 
 export async function startHttp(): Promise<void> {


### PR DESCRIPTION
## Problem

When `MCP_TLS_STRICT=true`, `checkIssuerTls` called `process.exit(1)` ~25ms after startup if Traefik hadn't obtained the Let's Encrypt cert yet. This caused a cascading deadlock:

1. MCP crash-loops → healthcheck never passes → container stays "unhealthy"
2. Traefik filters out unhealthy containers → `mcp` router never registered
3. ACME challenge never requested → no LE cert → repeat forever

## Fix

**`mcp-server/src/transports/http.ts`**
- Extract `attemptTlsCheck` returning `'ok' | 'skip' | 'retry'`
- Wrap in retry loop: up to 6 attempts × 15 s = 90 s total
- During this window MCP is already listening; Traefik registers the router and ACME completes before the next retry
- Only strict-mode TLS cert errors retry; invalid URL, `http://`, and transient network errors are unchanged

**`hetzner/docker/full/docker-compose.yml`**
- Add `EVENTS: 1` to `socket-proxy` — Traefik receives container health-change events and picks up MCP once its healthcheck passes
- Remove `mcp` from `traefik`'s `depends_on` — Traefik must start independently to serve the ACME HTTP-01 challenge before MCP is healthy

**`hetzner/cmd/aiquila-hetzner/main.go`**
- Apply Nextcloud post-install OCC hardening: `trusted_proxies`, `forwarded_for_headers`, `maintenance_window_start`, `db:add-missing-indices`, `maintenance:repair`

**Version bump**: 0.1.46 → 0.1.47

## Test plan

- [ ] Deploy full stack with `MCP_TLS_STRICT=true` on a fresh server
- [ ] Confirm MCP logs show retry warnings, then `"TLS certificate valid and trusted"` within 90 s
- [ ] Confirm `curl -sI https://<domain>/.well-known/oauth-authorization-server` returns HTTP 200
- [ ] Confirm MCP container stays running (no crash-loop)

Related to #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)