### PR TITLE
fix(mcp): add MCP_ALLOWED_HOSTS for Docker internal hostname validation (#222)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ See `docs/dev/mcp-server-architecture.md` for full architecture details.
 | `MCP_AUTH_STATE_DIR` | No | Directory for persisted OAuth state (default `/app/state`) |
 | `MCP_LOCALE` | No | BCP 47 locale tag for `localTime` in `get_local_time` (e.g. `sv-SE`); defaults to system locale |
 | `MCP_MAX_FILE_SIZE` | No | Max `write_file` content length in bytes (default `1073741824` = 1 GB) |
+| `MCP_ALLOWED_HOSTS` | No | Comma-separated extra hostnames for DNS rebinding protection (e.g. `mcp` for Docker service name) |
 | `MCP_OCC_ALLOWLIST` | No | Comma-separated list of allowed OCC commands for `run_occ`; overrides default allowlist |
 | `LOG_LEVEL` | No | `trace`/`debug`/`info`/`warn`/`error`/`fatal` |
 

--- a/hetzner/docker/full/.env.example
+++ b/hetzner/docker/full/.env.example
@@ -55,7 +55,11 @@ MCP_REGISTRATION_TOKEN=
 # Mount a Docker volume here (done automatically in docker-compose.yml).
 # MCP_AUTH_STATE_DIR=/app/state
 
-# ── Internal token (NC→MCP auth on Docker network) ──────────────────────
+# ── Internal networking ──────────────────────────────────────────────────
+# Extra hostnames accepted by the MCP SDK's DNS rebinding protection.
+# Comma-separated. Required when Nextcloud connects to MCP via Docker service name.
+MCP_ALLOWED_HOSTS=mcp
+
 # Pre-shared bearer token for service-to-service auth — generate with: openssl rand -hex 32
 MCP_INTERNAL_TOKEN=
 

--- a/hetzner/docker/full/docker-compose.yml
+++ b/hetzner/docker/full/docker-compose.yml
@@ -133,6 +133,7 @@ services:
       MCP_REGISTRATION_ENABLED: ${MCP_REGISTRATION_ENABLED:-false}
       MCP_REGISTRATION_TOKEN: ${MCP_REGISTRATION_TOKEN:-}
       MCP_CLIENT_REDIRECT_URIS: ${MCP_CLIENT_REDIRECT_URIS:-https://claude.ai/api/mcp/auth_callback}
+      MCP_ALLOWED_HOSTS: ${MCP_ALLOWED_HOSTS:-mcp}
       MCP_INTERNAL_TOKEN: ${MCP_INTERNAL_TOKEN:-}
       MCP_TRUST_PROXY: "1" # hardcoded: Traefik is always a single proxy hop
       LOG_LEVEL: ${LOG_LEVEL:-info}

--- a/hetzner/internal/config/env.go
+++ b/hetzner/internal/config/env.go
@@ -295,6 +295,9 @@ func (e *FullEnv) Render() string {
 	b.WriteString("MCP_TRUST_PROXY=true\n")
 	b.WriteString("\n")
 
+	b.WriteString("# Extra hostnames for MCP SDK DNS rebinding protection (Docker service names)\n")
+	b.WriteString("MCP_ALLOWED_HOSTS=mcp\n")
+	b.WriteString("\n")
 	b.WriteString("# Internal token for NC→MCP auth on Docker network\n")
 	b.WriteString(fmt.Sprintf("MCP_INTERNAL_TOKEN=%s\n", e.MCPInternalToken))
 	b.WriteString("\n")

--- a/mcp-server/src/transports/http.ts
+++ b/mcp-server/src/transports/http.ts
@@ -130,6 +130,22 @@ export async function startHttp(): Promise<void> {
     }
   }
 
+  // MCP_ALLOWED_HOSTS lets operators add extra trusted hostnames (e.g. Docker
+  // service names like "mcp") so that container-to-container requests pass the
+  // SDK's DNS rebinding protection.  Comma-separated, whitespace-trimmed.
+  const extraHosts = process.env.MCP_ALLOWED_HOSTS;
+  if (extraHosts) {
+    const extras = extraHosts
+      .split(',')
+      .map((h) => h.trim())
+      .filter(Boolean);
+    if (allowedHosts) {
+      allowedHosts = [...new Set([...allowedHosts, ...extras])];
+    } else {
+      allowedHosts = [...new Set(['localhost', '127.0.0.1', ...extras])];
+    }
+  }
+
   const app = createMcpExpressApp({ host, allowedHosts });
 
   // Simple health check — bypasses all auth middleware so Docker health checks


### PR DESCRIPTION
The MCP SDK's DNS rebinding protection rejects requests with Docker service hostnames (e.g. "mcp") because they are not in the allowedHosts list. Add MCP_ALLOWED_HOSTS env var (comma-separated) to let operators whitelist extra hostnames for container-to-container communication.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Description
Brief description of the changes.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Component
- [ ] MCP Server
- [ ] Nextcloud App
- [ ] Documentation
- [ ] CI/CD

## Checklist
- [ ] I have tested my changes locally
- [ ] I have added tests for new functionality
- [ ] I have updated the documentation if needed
- [ ] My code follows the project's style guidelines

## Related Issues
Fixes #

## Screenshots (if applicable)
