### PR TITLE
fix(nextcloud): encrypt credentials at rest (#193)

### DIFF
--- a/docs/connectivity.md
+++ b/docs/connectivity.md
@@ -121,10 +121,10 @@ Benefits:
 
 ### API Key Storage
 
-- Admin API keys are stored in Nextcloud's `oc_appconfig` table
-- User API keys are stored in `oc_preferences` table
-- Both are stored as plain text (Nextcloud standard)
-- Consider using Nextcloud's Secret storage for production
+- API keys are stored via Nextcloud's `ICredentialsManager` (encrypted at rest)
+- MCP server tokens (bearer, OAuth) are encrypted via `ICrypto` before database storage
+- On upgrade, existing plaintext keys are automatically migrated to encrypted storage
+- Keys are never exposed in admin UI or CLI output — only `(configured)` / `****` is shown
 
 ### HTTPS
 

--- a/docs/dev/docker-setup.md
+++ b/docs/dev/docker-setup.md
@@ -116,7 +116,7 @@ php occ app:list
 php occ app:enable aiquila
 php occ user:list
 php occ config:app:get aiquila
-php occ config:app:set aiquila api_key --value="sk-ant-..."
+php occ aiquila:configure --api-key="sk-ant-..."
 ```
 
 ### Database Access

--- a/docs/internal-api.md
+++ b/docs/internal-api.md
@@ -326,8 +326,8 @@ For large files, consider:
 ## Security Considerations
 
 1. **API Keys:**
-   - Admin keys are stored in Nextcloud config
-   - User keys are encrypted in database
+   - Both admin and user keys are stored via `ICredentialsManager` (encrypted at rest)
+   - MCP server tokens are encrypted via `ICrypto` before database storage
    - Never expose API keys in responses
 
 2. **User Context:**

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -62,6 +62,11 @@ Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](htt
         <admin-section>OCA\AIquila\Settings\AdminSection</admin-section>
         <personal>OCA\AIquila\Settings\UserSettings</personal>
     </settings>
+    <repair-steps>
+        <post-migration>
+            <step>OCA\AIquila\Migration\RepairEncryptMcpTokens</step>
+        </post-migration>
+    </repair-steps>
     <commands>
         <command>OCA\AIquila\Command\ConfigureCommand</command>
         <command>OCA\AIquila\Command\TestSDKCommand</command>

--- a/nextcloud-app/lib/Command/ConfigureCommand.php
+++ b/nextcloud-app/lib/Command/ConfigureCommand.php
@@ -4,6 +4,7 @@ namespace OCA\AIquila\Command;
 
 use OC\Core\Command\Base;
 use OCA\AIquila\Service\ClaudeModels;
+use OCA\AIquila\Service\CredentialService;
 use OCP\IConfig;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -11,11 +12,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ConfigureCommand extends Base {
     private IConfig $config;
+    private CredentialService $credentials;
     private const APP_NAME = 'aiquila';
 
-    public function __construct(IConfig $config) {
+    public function __construct(IConfig $config, CredentialService $credentials) {
         parent::__construct();
         $this->config = $config;
+        $this->credentials = $credentials;
     }
 
     protected function configure(): void {
@@ -69,7 +72,7 @@ class ConfigureCommand extends Base {
                 $output->writeln('<error>Invalid API key format. Must start with sk-ant-</error>');
                 return 1;
             }
-            $this->config->setAppValue(self::APP_NAME, 'api_key', $apiKey);
+            $this->credentials->setApiKey(null, $apiKey);
             $output->writeln('<info>✓ API key updated</info>');
             $updated = true;
         }
@@ -123,7 +126,7 @@ class ConfigureCommand extends Base {
     }
 
     private function showConfiguration(OutputInterface $output): int {
-        $apiKey = $this->config->getAppValue(self::APP_NAME, 'api_key', '');
+        $hasKey = $this->credentials->hasApiKey(null);
         $model = $this->config->getAppValue(self::APP_NAME, 'model', ClaudeModels::DEFAULT_MODEL);
         $maxTokens = $this->config->getAppValue(self::APP_NAME, 'max_tokens', '4096');
         $timeout = $this->config->getAppValue(self::APP_NAME, 'api_timeout', '30');
@@ -132,10 +135,8 @@ class ConfigureCommand extends Base {
         $output->writeln('<info>AIquila Configuration:</info>');
         $output->writeln('');
 
-        // Mask API key for security
-        if (!empty($apiKey)) {
-            $maskedKey = substr($apiKey, 0, 10) . '...' . substr($apiKey, -4);
-            $output->writeln('  API Key:    <comment>' . $maskedKey . '</comment> (configured)');
+        if ($hasKey) {
+            $output->writeln('  API Key:    <comment>(configured)</comment>');
         } else {
             $output->writeln('  API Key:    <error>Not configured</error>');
         }

--- a/nextcloud-app/lib/Controller/McpServerController.php
+++ b/nextcloud-app/lib/Controller/McpServerController.php
@@ -6,6 +6,7 @@ namespace OCA\AIquila\Controller;
 
 use OCA\AIquila\Db\McpServer;
 use OCA\AIquila\Db\McpServerMapper;
+use OCA\AIquila\Service\CredentialService;
 use OCA\AIquila\Service\McpClientService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
@@ -18,6 +19,7 @@ use OCP\IURLGenerator;
 class McpServerController extends Controller {
     private McpServerMapper $mapper;
     private McpClientService $mcpClient;
+    private CredentialService $credentials;
     private IURLGenerator $urlGenerator;
 
     public function __construct(
@@ -25,11 +27,13 @@ class McpServerController extends Controller {
         IRequest $request,
         McpServerMapper $mapper,
         McpClientService $mcpClient,
+        CredentialService $credentials,
         IURLGenerator $urlGenerator
     ) {
         parent::__construct($appName, $request);
         $this->mapper = $mapper;
         $this->mcpClient = $mcpClient;
+        $this->credentials = $credentials;
         $this->urlGenerator = $urlGenerator;
     }
 
@@ -81,7 +85,7 @@ class McpServerController extends Controller {
         $server->setDisplayName($displayName);
         $server->setUrl($url);
         $server->setAuthType($authType);
-        $server->setAuthToken($authType === 'bearer' ? $authToken : null);
+        $server->setAuthToken($authType === 'bearer' ? $this->credentials->encryptToken($authToken) : null);
         $server->setIsEnabled(true);
         $server->setCreatedAt($now);
         $server->setUpdatedAt($now);
@@ -143,7 +147,7 @@ class McpServerController extends Controller {
             }
         }
         if (!empty($authToken) && $server->getAuthType() === 'bearer') {
-            $server->setAuthToken($authToken);
+            $server->setAuthToken($this->credentials->encryptToken($authToken));
         }
         if ($isEnabled !== null) {
             $server->setIsEnabled($isEnabled);
@@ -298,10 +302,7 @@ class McpServerController extends Controller {
      */
     private function serializeServer(McpServer $server): array {
         $token = $server->getAuthToken();
-        $maskedToken = null;
-        if ($token) {
-            $maskedToken = str_repeat('*', max(0, strlen($token) - 4)) . substr($token, -4);
-        }
+        $maskedToken = $token ? '****' : null;
 
         // Determine OAuth status
         $oauthStatus = null;

--- a/nextcloud-app/lib/Controller/SettingsController.php
+++ b/nextcloud-app/lib/Controller/SettingsController.php
@@ -4,6 +4,7 @@ namespace OCA\AIquila\Controller;
 
 use OCA\AIquila\Service\ClaudeModels;
 use OCA\AIquila\Service\ClaudeSDKService;
+use OCA\AIquila\Service\CredentialService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
@@ -15,18 +16,21 @@ class SettingsController extends Controller {
     private IConfig $config;
     private ?string $userId;
     private ClaudeSDKService $claudeService;
+    private CredentialService $credentials;
 
     public function __construct(
         string $appName,
         IRequest $request,
         IConfig $config,
         ?string $userId,
-        ClaudeSDKService $claudeService
+        ClaudeSDKService $claudeService,
+        CredentialService $credentials
     ) {
         parent::__construct($appName, $request);
         $this->config = $config;
         $this->userId = $userId;
         $this->claudeService = $claudeService;
+        $this->credentials = $credentials;
     }
 
     /**
@@ -41,14 +45,14 @@ class SettingsController extends Controller {
     #[NoAdminRequired]
     #[OpenAPI]
     public function get(): JSONResponse {
-        $userKey   = $this->config->getUserValue($this->userId, $this->appName, 'api_key', '');
-        $userModel = $this->config->getUserValue($this->userId, $this->appName, 'model',   '');
+        $hasUserKey = $this->credentials->hasApiKey($this->userId);
+        $userModel  = $this->config->getUserValue($this->userId, $this->appName, 'model', '');
 
         $liveModels      = $this->claudeService->listModels($this->userId);
         $availableModels = $liveModels ?? ClaudeModels::getAllModels();
 
         return new JSONResponse([
-            'hasUserKey'      => !empty($userKey),
+            'hasUserKey'      => $hasUserKey,
             'userModel'       => $userModel,
             'availableModels' => $availableModels,
         ]);
@@ -69,7 +73,11 @@ class SettingsController extends Controller {
     #[NoAdminRequired]
     #[OpenAPI]
     public function save(string $api_key = '', string $model = ''): JSONResponse {
-        $this->config->setUserValue($this->userId, $this->appName, 'api_key', $api_key);
+        if ($api_key !== '') {
+            $this->credentials->setApiKey($this->userId, $api_key);
+        } else {
+            $this->credentials->deleteApiKey($this->userId);
+        }
 
         if ($model !== '') {
             $this->config->setUserValue($this->userId, $this->appName, 'model', $model);
@@ -95,7 +103,7 @@ class SettingsController extends Controller {
     #[OpenAPI(scope: OpenAPI::SCOPE_ADMINISTRATION)]
     public function saveAdmin(string $api_key = '', string $model = '', string $max_tokens = '', string $api_timeout = ''): JSONResponse {
         if (!empty($api_key)) {
-            $this->config->setAppValue($this->appName, 'api_key', $api_key);
+            $this->credentials->setApiKey(null, $api_key);
         }
         if (!empty($model)) {
             $this->config->setAppValue($this->appName, 'model', $model);
@@ -133,7 +141,7 @@ class SettingsController extends Controller {
      */
     #[OpenAPI(scope: OpenAPI::SCOPE_ADMINISTRATION)]
     public function testConfig(string $api_key = '', string $model = '', string $max_tokens = '', string $timeout = ''): JSONResponse {
-        $testApiKey = !empty($api_key) ? $api_key : $this->config->getAppValue($this->appName, 'api_key', '');
+        $testApiKey = !empty($api_key) ? $api_key : $this->credentials->getApiKey(null);
         $testModel = !empty($model) ? $model : $this->config->getAppValue($this->appName, 'model', ClaudeModels::DEFAULT_MODEL);
         $testMaxTokens = !empty($max_tokens) ? (int)$max_tokens : (int)$this->config->getAppValue($this->appName, 'max_tokens', '4096');
         $testTimeout = !empty($timeout) ? (int)$timeout : (int)$this->config->getAppValue($this->appName, 'api_timeout', '30');
@@ -142,21 +150,28 @@ class SettingsController extends Controller {
             return new JSONResponse(['success' => false, 'message' => 'No API key provided'], 400);
         }
 
+        // Save originals for non-sensitive config (API key handled via CredentialService)
+        $originalApiKey = $this->credentials->getApiKey(null);
         $originalConfig = [
-            'api_key'     => $this->config->getAppValue($this->appName, 'api_key', ''),
             'model'       => $this->config->getAppValue($this->appName, 'model', ''),
             'max_tokens'  => $this->config->getAppValue($this->appName, 'max_tokens', ''),
             'api_timeout' => $this->config->getAppValue($this->appName, 'api_timeout', ''),
         ];
 
         try {
-            $this->config->setAppValue($this->appName, 'api_key', $testApiKey);
+            $this->credentials->setApiKey(null, $testApiKey);
             $this->config->setAppValue($this->appName, 'model', $testModel);
             $this->config->setAppValue($this->appName, 'max_tokens', (string)$testMaxTokens);
             $this->config->setAppValue($this->appName, 'api_timeout', (string)$testTimeout);
 
             $result = $this->claudeService->ask('Test: Respond with "OK" if you receive this.', '', null);
 
+            // Restore originals
+            if ($originalApiKey !== '') {
+                $this->credentials->setApiKey(null, $originalApiKey);
+            } else {
+                $this->credentials->deleteApiKey(null);
+            }
             foreach ($originalConfig as $key => $value) {
                 if (!empty($value)) {
                     $this->config->setAppValue($this->appName, $key, $value);
@@ -170,6 +185,12 @@ class SettingsController extends Controller {
             return new JSONResponse(['success' => true, 'message' => $result['response']]);
 
         } catch (\Throwable $e) {
+            // Restore originals
+            if ($originalApiKey !== '') {
+                $this->credentials->setApiKey(null, $originalApiKey);
+            } else {
+                $this->credentials->deleteApiKey(null);
+            }
             foreach ($originalConfig as $key => $value) {
                 if (!empty($value)) {
                     $this->config->setAppValue($this->appName, $key, $value);

--- a/nextcloud-app/lib/Migration/RepairEncryptMcpTokens.php
+++ b/nextcloud-app/lib/Migration/RepairEncryptMcpTokens.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Migration;
+
+use OCA\AIquila\Db\McpServerMapper;
+use OCA\AIquila\Service\CredentialService;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+
+class RepairEncryptMcpTokens implements IRepairStep {
+    public function __construct(
+        private McpServerMapper $mapper,
+        private CredentialService $credentials,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function getName(): string {
+        return 'Encrypt MCP server tokens at rest';
+    }
+
+    public function run(IOutput $output): void {
+        $servers = $this->mapper->findAll();
+        $migrated = 0;
+
+        foreach ($servers as $server) {
+            $changed = false;
+
+            foreach (['getAuthToken', 'getOauthAccessToken', 'getOauthRefreshToken'] as $getter) {
+                $value = $server->$getter();
+                if ($value === null || $value === '') {
+                    continue;
+                }
+
+                // Try to decrypt — if it fails, it's plaintext and needs encryption
+                $setter = str_replace('get', 'set', $getter);
+                try {
+                    $this->credentials->decryptToken($value);
+                    // If decryptToken returns without exception via ICrypto::decrypt,
+                    // the value is already encrypted. But decryptToken also catches
+                    // exceptions and returns raw value. We need to check differently.
+                    // Try ICrypto::decrypt directly would be cleaner, but we use the
+                    // service's encrypt method to re-encrypt plaintext values.
+                } catch (\Exception) {
+                    // Already handled in decryptToken
+                }
+
+                // The simplest approach: encrypt the value. If it was already encrypted,
+                // decryptToken will decrypt it fine later (double-encrypted won't work).
+                // So we must check: can we decrypt it? If yes, it's already encrypted.
+                $decrypted = $this->credentials->decryptToken($value);
+                if ($decrypted === $value) {
+                    // decryptToken returned raw value (either plaintext or decrypt failed)
+                    // This means it's plaintext — encrypt it
+                    $encrypted = $this->credentials->encryptToken($value);
+                    $server->$setter($encrypted);
+                    $changed = true;
+                }
+                // If $decrypted !== $value, it was successfully decrypted, so already encrypted
+            }
+
+            if ($changed) {
+                $server->setUpdatedAt(time());
+                $this->mapper->update($server);
+                $migrated++;
+            }
+        }
+
+        if ($migrated > 0) {
+            $output->info("Encrypted tokens for $migrated MCP server(s)");
+            $this->logger->info('RepairEncryptMcpTokens: migrated {count} servers', ['count' => $migrated]);
+        }
+    }
+}

--- a/nextcloud-app/lib/Service/ClaudeSDKService.php
+++ b/nextcloud-app/lib/Service/ClaudeSDKService.php
@@ -25,11 +25,13 @@ use Psr\Log\LoggerInterface;
 class ClaudeSDKService {
     private IConfig $config;
     private LoggerInterface $logger;
+    private CredentialService $credentials;
     private string $appName = 'aiquila';
 
-    public function __construct(IConfig $config, LoggerInterface $logger) {
+    public function __construct(IConfig $config, LoggerInterface $logger, CredentialService $credentials) {
         $this->config = $config;
         $this->logger = $logger;
+        $this->credentials = $credentials;
     }
 
     /**
@@ -48,11 +50,7 @@ class ClaudeSDKService {
      * Get API key (user-specific or admin)
      */
     public function getApiKey(?string $userId = null): string {
-        if ($userId) {
-            $userKey = $this->config->getUserValue($userId, $this->appName, 'api_key', '');
-            if ($userKey) return $userKey;
-        }
-        return $this->config->getAppValue($this->appName, 'api_key', '');
+        return $this->credentials->getApiKey($userId);
     }
 
     /**

--- a/nextcloud-app/lib/Service/CredentialService.php
+++ b/nextcloud-app/lib/Service/CredentialService.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Service;
+
+use OCP\IConfig;
+use OCP\Security\ICrypto;
+use OCP\Security\ICredentialsManager;
+use Psr\Log\LoggerInterface;
+
+class CredentialService {
+    private const APP_NAME = 'aiquila';
+    private const CREDENTIAL_KEY = 'aiquila/api_key';
+
+    public function __construct(
+        private ICredentialsManager $credentialsManager,
+        private ICrypto $crypto,
+        private IConfig $config,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Get API key from secure storage, migrating from plaintext IConfig if needed.
+     *
+     * @param string|null $userId User ID, or null for app-scope key
+     */
+    public function getApiKey(?string $userId): string {
+        $credUserId = $userId ?? '';
+
+        // Try secure storage first
+        $key = $this->credentialsManager->retrieve($credUserId, self::CREDENTIAL_KEY);
+        if (is_string($key) && $key !== '') {
+            return $key;
+        }
+
+        // Fall back to IConfig (plaintext migration)
+        if ($userId !== null) {
+            $plaintext = $this->config->getUserValue($userId, self::APP_NAME, 'api_key', '');
+        } else {
+            $plaintext = $this->config->getAppValue(self::APP_NAME, 'api_key', '');
+        }
+
+        if ($plaintext !== '') {
+            // Migrate: store encrypted, delete plaintext
+            $this->credentialsManager->store($credUserId, self::CREDENTIAL_KEY, $plaintext);
+            if ($userId !== null) {
+                $this->config->deleteUserValue($userId, self::APP_NAME, 'api_key');
+            } else {
+                $this->config->deleteAppValue(self::APP_NAME, 'api_key');
+            }
+            $this->logger->info('Migrated API key from plaintext to secure storage', [
+                'scope' => $userId !== null ? 'user' : 'app',
+            ]);
+            return $plaintext;
+        }
+
+        // If user key is empty, fall back to app-scope key
+        if ($userId !== null) {
+            return $this->getApiKey(null);
+        }
+
+        return '';
+    }
+
+    /**
+     * Store API key in secure storage, removing any plaintext leftover.
+     */
+    public function setApiKey(?string $userId, string $key): void {
+        $credUserId = $userId ?? '';
+        $this->credentialsManager->store($credUserId, self::CREDENTIAL_KEY, $key);
+
+        // Clean up plaintext leftovers
+        if ($userId !== null) {
+            $this->config->deleteUserValue($userId, self::APP_NAME, 'api_key');
+        } else {
+            $this->config->deleteAppValue(self::APP_NAME, 'api_key');
+        }
+    }
+
+    /**
+     * Delete API key from both secure and plaintext storage.
+     */
+    public function deleteApiKey(?string $userId): void {
+        $credUserId = $userId ?? '';
+        $this->credentialsManager->delete($credUserId, self::CREDENTIAL_KEY);
+
+        if ($userId !== null) {
+            $this->config->deleteUserValue($userId, self::APP_NAME, 'api_key');
+        } else {
+            $this->config->deleteAppValue(self::APP_NAME, 'api_key');
+        }
+    }
+
+    /**
+     * Check if an API key exists without exposing its value.
+     */
+    public function hasApiKey(?string $userId): bool {
+        $credUserId = $userId ?? '';
+
+        $key = $this->credentialsManager->retrieve($credUserId, self::CREDENTIAL_KEY);
+        if (is_string($key) && $key !== '') {
+            return true;
+        }
+
+        // Check plaintext fallback too
+        if ($userId !== null) {
+            return $this->config->getUserValue($userId, self::APP_NAME, 'api_key', '') !== '';
+        }
+        return $this->config->getAppValue(self::APP_NAME, 'api_key', '') !== '';
+    }
+
+    /**
+     * Encrypt a token for database storage. Null passthrough.
+     */
+    public function encryptToken(?string $plaintext): ?string {
+        if ($plaintext === null || $plaintext === '') {
+            return $plaintext;
+        }
+        return $this->crypto->encrypt($plaintext);
+    }
+
+    /**
+     * Decrypt a token from database storage. Null passthrough.
+     * If decryption fails (plaintext value), returns raw value with a warning.
+     */
+    public function decryptToken(?string $ciphertext): ?string {
+        if ($ciphertext === null || $ciphertext === '') {
+            return $ciphertext;
+        }
+
+        try {
+            return $this->crypto->decrypt($ciphertext);
+        } catch (\Exception $e) {
+            $this->logger->warning('Failed to decrypt token — assuming plaintext (pre-migration value)', [
+                'exception' => $e->getMessage(),
+            ]);
+            return $ciphertext;
+        }
+    }
+}

--- a/nextcloud-app/lib/Service/McpClientService.php
+++ b/nextcloud-app/lib/Service/McpClientService.php
@@ -13,6 +13,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 class McpClientService {
     private McpServerMapper $mapper;
     private LoggerInterface $logger;
+    private CredentialService $credentials;
     private HttpClientInterface $httpClient;
 
     private const PROTOCOL_VERSION = '2025-03-26';
@@ -24,9 +25,10 @@ class McpClientService {
     /** @var array<int, bool> Track which servers have been initialized */
     private array $initialized = [];
 
-    public function __construct(McpServerMapper $mapper, LoggerInterface $logger) {
+    public function __construct(McpServerMapper $mapper, LoggerInterface $logger, CredentialService $credentials) {
         $this->mapper = $mapper;
         $this->logger = $logger;
+        $this->credentials = $credentials;
         $this->httpClient = HttpClient::create(['timeout' => 30]);
     }
 
@@ -52,9 +54,9 @@ class McpClientService {
             if ($this->isTokenExpired($server)) {
                 $this->refreshOAuthToken($server);
             }
-            $headers['Authorization'] = 'Bearer ' . $server->getOauthAccessToken();
+            $headers['Authorization'] = 'Bearer ' . $this->credentials->decryptToken($server->getOauthAccessToken());
         } elseif ($server->getAuthType() === 'bearer' && $server->getAuthToken()) {
-            $headers['Authorization'] = 'Bearer ' . $server->getAuthToken();
+            $headers['Authorization'] = 'Bearer ' . $this->credentials->decryptToken($server->getAuthToken());
         }
 
         $serverId = $server->getId();
@@ -460,8 +462,8 @@ class McpClientService {
             throw new \RuntimeException('No access_token in token response');
         }
 
-        $server->setOauthAccessToken($result['access_token']);
-        $server->setOauthRefreshToken($result['refresh_token'] ?? null);
+        $server->setOauthAccessToken($this->credentials->encryptToken($result['access_token']));
+        $server->setOauthRefreshToken($this->credentials->encryptToken($result['refresh_token'] ?? null));
         $server->setOauthTokenExpiresAt(time() + ($result['expires_in'] ?? 3600));
         $server->setOauthCodeVerifier(null);
         $server->setOauthState(null);
@@ -486,7 +488,7 @@ class McpClientService {
             $response = $this->httpClient->request('POST', $tokenEndpoint, [
                 'body' => [
                     'grant_type' => 'refresh_token',
-                    'refresh_token' => $server->getOauthRefreshToken(),
+                    'refresh_token' => $this->credentials->decryptToken($server->getOauthRefreshToken()),
                     'client_id' => $server->getOauthClientId(),
                 ],
             ]);
@@ -497,9 +499,9 @@ class McpClientService {
                 throw new \RuntimeException('No access_token in refresh response');
             }
 
-            $server->setOauthAccessToken($result['access_token']);
+            $server->setOauthAccessToken($this->credentials->encryptToken($result['access_token']));
             if (isset($result['refresh_token'])) {
-                $server->setOauthRefreshToken($result['refresh_token']);
+                $server->setOauthRefreshToken($this->credentials->encryptToken($result['refresh_token']));
             }
             $server->setOauthTokenExpiresAt(time() + ($result['expires_in'] ?? 3600));
             $server->setUpdatedAt(time());

--- a/nextcloud-app/lib/Settings/AdminSettings.php
+++ b/nextcloud-app/lib/Settings/AdminSettings.php
@@ -3,26 +3,29 @@
 namespace OCA\AIquila\Settings;
 
 use OCA\AIquila\Service\ClaudeModels;
+use OCA\AIquila\Service\CredentialService;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\Settings\ISettings;
 
 class AdminSettings implements ISettings {
     private IConfig $config;
+    private CredentialService $credentials;
 
-    public function __construct(IConfig $config) {
+    public function __construct(IConfig $config, CredentialService $credentials) {
         $this->config = $config;
+        $this->credentials = $credentials;
     }
 
     public function getForm(): TemplateResponse {
-        $apiKey = $this->config->getAppValue('aiquila', 'api_key', '');
+        $hasKey = $this->credentials->hasApiKey(null);
         $model = $this->config->getAppValue('aiquila', 'model', ClaudeModels::DEFAULT_MODEL);
         $maxTokens = $this->config->getAppValue('aiquila', 'max_tokens', '4096');
         $apiTimeout = $this->config->getAppValue('aiquila', 'api_timeout', '30');
 
         return new TemplateResponse('aiquila', 'admin', [
-            'api_key' => $apiKey ? '********' : '',
-            'has_key' => !empty($apiKey),
+            'api_key' => $hasKey ? '********' : '',
+            'has_key' => $hasKey,
             'model' => $model,
             'max_tokens' => $maxTokens,
             'api_timeout' => $apiTimeout,

--- a/nextcloud-app/lib/Settings/UserSettings.php
+++ b/nextcloud-app/lib/Settings/UserSettings.php
@@ -3,25 +3,28 @@
 namespace OCA\AIquila\Settings;
 
 use OCA\AIquila\Service\ClaudeModels;
+use OCA\AIquila\Service\CredentialService;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\Settings\ISettings;
 
 class UserSettings implements ISettings {
     private IConfig $config;
+    private CredentialService $credentials;
     private ?string $userId;
 
-    public function __construct(IConfig $config, ?string $userId) {
+    public function __construct(IConfig $config, CredentialService $credentials, ?string $userId) {
         $this->config = $config;
+        $this->credentials = $credentials;
         $this->userId = $userId;
     }
 
     public function getForm(): TemplateResponse {
-        $apiKey   = $this->config->getUserValue($this->userId, 'aiquila', 'api_key', '');
+        $hasKey    = $this->credentials->hasApiKey($this->userId);
         $userModel = $this->config->getUserValue($this->userId, 'aiquila', 'model', '');
         return new TemplateResponse('aiquila', 'user', [
-            'api_key'          => $apiKey ? '********' : '',
-            'has_key'          => !empty($apiKey),
+            'api_key'          => $hasKey ? '********' : '',
+            'has_key'          => $hasKey,
             'user_model'       => $userModel,
             'available_models' => ClaudeModels::getAllModels(),
         ], '');

--- a/nextcloud-app/tests/Unit/ClaudeServiceTest.php
+++ b/nextcloud-app/tests/Unit/ClaudeServiceTest.php
@@ -16,6 +16,7 @@ use Anthropic\Messages\Usage;
 use Anthropic\Models\ModelInfo;
 use OCA\AIquila\Service\ClaudeModels;
 use OCA\AIquila\Service\ClaudeSDKService;
+use OCA\AIquila\Service\CredentialService;
 use OCP\IConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -125,14 +126,16 @@ class TestableClaudeSDKService extends ClaudeSDKService {
 class ClaudeServiceTest extends TestCase {
     private $config;
     private $logger;
+    private $credentials;
     private ClaudeSDKService $service;
     private TestableClaudeSDKService $testable;
 
     protected function setUp(): void {
-        $this->config   = $this->createMock(IConfig::class);
-        $this->logger   = $this->createMock(LoggerInterface::class);
-        $this->service  = new ClaudeSDKService($this->config, $this->logger);
-        $this->testable = new TestableClaudeSDKService($this->config, $this->logger);
+        $this->config      = $this->createMock(IConfig::class);
+        $this->logger      = $this->createMock(LoggerInterface::class);
+        $this->credentials = $this->createMock(CredentialService::class);
+        $this->service     = new ClaudeSDKService($this->config, $this->logger, $this->credentials);
+        $this->testable    = new TestableClaudeSDKService($this->config, $this->logger, $this->credentials);
     }
 
     // ── PSR-7 helpers for building SDK exceptions ─────────────────────────
@@ -165,10 +168,10 @@ class ClaudeServiceTest extends TestCase {
     }
 
     private function configWithApiKey(): void {
+        $this->credentials->method('getApiKey')->willReturn('test-key');
         $this->config->method('getUserValue')->willReturn('');
         $this->config->method('getAppValue')
             ->willReturnCallback(fn($app, $key, $default) => match ($key) {
-                'api_key'    => 'test-key',
                 'model'      => ClaudeModels::DEFAULT_MODEL,
                 'max_tokens' => '4096',
                 default      => $default,
@@ -178,20 +181,16 @@ class ClaudeServiceTest extends TestCase {
     // ── getApiKey ─────────────────────────────────────────────────────────
 
     public function testGetApiKeyReturnsUserKeyFirst(): void {
-        $this->config->method('getUserValue')
-            ->with('testuser', 'aiquila', 'api_key', '')
+        $this->credentials->method('getApiKey')
+            ->with('testuser')
             ->willReturn('user-api-key');
 
         $this->assertEquals('user-api-key', $this->service->getApiKey('testuser'));
     }
 
     public function testGetApiKeyFallsBackToAdminKey(): void {
-        $this->config->method('getUserValue')
-            ->with('testuser', 'aiquila', 'api_key', '')
-            ->willReturn('');
-
-        $this->config->method('getAppValue')
-            ->with('aiquila', 'api_key', '')
+        $this->credentials->method('getApiKey')
+            ->with('testuser')
             ->willReturn('admin-api-key');
 
         $this->assertEquals('admin-api-key', $this->service->getApiKey('testuser'));
@@ -280,8 +279,7 @@ class ClaudeServiceTest extends TestCase {
     // ── ask(): no API key ─────────────────────────────────────────────────
 
     public function testAskReturnsErrorWhenNoApiKey(): void {
-        $this->config->method('getUserValue')->willReturn('');
-        $this->config->method('getAppValue')->willReturn('');
+        $this->credentials->method('getApiKey')->willReturn('');
 
         $result = $this->service->ask('Hello', '', 'testuser');
         $this->assertArrayHasKey('error', $result);

--- a/nextcloud-app/tests/Unit/CredentialServiceTest.php
+++ b/nextcloud-app/tests/Unit/CredentialServiceTest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace OCA\AIquila\Tests\Unit;
+
+use OCA\AIquila\Service\CredentialService;
+use OCP\IConfig;
+use OCP\Security\ICrypto;
+use OCP\Security\ICredentialsManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class CredentialServiceTest extends TestCase {
+    private ICredentialsManager $credManager;
+    private ICrypto $crypto;
+    private IConfig $config;
+    private LoggerInterface $logger;
+    private CredentialService $service;
+
+    protected function setUp(): void {
+        $this->credManager = $this->createMock(ICredentialsManager::class);
+        $this->crypto = $this->createMock(ICrypto::class);
+        $this->config = $this->createMock(IConfig::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->service = new CredentialService(
+            $this->credManager,
+            $this->crypto,
+            $this->config,
+            $this->logger
+        );
+    }
+
+    public function testGetApiKeyFromCredentialsManager(): void {
+        $this->credManager->method('retrieve')
+            ->with('testuser', 'aiquila/api_key')
+            ->willReturn('sk-ant-secure-key');
+
+        $result = $this->service->getApiKey('testuser');
+        $this->assertEquals('sk-ant-secure-key', $result);
+    }
+
+    public function testGetApiKeyMigratesFromIConfig(): void {
+        $this->credManager->method('retrieve')
+            ->with('testuser', 'aiquila/api_key')
+            ->willReturn(null);
+
+        $this->config->method('getUserValue')
+            ->with('testuser', 'aiquila', 'api_key', '')
+            ->willReturn('sk-ant-plaintext-key');
+
+        // Expect migration: store in credentials manager
+        $this->credManager->expects($this->once())
+            ->method('store')
+            ->with('testuser', 'aiquila/api_key', 'sk-ant-plaintext-key');
+
+        // Expect plaintext deletion
+        $this->config->expects($this->once())
+            ->method('deleteUserValue')
+            ->with('testuser', 'aiquila', 'api_key');
+
+        $result = $this->service->getApiKey('testuser');
+        $this->assertEquals('sk-ant-plaintext-key', $result);
+    }
+
+    public function testGetApiKeyFallsBackToAppKey(): void {
+        // User key not found in either store
+        $this->credManager->method('retrieve')
+            ->willReturnMap([
+                ['testuser', 'aiquila/api_key', null],
+                ['', 'aiquila/api_key', 'sk-ant-app-key'],
+            ]);
+
+        $this->config->method('getUserValue')
+            ->with('testuser', 'aiquila', 'api_key', '')
+            ->willReturn('');
+
+        $result = $this->service->getApiKey('testuser');
+        $this->assertEquals('sk-ant-app-key', $result);
+    }
+
+    public function testGetApiKeyAppScope(): void {
+        $this->credManager->method('retrieve')
+            ->with('', 'aiquila/api_key')
+            ->willReturn('sk-ant-app-key');
+
+        $result = $this->service->getApiKey(null);
+        $this->assertEquals('sk-ant-app-key', $result);
+    }
+
+    public function testGetApiKeyAppScopeMigratesFromIConfig(): void {
+        $this->credManager->method('retrieve')
+            ->with('', 'aiquila/api_key')
+            ->willReturn(null);
+
+        $this->config->method('getAppValue')
+            ->with('aiquila', 'api_key', '')
+            ->willReturn('sk-ant-old-app-key');
+
+        $this->credManager->expects($this->once())
+            ->method('store')
+            ->with('', 'aiquila/api_key', 'sk-ant-old-app-key');
+
+        $this->config->expects($this->once())
+            ->method('deleteAppValue')
+            ->with('aiquila', 'api_key');
+
+        $result = $this->service->getApiKey(null);
+        $this->assertEquals('sk-ant-old-app-key', $result);
+    }
+
+    public function testHasApiKeyTrue(): void {
+        $this->credManager->method('retrieve')
+            ->with('testuser', 'aiquila/api_key')
+            ->willReturn('sk-ant-key');
+
+        $this->assertTrue($this->service->hasApiKey('testuser'));
+    }
+
+    public function testHasApiKeyFalse(): void {
+        $this->credManager->method('retrieve')
+            ->with('testuser', 'aiquila/api_key')
+            ->willReturn(null);
+
+        $this->config->method('getUserValue')
+            ->with('testuser', 'aiquila', 'api_key', '')
+            ->willReturn('');
+
+        $this->assertFalse($this->service->hasApiKey('testuser'));
+    }
+
+    public function testHasApiKeyChecksPlaintextFallback(): void {
+        $this->credManager->method('retrieve')
+            ->with('testuser', 'aiquila/api_key')
+            ->willReturn(null);
+
+        $this->config->method('getUserValue')
+            ->with('testuser', 'aiquila', 'api_key', '')
+            ->willReturn('sk-ant-plaintext');
+
+        $this->assertTrue($this->service->hasApiKey('testuser'));
+    }
+
+    public function testSetApiKeyStoresAndCleansPlaintext(): void {
+        $this->credManager->expects($this->once())
+            ->method('store')
+            ->with('testuser', 'aiquila/api_key', 'sk-ant-new-key');
+
+        $this->config->expects($this->once())
+            ->method('deleteUserValue')
+            ->with('testuser', 'aiquila', 'api_key');
+
+        $this->service->setApiKey('testuser', 'sk-ant-new-key');
+    }
+
+    public function testSetApiKeyAppScope(): void {
+        $this->credManager->expects($this->once())
+            ->method('store')
+            ->with('', 'aiquila/api_key', 'sk-ant-app-key');
+
+        $this->config->expects($this->once())
+            ->method('deleteAppValue')
+            ->with('aiquila', 'api_key');
+
+        $this->service->setApiKey(null, 'sk-ant-app-key');
+    }
+
+    public function testDeleteApiKey(): void {
+        $this->credManager->expects($this->once())
+            ->method('delete')
+            ->with('testuser', 'aiquila/api_key');
+
+        $this->config->expects($this->once())
+            ->method('deleteUserValue')
+            ->with('testuser', 'aiquila', 'api_key');
+
+        $this->service->deleteApiKey('testuser');
+    }
+
+    public function testEncryptTokenNullPassthrough(): void {
+        $this->assertNull($this->service->encryptToken(null));
+    }
+
+    public function testEncryptTokenEmptyPassthrough(): void {
+        $this->assertSame('', $this->service->encryptToken(''));
+    }
+
+    public function testEncryptToken(): void {
+        $this->crypto->method('encrypt')
+            ->with('my-secret-token')
+            ->willReturn('encrypted-data');
+
+        $result = $this->service->encryptToken('my-secret-token');
+        $this->assertEquals('encrypted-data', $result);
+    }
+
+    public function testDecryptTokenNullPassthrough(): void {
+        $this->assertNull($this->service->decryptToken(null));
+    }
+
+    public function testDecryptTokenDecryptsEncrypted(): void {
+        $this->crypto->method('decrypt')
+            ->with('encrypted-data')
+            ->willReturn('my-secret-token');
+
+        $result = $this->service->decryptToken('encrypted-data');
+        $this->assertEquals('my-secret-token', $result);
+    }
+
+    public function testDecryptTokenPlaintextFallback(): void {
+        $this->crypto->method('decrypt')
+            ->willThrowException(new \Exception('Invalid ciphertext'));
+
+        $this->logger->expects($this->once())
+            ->method('warning');
+
+        $result = $this->service->decryptToken('plaintext-value');
+        $this->assertEquals('plaintext-value', $result);
+    }
+}

--- a/nextcloud-app/tests/Unit/McpClientServiceTest.php
+++ b/nextcloud-app/tests/Unit/McpClientServiceTest.php
@@ -4,6 +4,7 @@ namespace OCA\AIquila\Tests\Unit;
 
 use OCA\AIquila\Db\McpServer;
 use OCA\AIquila\Db\McpServerMapper;
+use OCA\AIquila\Service\CredentialService;
 use OCA\AIquila\Service\McpClientService;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -19,8 +20,8 @@ class TestableMcpClientService extends McpClientService {
     /** Captured calls: [['method' => ..., 'params' => ...], ...] */
     public array $capturedCalls = [];
 
-    public function __construct(McpServerMapper $mapper, LoggerInterface $logger) {
-        parent::__construct($mapper, $logger);
+    public function __construct(McpServerMapper $mapper, LoggerInterface $logger, CredentialService $credentials) {
+        parent::__construct($mapper, $logger, $credentials);
     }
 
     /**
@@ -89,12 +90,21 @@ class TestableMcpClientService extends McpClientService {
 class McpClientServiceTest extends TestCase {
     private McpServerMapper $mapper;
     private LoggerInterface $logger;
+    private CredentialService $credentials;
     private TestableMcpClientService $service;
 
     protected function setUp(): void {
         $this->mapper = $this->createMock(McpServerMapper::class);
         $this->logger = $this->createMock(LoggerInterface::class);
-        $this->service = new TestableMcpClientService($this->mapper, $this->logger);
+        $this->credentials = $this->createMock(CredentialService::class);
+
+        // Default: encrypt/decrypt pass through for test simplicity
+        $this->credentials->method('encryptToken')
+            ->willReturnCallback(fn(?string $v) => $v);
+        $this->credentials->method('decryptToken')
+            ->willReturnCallback(fn(?string $v) => $v);
+
+        $this->service = new TestableMcpClientService($this->mapper, $this->logger, $this->credentials);
     }
 
     private function makeServer(int $id = 1, string $name = 'Test Server', string $url = 'http://localhost:3339/mcp'): McpServer {
@@ -270,10 +280,6 @@ class McpClientServiceTest extends TestCase {
         ]));
 
         $this->mapper->method('update')->willReturnArgument(0);
-
-        // We can't test the HTTP call directly via TestableMcpClientService
-        // since completeOAuth uses httpClient directly. Test the state validation instead.
-        // The actual HTTP integration is covered by functional tests.
 
         // Verify state mismatch throws
         $this->expectException(\RuntimeException::class);

--- a/nextcloud-app/tests/Unit/McpServerControllerTest.php
+++ b/nextcloud-app/tests/Unit/McpServerControllerTest.php
@@ -5,6 +5,7 @@ namespace OCA\AIquila\Tests\Unit;
 use OCA\AIquila\Controller\McpServerController;
 use OCA\AIquila\Db\McpServer;
 use OCA\AIquila\Db\McpServerMapper;
+use OCA\AIquila\Service\CredentialService;
 use OCA\AIquila\Service\McpClientService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IRequest;
@@ -14,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 class McpServerControllerTest extends TestCase {
     private McpServerMapper $mapper;
     private McpClientService $mcpClient;
+    private CredentialService $credentials;
     private IURLGenerator $urlGenerator;
     private McpServerController $controller;
     private IRequest $request;
@@ -22,12 +24,19 @@ class McpServerControllerTest extends TestCase {
         $this->request = $this->createMock(IRequest::class);
         $this->mapper = $this->createMock(McpServerMapper::class);
         $this->mcpClient = $this->createMock(McpClientService::class);
+        $this->credentials = $this->createMock(CredentialService::class);
         $this->urlGenerator = $this->createMock(IURLGenerator::class);
+
+        // Default: encryptToken returns a fixed encrypted value
+        $this->credentials->method('encryptToken')
+            ->willReturnCallback(fn(?string $v) => $v !== null && $v !== '' ? 'encrypted:' . $v : $v);
+
         $this->controller = new McpServerController(
             'aiquila',
             $this->request,
             $this->mapper,
             $this->mcpClient,
+            $this->credentials,
             $this->urlGenerator
         );
     }
@@ -63,14 +72,13 @@ class McpServerControllerTest extends TestCase {
     public function testIndexMasksAuthToken(): void {
         $server = $this->makeServer();
         $server->setAuthType('bearer');
-        $server->setAuthToken('super-secret-token-12345');
+        $server->setAuthToken('encrypted:super-secret-token-12345');
         $this->mapper->method('findAll')->willReturn([$server]);
 
         $response = $this->controller->index();
         $data = $response->getData();
 
-        $this->assertNotEquals('super-secret-token-12345', $data[0]['auth_token_masked']);
-        $this->assertStringEndsWith('2345', $data[0]['auth_token_masked']);
+        $this->assertEquals('****', $data[0]['auth_token_masked']);
     }
 
     public function testCreateValidatesRequired(): void {
@@ -97,6 +105,21 @@ class McpServerControllerTest extends TestCase {
 
         $this->assertEquals(200, $response->getStatus());
         $this->assertEquals('My MCP', $data['display_name']);
+    }
+
+    public function testCreateBearerEncryptsToken(): void {
+        $this->mapper->method('insert')->willReturnCallback(function (McpServer $s) {
+            // Verify the token was encrypted before insert
+            $this->assertEquals('encrypted:my-token', $s->getAuthToken());
+            $ref = new \ReflectionClass($s);
+            $parent = $ref->getParentClass();
+            $idProp = $parent->getProperty('id');
+            $idProp->setValue($s, 1);
+            return $s;
+        });
+
+        $response = $this->controller->create('My MCP', 'http://localhost:3339/mcp', 'bearer', 'my-token');
+        $this->assertEquals(200, $response->getStatus());
     }
 
     public function testDestroyNotFound(): void {

--- a/nextcloud-app/tests/Unit/SettingsControllerTest.php
+++ b/nextcloud-app/tests/Unit/SettingsControllerTest.php
@@ -5,6 +5,7 @@ namespace OCA\AIquila\Tests\Unit;
 use OCA\AIquila\Controller\SettingsController;
 use OCA\AIquila\Service\ClaudeModels;
 use OCA\AIquila\Service\ClaudeSDKService;
+use OCA\AIquila\Service\CredentialService;
 use OCP\IConfig;
 use OCP\IRequest;
 use PHPUnit\Framework\TestCase;
@@ -13,22 +14,26 @@ class SettingsControllerTest extends TestCase {
     private $config;
     private $request;
     private $claude;
+    private $credentials;
     private SettingsController $ctrl;
 
     protected function setUp(): void {
-        $this->config  = $this->createMock(IConfig::class);
-        $this->request = $this->createMock(IRequest::class);
-        $this->claude  = $this->createMock(ClaudeSDKService::class);
-        $this->ctrl    = new SettingsController(
+        $this->config      = $this->createMock(IConfig::class);
+        $this->request     = $this->createMock(IRequest::class);
+        $this->claude      = $this->createMock(ClaudeSDKService::class);
+        $this->credentials = $this->createMock(CredentialService::class);
+        $this->ctrl        = new SettingsController(
             'aiquila',
             $this->request,
             $this->config,
             'testuser',
-            $this->claude
+            $this->claude,
+            $this->credentials
         );
     }
 
     public function testGetReturnsHasUserKeyFalse(): void {
+        $this->credentials->method('hasApiKey')->with('testuser')->willReturn(false);
         $this->config->method('getUserValue')->willReturn('');
         $this->claude->method('listModels')->willReturn(null);
 
@@ -39,10 +44,10 @@ class SettingsControllerTest extends TestCase {
     }
 
     public function testGetReturnsHasUserKeyTrue(): void {
+        $this->credentials->method('hasApiKey')->with('testuser')->willReturn(true);
         $this->config->method('getUserValue')
             ->willReturnMap([
-                ['testuser', 'aiquila', 'api_key', '', 'user-secret-key'],
-                ['testuser', 'aiquila', 'model',   '', ''],
+                ['testuser', 'aiquila', 'model', '', ''],
             ]);
         $this->claude->method('listModels')->willReturn(null);
 
@@ -53,10 +58,10 @@ class SettingsControllerTest extends TestCase {
     }
 
     public function testGetReturnsUserModelAndAvailableModels(): void {
+        $this->credentials->method('hasApiKey')->willReturn(false);
         $this->config->method('getUserValue')
             ->willReturnMap([
-                ['testuser', 'aiquila', 'api_key', '', ''],
-                ['testuser', 'aiquila', 'model',   '', ClaudeModels::HAIKU_4_5],
+                ['testuser', 'aiquila', 'model', '', ClaudeModels::HAIKU_4_5],
             ]);
         $this->claude->method('listModels')->willReturn(null);
 
@@ -68,6 +73,7 @@ class SettingsControllerTest extends TestCase {
     }
 
     public function testGetUsesLiveModelsWhenAvailable(): void {
+        $this->credentials->method('hasApiKey')->willReturn(false);
         $this->config->method('getUserValue')->willReturn('');
         $this->claude->method('listModels')->with('testuser')->willReturn(['claude-test-model']);
 
@@ -78,6 +84,7 @@ class SettingsControllerTest extends TestCase {
     }
 
     public function testGetFallsBackToStaticModelsWhenListFails(): void {
+        $this->credentials->method('hasApiKey')->willReturn(false);
         $this->config->method('getUserValue')->willReturn('');
         $this->claude->method('listModels')->with('testuser')->willReturn(null);
 
@@ -88,24 +95,24 @@ class SettingsControllerTest extends TestCase {
     }
 
     public function testSaveStoresApiKeyAndModel(): void {
-        $calls = [];
-        $this->config->method('setUserValue')
-            ->willReturnCallback(function (string $uid, string $app, string $key, string $val) use (&$calls): void {
-                $calls[] = [$uid, $app, $key, $val];
-            });
+        $this->credentials->expects($this->once())
+            ->method('setApiKey')
+            ->with('testuser', 'my-api-key');
+
+        $this->config->expects($this->once())
+            ->method('setUserValue')
+            ->with('testuser', 'aiquila', 'model', ClaudeModels::OPUS_4_6);
 
         $response = $this->ctrl->save('my-api-key', ClaudeModels::OPUS_4_6);
 
         $this->assertEquals(200, $response->getStatus());
         $this->assertEquals('ok', $response->getData()['status']);
-        $this->assertContains(['testuser', 'aiquila', 'api_key', 'my-api-key'], $calls);
-        $this->assertContains(['testuser', 'aiquila', 'model', ClaudeModels::OPUS_4_6], $calls);
     }
 
     public function testSaveWithEmptyModelDeletesUserValue(): void {
-        $this->config->expects($this->once())
-            ->method('setUserValue')
-            ->with('testuser', 'aiquila', 'api_key', 'some-key');
+        $this->credentials->expects($this->once())
+            ->method('setApiKey')
+            ->with('testuser', 'some-key');
 
         $this->config->expects($this->once())
             ->method('deleteUserValue')
@@ -115,15 +122,11 @@ class SettingsControllerTest extends TestCase {
         $this->assertEquals('ok', $response->getData()['status']);
     }
 
-    public function testSaveWithEmptyApiKeyClearsKey(): void {
-        $calls = [];
-        $this->config->method('setUserValue')
-            ->willReturnCallback(function (string $uid, string $app, string $key, string $val) use (&$calls): void {
-                $calls[] = [$uid, $app, $key, $val];
-            });
+    public function testSaveWithEmptyApiKeyDeletesKey(): void {
+        $this->credentials->expects($this->once())
+            ->method('deleteApiKey')
+            ->with('testuser');
 
         $this->ctrl->save('', ClaudeModels::SONNET_4_5);
-
-        $this->assertContains(['testuser', 'aiquila', 'api_key', ''], $calls);
     }
 }

--- a/nextcloud-app/tests/bootstrap.php
+++ b/nextcloud-app/tests/bootstrap.php
@@ -30,6 +30,7 @@ if (!interface_exists('OCP\IConfig')) {
     interface OCP_IConfig {
         public function getAppValue(string $appName, string $key, string $default = ''): string;
         public function setAppValue(string $appName, string $key, string $value): void;
+        public function deleteAppValue(string $appName, string $key): void;
         public function getUserValue(string $userId, string $appName, string $key, string $default = ''): string;
         public function setUserValue(string $userId, string $appName, string $key, string $value): void;
         public function deleteUserValue(string $userId, string $appName, string $key): void;
@@ -317,4 +318,40 @@ if (!interface_exists('Psr\Log\LoggerInterface')) {
         public function log(mixed $level, string|\Stringable $message, array $context = []): void;
     }
     class_alias('Psr_Log_LoggerInterface', 'Psr\Log\LoggerInterface');
+}
+
+if (!interface_exists('OCP\Security\ICredentialsManager')) {
+    interface OCP_Security_ICredentialsManager {
+        public function store(string $userId, string $identifier, mixed $credentials): void;
+        public function retrieve(string $userId, string $identifier): mixed;
+        public function delete(string $userId, string $identifier): void;
+    }
+    class_alias('OCP_Security_ICredentialsManager', 'OCP\Security\ICredentialsManager');
+}
+
+if (!interface_exists('OCP\Security\ICrypto')) {
+    interface OCP_Security_ICrypto {
+        public function encrypt(string $plaintext, string $password = ''): string;
+        public function decrypt(string $encryptedContent, string $password = ''): string;
+    }
+    class_alias('OCP_Security_ICrypto', 'OCP\Security\ICrypto');
+}
+
+if (!interface_exists('OCP\Migration\IOutput')) {
+    interface OCP_Migration_IOutput {
+        public function info(string $message): void;
+        public function warning(string $message): void;
+        public function startProgress(int $max = 0): void;
+        public function advance(int $step = 1, string $description = ''): void;
+        public function finishProgress(): void;
+    }
+    class_alias('OCP_Migration_IOutput', 'OCP\Migration\IOutput');
+}
+
+if (!interface_exists('OCP\Migration\IRepairStep')) {
+    interface OCP_Migration_IRepairStep {
+        public function getName(): string;
+        public function run(\OCP\Migration\IOutput $output): void;
+    }
+    class_alias('OCP_Migration_IRepairStep', 'OCP\Migration\IRepairStep');
 }


### PR DESCRIPTION
## Summary

- **API keys** now stored via Nextcloud's `ICredentialsManager` (encrypted at rest) instead of plaintext `IConfig`
- **MCP server tokens** (bearer, OAuth access/refresh) encrypted via `ICrypto` before database storage
- **Transparent migration**: plaintext values auto-migrate on first access; `RepairEncryptMcpTokens` repair step bulk-encrypts on app upgrade
- **No breaking changes**: all migration paths handle plaintext fallback gracefully

Closes #193

## Changes

| File | Change |
|------|--------|
| `lib/Service/CredentialService.php` | New — central encrypt/decrypt service wrapping `ICredentialsManager` + `ICrypto` |
| `lib/Migration/RepairEncryptMcpTokens.php` | New — repair step for bulk token encryption on upgrade |
| `lib/Service/ClaudeSDKService.php` | `getApiKey()` delegates to `CredentialService` |
| `lib/Controller/SettingsController.php` | API key CRUD via `CredentialService` |
| `lib/Settings/AdminSettings.php` | Uses `hasApiKey(null)` — no raw key access |
| `lib/Settings/UserSettings.php` | Uses `hasApiKey($userId)` — no raw key access |
| `lib/Command/ConfigureCommand.php` | Stores via `CredentialService`; `--show` prints `(configured)` instead of partial mask |
| `lib/Controller/McpServerController.php` | Encrypts bearer tokens on create/update; masks as `****` |
| `lib/Service/McpClientService.php` | Decrypts tokens before HTTP use; encrypts on OAuth exchange/refresh |
| `appinfo/info.xml` | Registers `RepairEncryptMcpTokens` repair step |
| `docs/connectivity.md` | Updated credential storage docs |
| `docs/dev/docker-setup.md` | Use `occ aiquila:configure` instead of `config:app:set` |
| `docs/internal-api.md` | Updated security section |

## Test plan

- [x] All 184 unit tests pass (443 assertions)
- [ ] Deploy to dev instance, verify `occ aiquila:configure --show` shows `(configured)`
- [ ] Verify existing plaintext API keys auto-migrate on first use
- [ ] Verify MCP server bearer tokens are encrypted in `aiquila_mcp_servers` table after upgrade
- [ ] Verify OAuth flow still works end-to-end with encrypted token storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)