### PR TITLE
fix(nextcloud): Conversation jsonSerialize for NC33 (v0.1.65) (#172)

### DIFF
--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -28,7 +28,7 @@
 
 Built with [Claude](https://www.anthropic.com/claude) by [Anthropic](https://www.anthropic.com). Made possible by the [Nextcloud](https://nextcloud.com) platform and its open-source community. Thank you.
     ]]></description>
-    <version>0.1.64</version>
+    <version>0.1.65</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>


### PR DESCRIPTION
## Summary

- Add explicit `JsonSerializable` implementation to `Conversation` entity to fix `BadFunctionCallException: jsonSerialize does not exist` on Nextcloud 33
- Bump Nextcloud app version to 0.1.65

NC33's `Entity` base class no longer proxies `jsonSerialize()` via `__call`, breaking `PageController::index()` which serializes conversation entities.

## Test plan

- [ ] Open `/apps/aiquila/` on a NC33 instance — should load without error
- [ ] Verify `conversations` initial state in browser dev tools contains expected JSON array
- [ ] Run PHPUnit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---------

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>

## Description
Brief description of the changes.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Component
- [ ] MCP Server
- [ ] Nextcloud App
- [ ] Documentation
- [ ] CI/CD

## Checklist
- [ ] I have tested my changes locally
- [ ] I have added tests for new functionality
- [ ] I have updated the documentation if needed
- [ ] My code follows the project's style guidelines

## Related Issues
Fixes #

## Screenshots (if applicable)
