### PR TITLE
chore: bump version to 0.2.5

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.1.68",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.1.68",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.1.68",
+  "version": "0.2.5",
   "description": "AIquila - MCP server for Nextcloud integration with Claude AI",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -16,13 +16,13 @@
       "sizes": ["any"]
     }
   ],
-  "version": "0.1.68",
+  "version": "0.2.5",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.1.68",
+      "version": "0.2.5",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -50,8 +50,8 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.1.68",
-      "version": "0.1.68",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.2.5",
+      "version": "0.2.5",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.1.68</version>
+    <version>0.2.5</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>


### PR DESCRIPTION
## Summary
- Bump both MCP server and Nextcloud app version from 0.1.68 to 0.2.5
- Updates `package.json`, `server.json` (including OCI image tag), and `info.xml`

## Test plan
- [x] All 25 local Docker tests passed (5 NC checks + 20 MCP tool tests)
- [x] Migration columns verified in DB
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)