### PR TITLE
feat(mcp): add 24 new tools for v0.3.0 milestone

### DIFF
--- a/mcp-server/src/__tests__/tools-ocs.test.ts
+++ b/mcp-server/src/__tests__/tools-ocs.test.ts
@@ -2926,4 +2926,626 @@ END:VCARD</cr:address-data>
       expect(allowlist).not.toContain('config:list');
     });
   });
+
+  // ─── Bulk File Operations ─────────────────────────────────────────────
+
+  describe('bulk_file_operations', () => {
+    it('should execute multiple operations', async () => {
+      mockClient.moveFile.mockResolvedValue(undefined);
+      mockClient.copyFile.mockResolvedValue(undefined);
+      mockClient.deleteFile.mockResolvedValue(undefined);
+
+      const { bulkFileOperationsTool } = await import('../tools/system/files.js');
+      const result = await bulkFileOperationsTool.handler({
+        operations: [
+          { action: 'move', source: '/a.txt', destination: '/b.txt' },
+          { action: 'copy', source: '/c.txt', destination: '/d.txt' },
+          { action: 'delete', source: '/e.txt' },
+        ],
+      });
+
+      expect(result.content[0].text).toContain('3/3 succeeded');
+      expect(result.content[0].text).toContain('move /a.txt');
+      expect(result.content[0].text).toContain('delete /e.txt');
+    });
+
+    it('should handle partial failures', async () => {
+      mockClient.moveFile.mockResolvedValue(undefined);
+      mockClient.deleteFile.mockRejectedValue(new Error('Not found'));
+
+      const { bulkFileOperationsTool } = await import('../tools/system/files.js');
+      const result = await bulkFileOperationsTool.handler({
+        operations: [
+          { action: 'move', source: '/a.txt', destination: '/b.txt' },
+          { action: 'delete', source: '/missing.txt' },
+        ],
+      });
+
+      expect(result.content[0].text).toContain('1/2 succeeded');
+      expect(result.isError).toBe(true);
+    });
+
+    it('should reject move/copy without destination', async () => {
+      const { bulkFileOperationsTool } = await import('../tools/system/files.js');
+      const result = await bulkFileOperationsTool.handler({
+        operations: [{ action: 'move', source: '/a.txt' }],
+      });
+
+      expect(result.content[0].text).toContain('missing destination');
+    });
+  });
+
+  // ─── Trash Tools ─────────────────────────────────────────────────────
+
+  describe('list_trash', () => {
+    it('should list trash items', async () => {
+      const xml = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+  <d:response>
+    <d:href>/remote.php/dav/trashbin/admin/trash/</d:href>
+    <d:propstat><d:prop></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/remote.php/dav/trashbin/admin/trash/doc.pdf.d1711234567</d:href>
+    <d:propstat><d:prop>
+      <d:displayname>doc.pdf</d:displayname>
+      <d:getcontentlength>10240</d:getcontentlength>
+      <oc:trashbin-original-location>Documents/doc.pdf</oc:trashbin-original-location>
+      <oc:trashbin-delete-timestamp>1711234567</oc:trashbin-delete-timestamp>
+    </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+</d:multistatus>`;
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        status: 207,
+        statusText: 'Multi-Status',
+        text: () => Promise.resolve(xml),
+        headers: new Headers(),
+      });
+
+      const { listTrashTool } = await import('../tools/apps/trash.js');
+      const result = await listTrashTool.handler();
+
+      expect(result.content[0].text).toContain('doc.pdf');
+      expect(result.content[0].text).toContain('Documents/doc.pdf');
+    });
+
+    it('should handle empty trash', async () => {
+      const xml = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/remote.php/dav/trashbin/admin/trash/</d:href>
+    <d:propstat><d:prop></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+</d:multistatus>`;
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        status: 207,
+        text: () => Promise.resolve(xml),
+        headers: new Headers(),
+      });
+
+      const { listTrashTool } = await import('../tools/apps/trash.js');
+      const result = await listTrashTool.handler();
+
+      expect(result.content[0].text).toContain('empty');
+    });
+  });
+
+  describe('restore_from_trash', () => {
+    it('should restore a trash item', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+        headers: new Headers(),
+      });
+
+      const { restoreFromTrashTool } = await import('../tools/apps/trash.js');
+      const result = await restoreFromTrashTool.handler({
+        trashKey: 'doc.pdf.d1711234567',
+      });
+
+      expect(result.content[0].text).toContain('Restored');
+    });
+  });
+
+  describe('empty_trash', () => {
+    it('should empty the trash', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        status: 204,
+        statusText: 'No Content',
+        headers: new Headers(),
+      });
+
+      const { emptyTrashTool } = await import('../tools/apps/trash.js');
+      const result = await emptyTrashTool.handler();
+
+      expect(result.content[0].text).toContain('emptied');
+    });
+  });
+
+  // ─── File Versioning Tools ──────────────────────────────────────────────
+
+  describe('list_file_versions', () => {
+    it('should list file versions', async () => {
+      const xml = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/remote.php/dav/versions/admin/versions/12345</d:href>
+    <d:propstat><d:prop></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/remote.php/dav/versions/admin/versions/12345/1711234567</d:href>
+    <d:propstat><d:prop>
+      <d:getlastmodified>Sat, 23 Mar 2024 15:16:07 GMT</d:getlastmodified>
+      <d:getcontentlength>5120</d:getcontentlength>
+    </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+</d:multistatus>`;
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        status: 207,
+        text: () => Promise.resolve(xml),
+        headers: new Headers(),
+      });
+
+      const { listFileVersionsTool } = await import('../tools/apps/versions.js');
+      const result = await listFileVersionsTool.handler({ fileId: 12345 });
+
+      expect(result.content[0].text).toContain('1711234567');
+      expect(result.content[0].text).toContain('Sat, 23 Mar 2024');
+    });
+
+    it('should handle no versions', async () => {
+      const xml = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/remote.php/dav/versions/admin/versions/12345</d:href>
+    <d:propstat><d:prop></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+</d:multistatus>`;
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        status: 207,
+        text: () => Promise.resolve(xml),
+        headers: new Headers(),
+      });
+
+      const { listFileVersionsTool } = await import('../tools/apps/versions.js');
+      const result = await listFileVersionsTool.handler({ fileId: 12345 });
+
+      expect(result.content[0].text).toContain('No previous versions');
+    });
+  });
+
+  describe('restore_file_version', () => {
+    it('should restore a file version', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+        headers: new Headers(),
+      });
+
+      const { restoreFileVersionTool } = await import('../tools/apps/versions.js');
+      const result = await restoreFileVersionTool.handler({
+        fileId: 12345,
+        versionId: '1711234567',
+      });
+
+      expect(result.content[0].text).toContain('Restored version 1711234567');
+    });
+  });
+
+  // ─── Notification Tools ──────────────────────────────────────────────
+
+  describe('list_notifications', () => {
+    it('should list notifications', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: [
+            {
+              notification_id: 1,
+              app: 'files_sharing',
+              subject: 'Alice shared doc.pdf with you',
+              message: '',
+              datetime: '2026-03-24T12:00:00+00:00',
+            },
+          ],
+        },
+      });
+
+      const { listNotificationsTool } = await import('../tools/apps/notifications.js');
+      const result = await listNotificationsTool.handler();
+
+      expect(result.content[0].text).toContain('Alice shared doc.pdf');
+    });
+
+    it('should handle empty notifications', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data: [] },
+      });
+
+      const { listNotificationsTool } = await import('../tools/apps/notifications.js');
+      const result = await listNotificationsTool.handler();
+
+      expect(result.content[0].text).toContain('No notifications');
+    });
+  });
+
+  describe('get_notification', () => {
+    it('should get notification details', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: { notification_id: 1, app: 'files', subject: 'Test' },
+        },
+      });
+
+      const { getNotificationTool } = await import('../tools/apps/notifications.js');
+      const result = await getNotificationTool.handler({ id: 1 });
+
+      expect(result.content[0].text).toContain('Test');
+    });
+  });
+
+  describe('mark_notification_read', () => {
+    it('should mark notification as read', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data: {} },
+      });
+
+      const { markNotificationReadTool } = await import('../tools/apps/notifications.js');
+      const result = await markNotificationReadTool.handler({ id: 1 });
+
+      expect(result.content[0].text).toContain('marked as read');
+    });
+  });
+
+  describe('delete_all_notifications', () => {
+    it('should delete all notifications', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data: {} },
+      });
+
+      const { deleteAllNotificationsTool } = await import('../tools/apps/notifications.js');
+      const result = await deleteAllNotificationsTool.handler();
+
+      expect(result.content[0].text).toContain('All notifications deleted');
+    });
+  });
+
+  // ─── Share Enhancement Tools ──────────────────────────────────────────
+
+  describe('get_share', () => {
+    it('should return share details', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: { id: 42, share_type: 0, path: '/doc.pdf', share_with: 'bob' },
+        },
+      });
+
+      const { getShareTool } = await import('../tools/apps/shares.js');
+      const result = await getShareTool.handler({ shareId: 42 });
+
+      expect(result.content[0].text).toContain('42');
+      expect(result.content[0].text).toContain('doc.pdf');
+    });
+  });
+
+  describe('list_shares_with_me', () => {
+    it('should list shares shared with current user', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: [
+            {
+              id: 1,
+              share_type: 0,
+              path: '/shared-doc.pdf',
+              uid_owner: 'alice',
+              displayname_owner: 'Alice',
+            },
+          ],
+        },
+      });
+
+      const { listSharesWithMeTool } = await import('../tools/apps/shares.js');
+      const result = await listSharesWithMeTool.handler();
+
+      expect(result.content[0].text).toContain('shared-doc.pdf');
+      expect(result.content[0].text).toContain('Alice');
+    });
+
+    it('should handle no shares', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data: [] },
+      });
+
+      const { listSharesWithMeTool } = await import('../tools/apps/shares.js');
+      const result = await listSharesWithMeTool.handler();
+
+      expect(result.content[0].text).toContain('No shares found');
+    });
+  });
+
+  describe('search_sharees', () => {
+    it('should search for share recipients', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 100, message: 'OK' },
+          data: {
+            exact: { users: [], groups: [] },
+            users: [{ label: 'Bob', value: { shareType: 0, shareWith: 'bob' } }],
+          },
+        },
+      });
+
+      const { searchShareesTool } = await import('../tools/apps/shares.js');
+      const result = await searchShareesTool.handler({ search: 'bob' });
+
+      expect(result.content[0].text).toContain('Bob');
+      expect(mockFetchOCS).toHaveBeenCalledWith(
+        '/ocs/v1.php/apps/files_sharing/api/v1/sharees',
+        expect.objectContaining({
+          queryParams: expect.objectContaining({ search: 'bob', 'shareType[]': expect.any(Array) }),
+        })
+      );
+    });
+  });
+
+  describe('list_pending_shares', () => {
+    it('should list pending remote shares', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 100, message: 'OK' },
+          data: [{ id: 5, name: 'shared-folder', remote: 'https://other.cloud' }],
+        },
+      });
+
+      const { listPendingSharesTool } = await import('../tools/apps/shares.js');
+      const result = await listPendingSharesTool.handler();
+
+      expect(result.content[0].text).toContain('shared-folder');
+    });
+
+    it('should handle no pending shares', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 100, message: 'OK' }, data: [] },
+      });
+
+      const { listPendingSharesTool } = await import('../tools/apps/shares.js');
+      const result = await listPendingSharesTool.handler();
+
+      expect(result.content[0].text).toContain('No pending');
+    });
+  });
+
+  describe('accept_pending_share', () => {
+    it('should accept pending share', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 100, message: 'OK' }, data: {} },
+      });
+
+      const { acceptPendingShareTool } = await import('../tools/apps/shares.js');
+      const result = await acceptPendingShareTool.handler({ shareId: 5 });
+
+      expect(result.content[0].text).toContain('accepted');
+      expect(mockFetchOCS).toHaveBeenCalledWith(
+        '/ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending/5',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+  });
+
+  describe('decline_pending_share', () => {
+    it('should decline pending share', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 100, message: 'OK' }, data: {} },
+      });
+
+      const { declinePendingShareTool } = await import('../tools/apps/shares.js');
+      const result = await declinePendingShareTool.handler({ shareId: 5 });
+
+      expect(result.content[0].text).toContain('declined');
+    });
+  });
+
+  // ─── User Status Tools ──────────────────────────────────────────────────
+
+  describe('get_user_status', () => {
+    it('should return current user status', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: {
+            userId: 'admin',
+            status: 'online',
+            icon: '☕',
+            message: 'Coffee break',
+            clearAt: null,
+          },
+        },
+      });
+
+      const { getUserStatusTool } = await import('../tools/apps/user-status.js');
+      const result = await getUserStatusTool.handler({});
+
+      expect(result.content[0].text).toContain('online');
+      expect(result.content[0].text).toContain('Coffee break');
+      expect(result).not.toHaveProperty('isError');
+    });
+
+    it('should handle errors', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('API error'));
+
+      const { getUserStatusTool } = await import('../tools/apps/user-status.js');
+      const result = await getUserStatusTool.handler({});
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('set_user_status', () => {
+    it('should set status type', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data: {} },
+      });
+
+      const { setUserStatusTool } = await import('../tools/apps/user-status.js');
+      const result = await setUserStatusTool.handler({ statusType: 'dnd' });
+
+      expect(result.content[0].text).toContain('dnd');
+      expect(mockFetchOCS).toHaveBeenCalledWith(
+        '/ocs/v2.php/apps/user_status/api/v1/user_status/status',
+        expect.objectContaining({ method: 'PUT', body: { statusType: 'dnd' } })
+      );
+    });
+  });
+
+  describe('set_user_status_message', () => {
+    it('should set custom message with icon', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data: {} },
+      });
+
+      const { setUserStatusMessageTool } = await import('../tools/apps/user-status.js');
+      const result = await setUserStatusMessageTool.handler({
+        message: 'In a meeting',
+        statusIcon: '📅',
+      });
+
+      expect(result.content[0].text).toContain('📅');
+      expect(result.content[0].text).toContain('In a meeting');
+    });
+  });
+
+  describe('clear_user_status_message', () => {
+    it('should clear status message', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data: {} },
+      });
+
+      const { clearUserStatusMessageTool } = await import('../tools/apps/user-status.js');
+      const result = await clearUserStatusMessageTool.handler();
+
+      expect(result.content[0].text).toContain('cleared');
+      expect(mockFetchOCS).toHaveBeenCalledWith(
+        '/ocs/v2.php/apps/user_status/api/v1/user_status/message',
+        expect.objectContaining({ method: 'DELETE' })
+      );
+    });
+  });
+
+  describe('list_user_statuses', () => {
+    it('should list all user statuses', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: [
+            { userId: 'alice', status: 'online', icon: null, message: null },
+            { userId: 'bob', status: 'away', icon: '🏠', message: 'Working from home' },
+          ],
+        },
+      });
+
+      const { listUserStatusesTool } = await import('../tools/apps/user-status.js');
+      const result = await listUserStatusesTool.handler({});
+
+      expect(result.content[0].text).toContain('alice: online');
+      expect(result.content[0].text).toContain('bob: away');
+      expect(result.content[0].text).toContain('Working from home');
+    });
+
+    it('should handle empty statuses', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data: [] },
+      });
+
+      const { listUserStatusesTool } = await import('../tools/apps/user-status.js');
+      const result = await listUserStatusesTool.handler({});
+
+      expect(result.content[0].text).toContain('No user statuses found');
+    });
+  });
+
+  // ─── Absence / Out-of-Office Tools ──────────────────────────────────────
+
+  describe('get_out_of_office', () => {
+    it('should return absence status', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: {
+            id: '1',
+            firstDay: '2026-04-01',
+            lastDay: '2026-04-10',
+            status: 'Vacation',
+            message: 'On holiday',
+          },
+        },
+      });
+
+      const { getOutOfOfficeTool } = await import('../tools/apps/absence.js');
+      const result = await getOutOfOfficeTool.handler({});
+
+      expect(result.content[0].text).toContain('Vacation');
+      expect(result.content[0].text).toContain('2026-04-01');
+    });
+
+    it('should handle 404 gracefully', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('OCS API error: 404 Not Found'));
+
+      const { getOutOfOfficeTool } = await import('../tools/apps/absence.js');
+      const result = await getOutOfOfficeTool.handler({});
+
+      expect(result.content[0].text).toContain('No out-of-office status set');
+      expect(result).not.toHaveProperty('isError');
+    });
+  });
+
+  describe('set_out_of_office', () => {
+    it('should set absence period', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data: {} },
+      });
+
+      const { setOutOfOfficeTool } = await import('../tools/apps/absence.js');
+      const result = await setOutOfOfficeTool.handler({
+        firstDay: '2026-04-01',
+        lastDay: '2026-04-10',
+        status: 'Vacation',
+        message: 'On holiday',
+      });
+
+      expect(result.content[0].text).toContain('Out-of-office set');
+      expect(result.content[0].text).toContain('2026-04-01');
+      expect(result.content[0].text).toContain('2026-04-10');
+    });
+  });
+
+  describe('clear_out_of_office', () => {
+    it('should clear absence', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data: {} },
+      });
+
+      const { clearOutOfOfficeTool } = await import('../tools/apps/absence.js');
+      const result = await clearOutOfOfficeTool.handler({});
+
+      expect(result.content[0].text).toContain('cleared');
+      expect(mockFetchOCS).toHaveBeenCalledWith(
+        expect.stringContaining('/outOfOffice/'),
+        expect.objectContaining({ method: 'DELETE' })
+      );
+    });
+  });
 });

--- a/mcp-server/src/client/ocs.ts
+++ b/mcp-server/src/client/ocs.ts
@@ -26,7 +26,7 @@ interface OcsRequestOptions {
   body?: Record<string, string>;
   /** JSON body (for newer TaskProcessing and text2image endpoints) */
   jsonBody?: unknown;
-  queryParams?: Record<string, string>;
+  queryParams?: Record<string, string | string[]>;
 }
 
 /**
@@ -44,7 +44,14 @@ export async function fetchOCS<T = unknown>(
 
   let url = `${config.url}${path}`;
   if (options.queryParams) {
-    const params = new URLSearchParams(options.queryParams);
+    const params = new URLSearchParams();
+    for (const [key, val] of Object.entries(options.queryParams)) {
+      if (Array.isArray(val)) {
+        for (const v of val) params.append(key, v);
+      } else {
+        params.append(key, val);
+      }
+    }
     url += `?${params.toString()}`;
   }
 

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -27,6 +27,11 @@ import { mapsTools } from './tools/apps/maps.js';
 import { assistantTools } from './tools/apps/assistant.js';
 import { translateTools } from './tools/apps/translate.js';
 import { talkTools } from './tools/apps/talk.js';
+import { userStatusTools } from './tools/apps/user-status.js';
+import { absenceTools } from './tools/apps/absence.js';
+import { notificationsTools } from './tools/apps/notifications.js';
+import { trashTools } from './tools/apps/trash.js';
+import { versionsTools } from './tools/apps/versions.js';
 
 const SERVER_NAME = 'aiquila';
 const _require = createRequire(import.meta.url);
@@ -55,6 +60,11 @@ const allToolSets = [
   assistantTools,
   translateTools,
   talkTools,
+  userStatusTools,
+  absenceTools,
+  notificationsTools,
+  trashTools,
+  versionsTools,
 ];
 
 /**

--- a/mcp-server/src/tools/apps/absence.ts
+++ b/mcp-server/src/tools/apps/absence.ts
@@ -1,0 +1,162 @@
+import { z } from 'zod';
+import { fetchOCS } from '../../client/ocs.js';
+import { getNextcloudConfig } from '../types.js';
+
+/**
+ * Nextcloud Out-of-Office / Absence Tools
+ * Manages absence status via OCS DAV API (NC 28+)
+ */
+
+// ---------------------------------------------------------------------------
+// get_out_of_office
+// ---------------------------------------------------------------------------
+
+export const getOutOfOfficeTool = {
+  name: 'get_out_of_office',
+  description: "Get a user's current out-of-office / absence status (NC 28+)",
+  inputSchema: z.object({
+    userId: z
+      .string()
+      .optional()
+      .describe('User ID to check (defaults to the configured Nextcloud user)'),
+  }),
+  handler: async (args: { userId?: string }) => {
+    try {
+      const userId = args.userId ?? getNextcloudConfig().user;
+      const result = await fetchOCS<Record<string, unknown>>(
+        `/ocs/v2.php/apps/dav/api/v1/outOfOffice/${encodeURIComponent(userId)}/now`
+      );
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result.ocs.data, null, 2) }],
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      // 404 means no absence is set — return a friendly message
+      if (msg.includes('404')) {
+        const userId = args.userId ?? getNextcloudConfig().user;
+        return {
+          content: [
+            { type: 'text' as const, text: `No out-of-office status set for "${userId}".` },
+          ],
+        };
+      }
+      return {
+        content: [{ type: 'text' as const, text: `Error getting out-of-office: ${msg}` }],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// set_out_of_office
+// ---------------------------------------------------------------------------
+
+export const setOutOfOfficeTool = {
+  name: 'set_out_of_office',
+  description: 'Set an out-of-office / absence period with status message (NC 28+)',
+  inputSchema: z.object({
+    firstDay: z.string().describe('First day of absence (YYYY-MM-DD)'),
+    lastDay: z.string().describe('Last day of absence (YYYY-MM-DD)'),
+    status: z.string().describe('Short status label (e.g. "Vacation", "Sick leave")'),
+    message: z.string().describe('Detailed absence message shown to others'),
+    replacementUserId: z
+      .string()
+      .optional()
+      .describe('User ID of the replacement/delegate during absence'),
+    userId: z
+      .string()
+      .optional()
+      .describe('User ID to set absence for (defaults to the configured Nextcloud user)'),
+  }),
+  handler: async (args: {
+    firstDay: string;
+    lastDay: string;
+    status: string;
+    message: string;
+    replacementUserId?: string;
+    userId?: string;
+  }) => {
+    try {
+      const userId = args.userId ?? getNextcloudConfig().user;
+
+      const payload: Record<string, string> = {
+        firstDay: args.firstDay,
+        lastDay: args.lastDay,
+        status: args.status,
+        message: args.message,
+      };
+      if (args.replacementUserId !== undefined) {
+        payload.replacementUserId = args.replacementUserId;
+      }
+
+      await fetchOCS(`/ocs/v2.php/apps/dav/api/v1/outOfOffice/${encodeURIComponent(userId)}`, {
+        method: 'POST',
+        jsonBody: payload,
+      });
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Out-of-office set for "${userId}": ${args.status} (${args.firstDay} → ${args.lastDay})`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error setting out-of-office: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// clear_out_of_office
+// ---------------------------------------------------------------------------
+
+export const clearOutOfOfficeTool = {
+  name: 'clear_out_of_office',
+  description: "Clear a user's out-of-office / absence status (NC 28+)",
+  inputSchema: z.object({
+    userId: z
+      .string()
+      .optional()
+      .describe('User ID to clear absence for (defaults to the configured Nextcloud user)'),
+  }),
+  handler: async (args: { userId?: string }) => {
+    try {
+      const userId = args.userId ?? getNextcloudConfig().user;
+      await fetchOCS(`/ocs/v2.php/apps/dav/api/v1/outOfOffice/${encodeURIComponent(userId)}`, {
+        method: 'DELETE',
+      });
+
+      return {
+        content: [{ type: 'text' as const, text: `Out-of-office cleared for "${userId}".` }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error clearing out-of-office: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export const absenceTools = [getOutOfOfficeTool, setOutOfOfficeTool, clearOutOfOfficeTool];

--- a/mcp-server/src/tools/apps/notifications.ts
+++ b/mcp-server/src/tools/apps/notifications.ts
@@ -1,0 +1,177 @@
+import { z } from 'zod';
+import { fetchOCS } from '../../client/ocs.js';
+
+/**
+ * Nextcloud Notification Tools
+ * List, read, and manage notifications via OCS Notifications API
+ */
+
+interface Notification {
+  notification_id: number;
+  app: string;
+  user: string;
+  datetime: string;
+  object_type: string;
+  object_id: string;
+  subject: string;
+  message: string;
+  link: string;
+  actions: unknown[];
+}
+
+// ---------------------------------------------------------------------------
+// list_notifications
+// ---------------------------------------------------------------------------
+
+export const listNotificationsTool = {
+  name: 'list_notifications',
+  description: 'List all notifications for the current user',
+  inputSchema: z.object({}),
+  handler: async () => {
+    try {
+      const result = await fetchOCS<Notification[]>(
+        '/ocs/v2.php/apps/notifications/api/v2/notifications'
+      );
+
+      const notifications = result.ocs.data;
+      if (notifications.length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: 'No notifications.' }],
+        };
+      }
+
+      const formatted = notifications.map((n) => {
+        const time = n.datetime ? ` (${n.datetime})` : '';
+        const msg = n.message ? `\n  ${n.message}` : '';
+        return `- [${n.app}] ${n.subject}${time}${msg}`;
+      });
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Notifications (${notifications.length}):\n${formatted.join('\n')}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error listing notifications: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// get_notification
+// ---------------------------------------------------------------------------
+
+export const getNotificationTool = {
+  name: 'get_notification',
+  description: 'Get details of a specific notification by ID',
+  inputSchema: z.object({
+    id: z.number().describe('The notification ID'),
+  }),
+  handler: async (args: { id: number }) => {
+    try {
+      const result = await fetchOCS<Notification>(
+        `/ocs/v2.php/apps/notifications/api/v2/notifications/${args.id}`
+      );
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result.ocs.data, null, 2) }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error getting notification: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// mark_notification_read
+// ---------------------------------------------------------------------------
+
+export const markNotificationReadTool = {
+  name: 'mark_notification_read',
+  description: 'Mark a notification as read (deletes it)',
+  inputSchema: z.object({
+    id: z.number().describe('The notification ID to mark as read'),
+  }),
+  handler: async (args: { id: number }) => {
+    try {
+      await fetchOCS(`/ocs/v2.php/apps/notifications/api/v2/notifications/${args.id}`, {
+        method: 'DELETE',
+      });
+
+      return {
+        content: [{ type: 'text' as const, text: `Notification ${args.id} marked as read.` }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error marking notification: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// delete_all_notifications
+// ---------------------------------------------------------------------------
+
+export const deleteAllNotificationsTool = {
+  name: 'delete_all_notifications',
+  description: 'Delete all notifications for the current user',
+  inputSchema: z.object({}),
+  handler: async () => {
+    try {
+      await fetchOCS('/ocs/v2.php/apps/notifications/api/v2/notifications', {
+        method: 'DELETE',
+      });
+
+      return {
+        content: [{ type: 'text' as const, text: 'All notifications deleted.' }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error deleting notifications: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export const notificationsTools = [
+  listNotificationsTool,
+  getNotificationTool,
+  markNotificationReadTool,
+  deleteAllNotificationsTool,
+];

--- a/mcp-server/src/tools/apps/shares.ts
+++ b/mcp-server/src/tools/apps/shares.ts
@@ -121,6 +121,8 @@ export const createShareTool = {
     password: z.string().optional().describe('Password-protect the share'),
     expireDate: z.string().optional().describe('Expiration date (YYYY-MM-DD)'),
     label: z.string().optional().describe('Label for public link shares'),
+    note: z.string().optional().describe('Note to the share recipient'),
+    hideDownload: z.boolean().optional().describe('Hide download button for public link shares'),
   }),
   handler: async (args: {
     path: string;
@@ -130,6 +132,8 @@ export const createShareTool = {
     password?: string;
     expireDate?: string;
     label?: string;
+    note?: string;
+    hideDownload?: boolean;
   }) => {
     try {
       const body: Record<string, string> = {
@@ -141,6 +145,8 @@ export const createShareTool = {
       if (args.password !== undefined) body.password = args.password;
       if (args.expireDate !== undefined) body.expireDate = args.expireDate;
       if (args.label !== undefined) body.label = args.label;
+      if (args.note !== undefined) body.note = args.note;
+      if (args.hideDownload !== undefined) body.hideDownload = args.hideDownload ? 'true' : 'false';
 
       const result = await fetchOCS<ShareEntry>('/ocs/v2.php/apps/files_sharing/api/v1/shares', {
         method: 'POST',
@@ -185,6 +191,8 @@ export const updateShareTool = {
     password: z.string().optional().describe('Password-protect the share'),
     expireDate: z.string().optional().describe('Expiration date (YYYY-MM-DD)'),
     label: z.string().optional().describe('Label for public link shares'),
+    note: z.string().optional().describe('Note to the share recipient'),
+    hideDownload: z.boolean().optional().describe('Hide download button for public link shares'),
   }),
   handler: async (args: {
     shareId: number;
@@ -192,6 +200,8 @@ export const updateShareTool = {
     password?: string;
     expireDate?: string;
     label?: string;
+    note?: string;
+    hideDownload?: boolean;
   }) => {
     try {
       const body: Record<string, string> = {};
@@ -199,6 +209,8 @@ export const updateShareTool = {
       if (args.password !== undefined) body.password = args.password;
       if (args.expireDate !== undefined) body.expireDate = args.expireDate;
       if (args.label !== undefined) body.label = args.label;
+      if (args.note !== undefined) body.note = args.note;
+      if (args.hideDownload !== undefined) body.hideDownload = args.hideDownload ? 'true' : 'false';
 
       const result = await fetchOCS<ShareEntry>(
         `/ocs/v2.php/apps/files_sharing/api/v1/shares/${args.shareId}`,
@@ -267,6 +279,247 @@ export const deleteShareTool = {
 };
 
 /**
+ * Get details of a specific share by ID
+ */
+export const getShareTool = {
+  name: 'get_share',
+  description: 'Get detailed information about a specific share by its ID',
+  inputSchema: z.object({
+    shareId: z.number().describe('The share ID to retrieve'),
+  }),
+  handler: async (args: { shareId: number }) => {
+    try {
+      const result = await fetchOCS<ShareEntry>(
+        `/ocs/v2.php/apps/files_sharing/api/v1/shares/${args.shareId}`
+      );
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result.ocs.data, null, 2) }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error getting share ${args.shareId}: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+/**
+ * List shares shared with the current user
+ */
+export const listSharesWithMeTool = {
+  name: 'list_shares_with_me',
+  description: 'List all files and folders shared with the current user',
+  inputSchema: z.object({}),
+  handler: async () => {
+    try {
+      const result = await fetchOCS<ShareEntry[]>('/ocs/v2.php/apps/files_sharing/api/v1/shares', {
+        queryParams: { shared_with_me: 'true' },
+      });
+
+      const shares = result.ocs.data;
+      if (shares.length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: 'No shares found shared with you.' }],
+        };
+      }
+
+      const formatted = shares.map((share) => {
+        const typeLabel = SHARE_TYPE_LABELS[share.share_type] ?? `Type ${share.share_type}`;
+        return `- [${typeLabel}] ${share.path} (from: ${share.displayname_owner})`;
+      });
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Shares with you (${shares.length}):\n${formatted.join('\n')}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error listing shares: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+/**
+ * Search for valid share recipients
+ */
+export const searchShareesTool = {
+  name: 'search_sharees',
+  description:
+    'Search for valid share recipients (users, groups, emails, federated users, circles, rooms)',
+  inputSchema: z.object({
+    search: z.string().describe('Search query for recipient name/email'),
+    itemType: z.enum(['file', 'folder']).optional().describe('Item type (default: file)'),
+    shareTypes: z
+      .array(z.number())
+      .optional()
+      .describe(
+        'Share types to include: 0=user, 1=group, 3=public, 4=email, 6=federated, 7=circle, 10=room (default: [0,1,3,4,6])'
+      ),
+  }),
+  handler: async (args: { search: string; itemType?: string; shareTypes?: number[] }) => {
+    try {
+      const shareTypes = args.shareTypes ?? [0, 1, 3, 4, 6];
+      const queryParams: Record<string, string | string[]> = {
+        search: args.search,
+        itemType: args.itemType ?? 'file',
+        'shareType[]': shareTypes.map(String),
+      };
+
+      const result = await fetchOCS<Record<string, unknown>>(
+        '/ocs/v1.php/apps/files_sharing/api/v1/sharees',
+        { queryParams }
+      );
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result.ocs.data, null, 2) }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error searching sharees: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+/**
+ * List pending federated (remote) shares
+ */
+export const listPendingSharesTool = {
+  name: 'list_pending_shares',
+  description: 'List pending federated/remote shares waiting to be accepted or declined',
+  inputSchema: z.object({}),
+  handler: async () => {
+    try {
+      const result = await fetchOCS<ShareEntry[]>(
+        '/ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending'
+      );
+
+      const shares = result.ocs.data;
+      if (shares.length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: 'No pending remote shares.' }],
+        };
+      }
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(shares, null, 2) }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error listing pending shares: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+/**
+ * Accept a pending federated share
+ */
+export const acceptPendingShareTool = {
+  name: 'accept_pending_share',
+  description: 'Accept a pending federated/remote share',
+  inputSchema: z.object({
+    shareId: z.number().describe('The pending share ID to accept'),
+  }),
+  handler: async (args: { shareId: number }) => {
+    try {
+      await fetchOCS(
+        `/ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending/${args.shareId}`,
+        { method: 'POST' }
+      );
+
+      return {
+        content: [{ type: 'text' as const, text: `Pending share ${args.shareId} accepted.` }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error accepting share: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+/**
+ * Decline a pending federated share
+ */
+export const declinePendingShareTool = {
+  name: 'decline_pending_share',
+  description: 'Decline a pending federated/remote share',
+  inputSchema: z.object({
+    shareId: z.number().describe('The pending share ID to decline'),
+  }),
+  handler: async (args: { shareId: number }) => {
+    try {
+      await fetchOCS(
+        `/ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending/${args.shareId}`,
+        { method: 'DELETE' }
+      );
+
+      return {
+        content: [{ type: 'text' as const, text: `Pending share ${args.shareId} declined.` }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error declining share: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+/**
  * Export all Share Management tools
  */
-export const sharesTools = [listSharesTool, createShareTool, updateShareTool, deleteShareTool];
+export const sharesTools = [
+  listSharesTool,
+  createShareTool,
+  updateShareTool,
+  deleteShareTool,
+  getShareTool,
+  listSharesWithMeTool,
+  searchShareesTool,
+  listPendingSharesTool,
+  acceptPendingShareTool,
+  declinePendingShareTool,
+];

--- a/mcp-server/src/tools/apps/trash.ts
+++ b/mcp-server/src/tools/apps/trash.ts
@@ -1,0 +1,217 @@
+import { z } from 'zod';
+import { fetchCalDAV, decodeXmlEntities } from '../../client/caldav.js';
+import { getNextcloudConfig } from '../types.js';
+
+/**
+ * Nextcloud Trash / Recycle Bin Tools
+ * Manages deleted files via WebDAV Trashbin API
+ */
+
+// ---------------------------------------------------------------------------
+// list_trash
+// ---------------------------------------------------------------------------
+
+export const listTrashTool = {
+  name: 'list_trash',
+  description: 'List files in the trash / recycle bin',
+  inputSchema: z.object({}),
+  handler: async () => {
+    try {
+      const config = getNextcloudConfig();
+      const url = `${config.url}/remote.php/dav/trashbin/${config.user}/trash/`;
+
+      const body = `<?xml version="1.0"?>
+<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
+  <d:prop>
+    <d:displayname />
+    <d:getlastmodified />
+    <d:getcontentlength />
+    <oc:trashbin-original-location />
+    <oc:trashbin-delete-timestamp />
+  </d:prop>
+</d:propfind>`;
+
+      const response = await fetchCalDAV(url, {
+        method: 'PROPFIND',
+        body,
+        headers: { Depth: '1' },
+      });
+
+      const text = await response.text();
+
+      if (!response.ok && response.status !== 207) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error listing trash: ${response.status} ${response.statusText}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Parse responses — skip the first one (container itself)
+      const responses = text.match(/<d:response>[\s\S]*?<\/d:response>/g) || [];
+      const items = responses.slice(1).map((r) => {
+        const href = r.match(/<d:href>([^<]*)<\/d:href>/)?.[1] ?? '';
+        const displayname = decodeXmlEntities(
+          r.match(/<d:displayname>([^<]*)<\/d:displayname>/)?.[1] ?? ''
+        );
+        const originalLocation = decodeXmlEntities(
+          r.match(/<oc:trashbin-original-location>([^<]*)<\/oc:trashbin-original-location>/)?.[1] ??
+            ''
+        );
+        const deleteTimestamp =
+          r.match(/<oc:trashbin-delete-timestamp>([^<]*)<\/oc:trashbin-delete-timestamp>/)?.[1] ??
+          '';
+        const size = r.match(/<d:getcontentlength>([^<]*)<\/d:getcontentlength>/)?.[1] ?? '';
+
+        const deletedAt = deleteTimestamp
+          ? new Date(parseInt(deleteTimestamp, 10) * 1000).toISOString()
+          : '';
+        const sizeStr = size ? ` (${Math.round(parseInt(size, 10) / 1024)} KB)` : '';
+        // Extract the trash item key from href for restore operations
+        const trashKey = href.split('/trash/')[1]?.replace(/\/$/, '') ?? '';
+
+        return `- ${displayname || trashKey}${sizeStr}\n  Original: ${originalLocation}\n  Deleted: ${deletedAt}\n  Key: ${trashKey}`;
+      });
+
+      if (items.length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: 'Trash is empty.' }],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Trash items (${items.length}):\n${items.join('\n')}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error listing trash: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// restore_from_trash
+// ---------------------------------------------------------------------------
+
+export const restoreFromTrashTool = {
+  name: 'restore_from_trash',
+  description:
+    'Restore a file from the trash to its original location (use the Key from list_trash)',
+  inputSchema: z.object({
+    trashKey: z.string().describe('The trash item key (from the Key field in list_trash output)'),
+  }),
+  handler: async (args: { trashKey: string }) => {
+    try {
+      const config = getNextcloudConfig();
+      const sourceUrl = `${config.url}/remote.php/dav/trashbin/${config.user}/trash/${args.trashKey}`;
+      const destUrl = `${config.url}/remote.php/dav/trashbin/${config.user}/restore/${args.trashKey}`;
+
+      const response = await fetchCalDAV(sourceUrl, {
+        method: 'MOVE',
+        headers: {
+          Destination: destUrl,
+          Overwrite: 'T',
+        },
+      });
+
+      if (response.status >= 200 && response.status < 300) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Restored "${args.trashKey}" from trash.`,
+            },
+          ],
+        };
+      }
+
+      const text = await response.text();
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error restoring from trash: ${response.status} ${response.statusText}\n${text}`,
+          },
+        ],
+        isError: true,
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error restoring from trash: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// empty_trash
+// ---------------------------------------------------------------------------
+
+export const emptyTrashTool = {
+  name: 'empty_trash',
+  description: 'Permanently delete all files in the trash (cannot be undone)',
+  inputSchema: z.object({}),
+  handler: async () => {
+    try {
+      const config = getNextcloudConfig();
+      const url = `${config.url}/remote.php/dav/trashbin/${config.user}/trash/`;
+
+      const response = await fetchCalDAV(url, { method: 'DELETE' });
+
+      if (response.status >= 200 && response.status < 300) {
+        return {
+          content: [{ type: 'text' as const, text: 'Trash emptied successfully.' }],
+        };
+      }
+
+      const text = await response.text();
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error emptying trash: ${response.status} ${response.statusText}\n${text}`,
+          },
+        ],
+        isError: true,
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error emptying trash: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export const trashTools = [listTrashTool, restoreFromTrashTool, emptyTrashTool];

--- a/mcp-server/src/tools/apps/user-status.ts
+++ b/mcp-server/src/tools/apps/user-status.ts
@@ -1,0 +1,240 @@
+import { z } from 'zod';
+import { fetchOCS } from '../../client/ocs.js';
+
+/**
+ * Nextcloud User Status Tools
+ * Manages user presence status via OCS User Status API
+ */
+
+interface UserStatus {
+  userId: string;
+  status: string;
+  icon: string | null;
+  message: string | null;
+  clearAt: number | null;
+  messageId: string | null;
+  messageIsPredefined: boolean;
+  statusIsUserDefined: boolean;
+}
+
+const STATUS_TYPES = ['online', 'away', 'dnd', 'invisible', 'offline'] as const;
+
+// ---------------------------------------------------------------------------
+// get_user_status
+// ---------------------------------------------------------------------------
+
+export const getUserStatusTool = {
+  name: 'get_user_status',
+  description:
+    "Get the current user's presence status (online, away, DND, invisible, custom message)",
+  inputSchema: z.object({
+    userId: z
+      .string()
+      .optional()
+      .describe('User ID to check (defaults to the configured Nextcloud user)'),
+  }),
+  handler: async (args: { userId?: string }) => {
+    try {
+      const path = args.userId
+        ? `/ocs/v2.php/apps/user_status/api/v1/statuses/${encodeURIComponent(args.userId)}`
+        : '/ocs/v2.php/apps/user_status/api/v1/user_status';
+
+      const result = await fetchOCS<UserStatus>(path);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result.ocs.data, null, 2) }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error getting user status: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// set_user_status
+// ---------------------------------------------------------------------------
+
+export const setUserStatusTool = {
+  name: 'set_user_status',
+  description: "Set the current user's status type (online, away, dnd, invisible, offline)",
+  inputSchema: z.object({
+    statusType: z.enum(STATUS_TYPES).describe('Status type to set'),
+  }),
+  handler: async (args: { statusType: string }) => {
+    try {
+      await fetchOCS('/ocs/v2.php/apps/user_status/api/v1/user_status/status', {
+        method: 'PUT',
+        body: { statusType: args.statusType },
+      });
+
+      return {
+        content: [{ type: 'text' as const, text: `Status set to "${args.statusType}".` }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error setting status: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// set_user_status_message
+// ---------------------------------------------------------------------------
+
+export const setUserStatusMessageTool = {
+  name: 'set_user_status_message',
+  description: 'Set a custom status message with optional emoji icon and auto-clear time',
+  inputSchema: z.object({
+    message: z.string().describe('Custom status message text'),
+    statusIcon: z.string().optional().describe('Status emoji icon (e.g. "☕", "🏠", "🤒")'),
+    clearAt: z
+      .number()
+      .optional()
+      .describe('Unix timestamp when the message should auto-clear (null = never)'),
+  }),
+  handler: async (args: { message: string; statusIcon?: string; clearAt?: number }) => {
+    try {
+      const body: Record<string, string> = { message: args.message };
+      if (args.statusIcon !== undefined) body.statusIcon = args.statusIcon;
+      if (args.clearAt !== undefined) body.clearAt = String(args.clearAt);
+
+      await fetchOCS('/ocs/v2.php/apps/user_status/api/v1/user_status/message/custom', {
+        method: 'PUT',
+        body,
+      });
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Status message set: ${args.statusIcon ?? ''} ${args.message}`.trim(),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error setting status message: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// clear_user_status_message
+// ---------------------------------------------------------------------------
+
+export const clearUserStatusMessageTool = {
+  name: 'clear_user_status_message',
+  description: "Clear the current user's custom status message",
+  inputSchema: z.object({}),
+  handler: async () => {
+    try {
+      await fetchOCS('/ocs/v2.php/apps/user_status/api/v1/user_status/message', {
+        method: 'DELETE',
+      });
+
+      return {
+        content: [{ type: 'text' as const, text: 'Status message cleared.' }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error clearing status message: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// list_user_statuses
+// ---------------------------------------------------------------------------
+
+export const listUserStatusesTool = {
+  name: 'list_user_statuses',
+  description: "List all users' statuses for team presence visibility",
+  inputSchema: z.object({
+    limit: z.number().optional().describe('Maximum number of statuses to return'),
+    offset: z.number().optional().describe('Offset for pagination'),
+  }),
+  handler: async (args: { limit?: number; offset?: number }) => {
+    try {
+      const queryParams: Record<string, string> = {};
+      if (args.limit !== undefined) queryParams.limit = String(args.limit);
+      if (args.offset !== undefined) queryParams.offset = String(args.offset);
+
+      const result = await fetchOCS<UserStatus[]>('/ocs/v2.php/apps/user_status/api/v1/statuses', {
+        queryParams,
+      });
+
+      const statuses = result.ocs.data;
+      if (statuses.length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: 'No user statuses found.' }],
+        };
+      }
+
+      const formatted = statuses.map((s) => {
+        const icon = s.icon ?? '';
+        const msg = s.message ?? '';
+        const custom = icon || msg ? ` — ${icon} ${msg}`.trim() : '';
+        return `- ${s.userId}: ${s.status}${custom}`;
+      });
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `User statuses (${statuses.length}):\n${formatted.join('\n')}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error listing user statuses: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export const userStatusTools = [
+  getUserStatusTool,
+  setUserStatusTool,
+  setUserStatusMessageTool,
+  clearUserStatusMessageTool,
+  listUserStatusesTool,
+];

--- a/mcp-server/src/tools/apps/versions.ts
+++ b/mcp-server/src/tools/apps/versions.ts
@@ -1,0 +1,166 @@
+import { z } from 'zod';
+import { fetchCalDAV } from '../../client/caldav.js';
+import { getNextcloudConfig } from '../types.js';
+
+/**
+ * Nextcloud File Versioning Tools
+ * Manages file versions via WebDAV Versions API
+ */
+
+// ---------------------------------------------------------------------------
+// list_file_versions
+// ---------------------------------------------------------------------------
+
+export const listFileVersionsTool = {
+  name: 'list_file_versions',
+  description: 'List previous versions of a file (use get_file_info to find the fileId)',
+  inputSchema: z.object({
+    fileId: z.number().describe('The Nextcloud internal file ID (from get_file_info)'),
+  }),
+  handler: async (args: { fileId: number }) => {
+    try {
+      const config = getNextcloudConfig();
+      const url = `${config.url}/remote.php/dav/versions/${config.user}/versions/${args.fileId}`;
+
+      const body = `<?xml version="1.0"?>
+<d:propfind xmlns:d="DAV:">
+  <d:prop>
+    <d:getlastmodified />
+    <d:getcontentlength />
+    <d:getcontenttype />
+  </d:prop>
+</d:propfind>`;
+
+      const response = await fetchCalDAV(url, {
+        method: 'PROPFIND',
+        body,
+        headers: { Depth: '1' },
+      });
+
+      const text = await response.text();
+
+      if (!response.ok && response.status !== 207) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error listing versions: ${response.status} ${response.statusText}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Parse responses — skip the first one (container)
+      const responses = text.match(/<d:response>[\s\S]*?<\/d:response>/g) || [];
+      const versions = responses.slice(1).map((r) => {
+        const href = r.match(/<d:href>([^<]*)<\/d:href>/)?.[1] ?? '';
+        const lastModified = r.match(/<d:getlastmodified>([^<]*)<\/d:getlastmodified>/)?.[1] ?? '';
+        const size = r.match(/<d:getcontentlength>([^<]*)<\/d:getcontentlength>/)?.[1] ?? '';
+
+        // Version identifier is the last segment of the href
+        const versionId = href.split('/').filter(Boolean).pop() ?? '';
+        const sizeStr = size ? ` (${Math.round(parseInt(size, 10) / 1024)} KB)` : '';
+
+        return `- Version: ${versionId}\n  Modified: ${lastModified}${sizeStr}`;
+      });
+
+      if (versions.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `No previous versions found for file ${args.fileId}.`,
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `File versions for ${args.fileId} (${versions.length}):\n${versions.join('\n')}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error listing file versions: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// restore_file_version
+// ---------------------------------------------------------------------------
+
+export const restoreFileVersionTool = {
+  name: 'restore_file_version',
+  description:
+    'Restore a previous version of a file (creates a new current version from the old one)',
+  inputSchema: z.object({
+    fileId: z.number().describe('The Nextcloud internal file ID'),
+    versionId: z.string().describe('The version identifier (from list_file_versions output)'),
+  }),
+  handler: async (args: { fileId: number; versionId: string }) => {
+    try {
+      const config = getNextcloudConfig();
+      const sourceUrl = `${config.url}/remote.php/dav/versions/${config.user}/versions/${args.fileId}/${args.versionId}`;
+      const destUrl = `${config.url}/remote.php/dav/versions/${config.user}/restore/target`;
+
+      const response = await fetchCalDAV(sourceUrl, {
+        method: 'MOVE',
+        headers: {
+          Destination: destUrl,
+          Overwrite: 'T',
+        },
+      });
+
+      if (response.status >= 200 && response.status < 300) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Restored version ${args.versionId} of file ${args.fileId}.`,
+            },
+          ],
+        };
+      }
+
+      const text = await response.text();
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error restoring version: ${response.status} ${response.statusText}\n${text}`,
+          },
+        ],
+        isError: true,
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error restoring version: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export const versionsTools = [listFileVersionsTool, restoreFileVersionTool];

--- a/mcp-server/src/tools/system/files.ts
+++ b/mcp-server/src/tools/system/files.ts
@@ -417,6 +417,75 @@ export const copyFileTool = {
 };
 
 /**
+ * Perform multiple file operations (move, copy, delete) in a single call
+ */
+export const bulkFileOperationsTool = {
+  name: 'bulk_file_operations',
+  description:
+    'Execute multiple file operations (move, copy, delete) sequentially in a single call. Returns per-item results.',
+  inputSchema: z.object({
+    operations: z
+      .array(
+        z.object({
+          action: z.enum(['move', 'copy', 'delete']).describe('The operation to perform'),
+          source: z.string().describe('Source file/folder path'),
+          destination: z.string().optional().describe('Destination path (required for move/copy)'),
+        })
+      )
+      .min(1)
+      .max(100)
+      .describe('Array of file operations to execute sequentially'),
+  }),
+  handler: async (args: {
+    operations: Array<{ action: 'move' | 'copy' | 'delete'; source: string; destination?: string }>;
+  }) => {
+    const client = getWebDAVClient();
+    const results: string[] = [];
+    let succeeded = 0;
+
+    for (const op of args.operations) {
+      try {
+        if ((op.action === 'move' || op.action === 'copy') && !op.destination) {
+          results.push(`✗ ${op.action} ${op.source} — missing destination`);
+          continue;
+        }
+
+        switch (op.action) {
+          case 'move':
+            await client.moveFile(op.source, op.destination!);
+            results.push(`✓ move ${op.source} → ${op.destination}`);
+            succeeded++;
+            break;
+          case 'copy':
+            await client.copyFile(op.source, op.destination!);
+            results.push(`✓ copy ${op.source} → ${op.destination}`);
+            succeeded++;
+            break;
+          case 'delete':
+            await client.deleteFile(op.source);
+            results.push(`✓ delete ${op.source}`);
+            succeeded++;
+            break;
+        }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        results.push(`✗ ${op.action} ${op.source} — ${msg}`);
+      }
+    }
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: `Bulk operations: ${succeeded}/${args.operations.length} succeeded\n${results.join('\n')}`,
+        },
+      ],
+      ...(succeeded < args.operations.length ? { isError: true } : {}),
+    };
+  },
+};
+
+/**
  * Export all file system tools
  */
 export const fileSystemTools = [
@@ -431,4 +500,5 @@ export const fileSystemTools = [
   searchFilesTool,
   getFileContentTool,
   analyzeImageTool,
+  bulkFileOperationsTool,
 ];


### PR DESCRIPTION
## Summary

Adds 24 new MCP tools and enhances 2 existing ones, covering 11 milestone issues:

- **User status** (#208, #213): get/set/clear status & custom message, list all user statuses
- **Out-of-office** (#212): get/set/clear absence with replacement user support
- **Share enhancements** (#209, #211, #214): `get_share`, `list_shares_with_me`, `search_sharees`, pending remote shares (list/accept/decline), `note` & `hideDownload` params on create/update
- **Notifications** (#155): list, get, mark read, delete all
- **Trash/recycle bin** (#154): list trash, restore, empty (WebDAV trashbin API)
- **File versioning** (#153): list versions, restore version (WebDAV versions API)
- **Bulk file operations** (#113): move/copy/delete multiple files in one call

Also extends `fetchOCS` queryParams to support `string[]` values for array query parameters (needed by `search_sharees`).

Closes #208, #213, #212, #209, #211, #214, #155, #154, #153, #113

## Test plan

- [x] `npm run build` — compiles clean
- [x] `npm test` — 452 tests pass (34 new)
- [x] `npm run lint` — 0 errors (80 pre-existing warnings)
- [x] `npx prettier --check src/` — all clean
- [ ] E2E: verify tools against running Nextcloud instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)