### PR TITLE
fix(mcp): make TLS cert check advisory-only, use node for health check

### DIFF
--- a/hetzner/docker/full/docker-compose.yml
+++ b/hetzner/docker/full/docker-compose.yml
@@ -137,7 +137,6 @@ services:
       MCP_CLIENT_REDIRECT_URIS: ${MCP_CLIENT_REDIRECT_URIS:-https://claude.ai/api/mcp/auth_callback}
       MCP_TRUST_PROXY: "1" # hardcoded: Traefik is always a single proxy hop
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      MCP_TLS_STRICT: ${MCP_TLS_STRICT:-true}
     volumes:
       - mcp_state:/app/state
     labels:
@@ -154,11 +153,11 @@ services:
         limits:
           memory: 512m
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:$${MCP_PORT:-3339}/health"]
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:' + (process.env.MCP_PORT||'3339') + '/health', r => process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
       interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 30s
+      start_period: 10s
     logging:
       driver: "json-file"
       options:

--- a/hetzner/docker/mcp/docker-compose.yml
+++ b/hetzner/docker/mcp/docker-compose.yml
@@ -29,7 +29,6 @@ services:
       MCP_CLIENT_REDIRECT_URIS: ${MCP_CLIENT_REDIRECT_URIS:-https://claude.ai/api/mcp/auth_callback}
       MCP_TRUST_PROXY: "1" # hardcoded: Traefik is always a single proxy hop
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      MCP_TLS_STRICT: ${MCP_TLS_STRICT:-true}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.mcp.rule=Host(`${MCP_DOMAIN}`)"
@@ -42,11 +41,11 @@ services:
       - "traefik.http.middlewares.crowdsec.plugin.crowdsec-bouncer-traefik-plugin.crowdseclapischeme=http"
       - "traefik.http.middlewares.crowdsec.plugin.crowdsec-bouncer-traefik-plugin.crowdseclapihost=crowdsec:8080"
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:$${MCP_PORT:-3339}/health"]
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:' + (process.env.MCP_PORT||'3339') + '/health', r => process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
       interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 30s
+      start_period: 10s
     volumes:
       - mcp_state:/app/state
     networks:

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "description": "AIquila - MCP server for Nextcloud integration with Claude AI",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/elgorro/aiquila.git",
     "source": "github"
   },
-  "version": "0.1.48",
+  "version": "0.1.49",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -41,7 +41,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.1.48",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.1.49",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/transports/http.ts
+++ b/mcp-server/src/transports/http.ts
@@ -15,7 +15,7 @@ const MCP_PATH = '/mcp';
 
 // TLS error codes that indicate a self-signed or untrusted certificate.
 // Network errors (ECONNREFUSED, ETIMEDOUT) are not included — they mean the
-// proxy is not yet reachable, which is transient and should not fail fast.
+// proxy is not yet reachable, which is transient and should not log a warning.
 const TLS_CERT_ERROR_CODES = new Set([
   'DEPTH_ZERO_SELF_SIGNED_CERT',
   'SELF_SIGNED_CERT_IN_CHAIN',
@@ -26,32 +26,38 @@ const TLS_CERT_ERROR_CODES = new Set([
   'ERR_TLS_CERT_ALTNAME_INVALID',
 ]);
 
-const TLS_INITIAL_DELAY_MS = 30_000;
-const MAX_TLS_ATTEMPTS = 10;
-const TLS_RETRY_DELAY_MS = 15_000;
+/**
+ * Advisory TLS certificate check — purely informational, never crashes the server.
+ *
+ * Claude.ai and Claude mobile require a CA-trusted cert. If the issuer URL still
+ * has a self-signed or untrusted cert at startup this is logged as a warning so
+ * operators know to fix it, but the MCP server continues running normally.
+ *
+ * Rationale: crashing or health-check-failing on a bad cert creates a deadlock on
+ * fresh deployments — the container goes unhealthy → Traefik removes it from routing →
+ * the ACME HTTP-01 challenge can never complete → the cert is never issued → repeat.
+ */
+async function checkIssuerTls(issuerUrl: string): Promise<void> {
+  let url: URL;
+  try {
+    url = new URL(issuerUrl);
+  } catch {
+    logger.warn(
+      { issuer: issuerUrl },
+      '[startup] MCP_AUTH_ISSUER is not a valid URL — skipping TLS check'
+    );
+    return;
+  }
 
-async function attemptTlsCheck(issuerUrl: string): Promise<'ok' | 'skip' | 'retry'> {
+  if (url.protocol !== 'https:') {
+    logger.warn(
+      { issuer: issuerUrl },
+      '[startup] MCP_AUTH_ISSUER uses http:// — plain http exposes OAuth tokens; use https://'
+    );
+    return;
+  }
+
   return new Promise((resolve) => {
-    let url: URL;
-    try {
-      url = new URL(issuerUrl);
-    } catch {
-      logger.error({ issuer: issuerUrl }, '[startup] MCP_AUTH_ISSUER is not a valid URL');
-      if (process.env.MCP_TLS_STRICT === 'true') process.exit(1);
-      resolve('skip');
-      return;
-    }
-
-    if (url.protocol !== 'https:') {
-      logger.error(
-        { issuer: issuerUrl },
-        '[startup] MCP_AUTH_ISSUER must use https:// — plain http exposes OAuth tokens'
-      );
-      if (process.env.MCP_TLS_STRICT === 'true') process.exit(1);
-      resolve('skip');
-      return;
-    }
-
     const req = https.request(
       {
         hostname: url.hostname,
@@ -62,62 +68,32 @@ async function attemptTlsCheck(issuerUrl: string): Promise<'ok' | 'skip' | 'retr
       },
       () => {
         logger.info({ issuer: issuerUrl }, '[startup] TLS certificate valid and trusted');
-        resolve('ok');
+        resolve();
       }
     );
 
     req.on('error', (err: NodeJS.ErrnoException) => {
       const code = err.code ?? '';
       if (TLS_CERT_ERROR_CODES.has(code)) {
-        const strict = process.env.MCP_TLS_STRICT === 'true';
-        const msg =
-          `[startup] TLS certificate rejected (${code}). ` +
-          `Claude.ai and Claude mobile require a CA-trusted certificate — self-signed certs ` +
-          `will cause Claude to refuse the connection. Use Let's Encrypt (via Traefik or Caddy ` +
-          `with a real domain) or mount a CA-signed cert.`;
-        if (strict) {
-          logger.warn({ issuer: issuerUrl, code }, msg);
-          resolve('retry');
-        } else {
-          logger.error(
-            { issuer: issuerUrl, code },
-            msg + ' Set MCP_TLS_STRICT=true to make this a hard failure.'
-          );
-          resolve('skip');
-        }
-      } else {
-        // Transient network error — proxy may not be ready yet; do not fail
         logger.warn(
-          { issuer: issuerUrl, code: err.code },
-          '[startup] TLS check skipped — could not reach issuer (proxy not ready?)'
+          { issuer: issuerUrl, code },
+          `[startup] TLS certificate not yet trusted (${code}). ` +
+            `Claude.ai and Claude mobile require a CA-trusted certificate — self-signed certs ` +
+            `will cause Claude to refuse the connection. ` +
+            `Use Let's Encrypt (via Traefik or Caddy with a real domain) or mount a CA-signed cert. ` +
+            `The MCP server will keep running; re-deploy once the cert is valid.`
         );
-        resolve('skip');
+      } else {
+        logger.debug(
+          { issuer: issuerUrl, code: err.code },
+          '[startup] TLS check skipped — could not reach issuer (proxy not ready yet)'
+        );
       }
+      resolve();
     });
 
     req.end();
   });
-}
-
-async function checkIssuerTls(issuerUrl: string): Promise<void> {
-  for (let attempt = 1; attempt <= MAX_TLS_ATTEMPTS; attempt++) {
-    const result = await attemptTlsCheck(issuerUrl);
-    if (result !== 'retry') return;
-    if (attempt < MAX_TLS_ATTEMPTS) {
-      logger.warn(
-        { issuer: issuerUrl, attempt, maxAttempts: MAX_TLS_ATTEMPTS },
-        `[startup] TLS cert not yet trusted, retrying in ${TLS_RETRY_DELAY_MS / 1000}s ` +
-          `(${attempt}/${MAX_TLS_ATTEMPTS}) — waiting for Let's Encrypt cert`
-      );
-      await new Promise((resolve) => setTimeout(resolve, TLS_RETRY_DELAY_MS));
-    } else {
-      logger.fatal(
-        { issuer: issuerUrl },
-        '[startup] TLS certificate still rejected after all retries — giving up'
-      );
-      process.exit(1);
-    }
-  }
 }
 
 export async function startHttp(): Promise<void> {
@@ -319,16 +295,9 @@ export async function startHttp(): Promise<void> {
     }
     logger.info('View logs: docker compose logs -f   or   make logs-follow');
     void (async () => {
-      // TLS certificate check (only when auth is enabled and issuer is configured).
-      // Wait before the first check to give Traefik time to obtain a Let's Encrypt
-      // certificate — without this delay, the check sees Traefik's default
-      // self-signed cert and enters a retry loop that may never resolve.
+      // Advisory TLS check — logs a warning if the cert is self-signed or untrusted,
+      // but never crashes the server or delays startup.
       if (authEnabled) {
-        logger.info(
-          { delayMs: TLS_INITIAL_DELAY_MS },
-          `[startup] Waiting ${TLS_INITIAL_DELAY_MS / 1000}s before TLS check (Let's Encrypt grace period)`
-        );
-        await new Promise((resolve) => setTimeout(resolve, TLS_INITIAL_DELAY_MS));
         await checkIssuerTls(process.env.MCP_AUTH_ISSUER!);
       }
       // Nextcloud reachability probe


### PR DESCRIPTION
## Problem

The TLS retry loop with `MCP_TLS_STRICT=true` (the default in docker-compose) caused a bootstrapping deadlock on fresh deployments:

1. Server starts → waits 30 s → TLS check sees Traefik's self-signed cert
2. Retry loop runs 10 × 15 s = 150 s, then `process.exit(1)`
3. Container restarts → health check never passes → Traefik filters out the container
4. ACME HTTP-01 challenge never completes → cert never issued → repeat forever

Even with `MCP_TLS_STRICT=false`, the health check became unhealthy (~90–120 s) before the container could stabilise, keeping it out of Traefik's routing table and preventing ACME from running.

## Fix

- **Remove the retry loop and `process.exit`** from the TLS check entirely. The check now runs once at startup, logs a warning if the cert is not yet trusted, and always continues. This breaks the deadlock: the container becomes healthy immediately → Traefik routes to it → ACME completes → cert issued.
- **Remove `MCP_TLS_STRICT`** from both docker-compose files — no longer meaningful.
- **Switch health check from `wget` to `node`**: `node -e 'require("http").get(...)'` — guaranteed present in `node:24-alpine`, no BusyBox wget dependency.
- **Reduce `start_period` from 30 s to 10 s**: no startup delay means the server is healthy within seconds.

## Test plan
- [x] `npm test` passes (329 tests, all green)
- [x] `npm run lint` — 0 errors
- [x] `npx prettier --check src/` — clean
- [ ] Deploy on fresh server: confirm container stays healthy, ACME completes, MCP is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)