### PR TITLE
fix(nextcloud): SAPI-aware log level for PHP_BINARY fallback in OccController

### DIFF
--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -28,7 +28,7 @@
 
 Built with [Claude](https://www.anthropic.com/claude) by [Anthropic](https://www.anthropic.com). Made possible by the [Nextcloud](https://nextcloud.com) platform and its open-source community. Thank you.
     ]]></description>
-    <version>0.1.51</version>
+    <version>0.1.52</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/lib/Controller/OccController.php
+++ b/nextcloud-app/lib/Controller/OccController.php
@@ -51,9 +51,15 @@ class OccController extends Controller {
         // non-CLI binary, so we fall back to PATH lookup.
         $phpBinary = PHP_BINARY;
         if (empty($phpBinary) || !is_executable($phpBinary)) {
-            $this->logger->warning('PHP_BINARY is empty or non-executable, falling back to PATH lookup', [
-                'php_binary' => $phpBinary,
-            ]);
+            $isApacheSapi = strpos(PHP_SAPI, 'apache') === 0;
+            if (empty($phpBinary) && $isApacheSapi) {
+                $this->logger->debug('PHP_BINARY is empty (Apache SAPI), falling back to PATH lookup');
+            } else {
+                $this->logger->warning('PHP_BINARY is empty or non-executable, falling back to PATH lookup', [
+                    'php_binary' => $phpBinary,
+                    'sapi' => PHP_SAPI,
+                ]);
+            }
             $candidates = ['php', 'php8', 'php8.4', 'php8.3'];
             $phpBinary = '';
             foreach ($candidates as $candidate) {


### PR DESCRIPTION
## Summary

- Log at `debug` instead of `warning` when `PHP_BINARY` is empty under Apache SAPI (`apache2handler`), since this is expected behavior in that environment
- Keep `warning` for genuinely unexpected cases (non-Apache empty binary or non-executable), and add `sapi` field to the warning context
- Bump Nextcloud app version to 0.1.52

## Test plan

- [ ] Trigger an OCC call on Apache → no `warning` in NC log, only `debug`
- [ ] Trigger an OCC call in a non-Apache env with a bad `PHP_BINARY` → `warning` still appears with `sapi` field
- [ ] OCC command still succeeds in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)