### PR TITLE
fix(nextcloud): unique declarative settings field IDs

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "AIquila - MCP server for Nextcloud integration with Claude AI",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,13 +18,13 @@
       ]
     }
   ],
-  "version": "0.2.15",
+  "version": "0.2.16",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.2.15</version>
+    <version>0.2.16</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/lib/Controller/SettingsController.php
+++ b/nextcloud-app/lib/Controller/SettingsController.php
@@ -46,7 +46,7 @@ class SettingsController extends Controller {
     #[OpenAPI]
     public function get(): JSONResponse {
         $hasUserKey = $this->credentials->hasApiKey($this->userId);
-        $userModel  = $this->config->getUserValue($this->userId, $this->appName, 'model', '');
+        $userModel  = $this->config->getUserValue($this->userId, $this->appName, 'user_model', '');
 
         $liveModels      = $this->claudeService->listModels($this->userId);
         $availableModels = $liveModels ?? ClaudeModels::getAllModels();
@@ -92,9 +92,9 @@ class SettingsController extends Controller {
         }
 
         if ($model !== '') {
-            $this->config->setUserValue($this->userId, $this->appName, 'model', $model);
+            $this->config->setUserValue($this->userId, $this->appName, 'user_model', $model);
         } else {
-            $this->config->deleteUserValue($this->userId, $this->appName, 'model');
+            $this->config->deleteUserValue($this->userId, $this->appName, 'user_model');
         }
 
         if ($default_system_prompt !== null) {

--- a/nextcloud-app/lib/Service/ClaudeSDKService.php
+++ b/nextcloud-app/lib/Service/ClaudeSDKService.php
@@ -64,7 +64,7 @@ class ClaudeSDKService {
      */
     public function getModel(?string $userId = null): string {
         if ($userId) {
-            $userModel = $this->config->getUserValue($userId, $this->appName, 'model', '');
+            $userModel = $this->config->getUserValue($userId, $this->appName, 'user_model', '');
             if ($userModel) return $userModel;
         }
         return $this->config->getAppValue($this->appName, 'model', ClaudeModels::DEFAULT_MODEL);

--- a/nextcloud-app/lib/Settings/UserDeclarativeSettings.php
+++ b/nextcloud-app/lib/Settings/UserDeclarativeSettings.php
@@ -26,7 +26,7 @@ class UserDeclarativeSettings implements IDeclarativeSettingsForm {
 			'description' => 'Override the default Claude model for your requests.',
 			'fields' => [
 				[
-					'id' => 'model',
+					'id' => 'user_model',
 					'title' => 'Preferred Model',
 					'description' => 'Leave on "(admin default)" to use the instance-wide model.',
 					'type' => DeclarativeSettingsTypes::SELECT,

--- a/nextcloud-app/tests/Unit/ClaudeServiceTest.php
+++ b/nextcloud-app/tests/Unit/ClaudeServiceTest.php
@@ -218,7 +218,7 @@ class ClaudeServiceTest extends TestCase {
 
     public function testGetModelReturnsUserPreferenceOverAdminModel(): void {
         $this->config->method('getUserValue')
-            ->willReturnMap([['testuser', 'aiquila', 'model', '', 'claude-haiku-4-5-20251001']]);
+            ->willReturnMap([['testuser', 'aiquila', 'user_model', '', 'claude-haiku-4-5-20251001']]);
 
         $this->assertEquals('claude-haiku-4-5-20251001', $this->service->getModel('testuser'));
     }

--- a/nextcloud-app/tests/Unit/Settings/UserDeclarativeSettingsTest.php
+++ b/nextcloud-app/tests/Unit/Settings/UserDeclarativeSettingsTest.php
@@ -27,7 +27,7 @@ class UserDeclarativeSettingsTest extends TestCase {
 
 	public function testModelField(): void {
 		$fields = $this->settings->getSchema()['fields'];
-		$model = $this->findField($fields, 'model');
+		$model = $this->findField($fields, 'user_model');
 
 		$this->assertNotNull($model, 'model field should exist');
 		$this->assertSame(DeclarativeSettingsTypes::SELECT, $model['type']);

--- a/nextcloud-app/tests/Unit/SettingsControllerTest.php
+++ b/nextcloud-app/tests/Unit/SettingsControllerTest.php
@@ -47,7 +47,7 @@ class SettingsControllerTest extends TestCase {
         $this->credentials->method('hasApiKey')->with('testuser')->willReturn(true);
         $this->config->method('getUserValue')
             ->willReturnMap([
-                ['testuser', 'aiquila', 'model', '', ''],
+                ['testuser', 'aiquila', 'user_model', '', ''],
                 ['testuser', 'aiquila', 'default_system_prompt', '', ''],
                 ['testuser', 'aiquila', 'default_verbose', '0', '0'],
             ]);
@@ -63,7 +63,7 @@ class SettingsControllerTest extends TestCase {
         $this->credentials->method('hasApiKey')->willReturn(false);
         $this->config->method('getUserValue')
             ->willReturnMap([
-                ['testuser', 'aiquila', 'model', '', ClaudeModels::HAIKU_4_5],
+                ['testuser', 'aiquila', 'user_model', '', ClaudeModels::HAIKU_4_5],
                 ['testuser', 'aiquila', 'default_system_prompt', '', ''],
                 ['testuser', 'aiquila', 'default_verbose', '0', '0'],
             ]);
@@ -105,7 +105,7 @@ class SettingsControllerTest extends TestCase {
 
         $this->config->expects($this->once())
             ->method('setUserValue')
-            ->with('testuser', 'aiquila', 'model', ClaudeModels::OPUS_4_6);
+            ->with('testuser', 'aiquila', 'user_model', ClaudeModels::OPUS_4_6);
 
         $response = $this->ctrl->save('my-api-key', ClaudeModels::OPUS_4_6);
 
@@ -120,7 +120,7 @@ class SettingsControllerTest extends TestCase {
 
         $this->config->expects($this->once())
             ->method('deleteUserValue')
-            ->with('testuser', 'aiquila', 'model');
+            ->with('testuser', 'aiquila', 'user_model');
 
         $response = $this->ctrl->save('some-key', '');
         $this->assertEquals('ok', $response->getData()['status']);


### PR DESCRIPTION
## Summary
- Fixes HTTP 500 on `/settings/admin/overview` caused by `AdminDeclarativeSettings` and `UserDeclarativeSettings` both using field ID `model`
- Nextcloud's `DeclarativeManager` requires field IDs to be unique across all schemas within an app
- Renames user-level field from `model` to `user_model` and updates all config reads/writes

## Test plan
- [ ] Navigate to `/settings/admin/overview` — should load without 500
- [ ] Navigate to AIquila admin settings — model/tokens/timeout render and save correctly
- [ ] Navigate to AIquila personal settings — model preference renders and saves correctly
- [ ] Verify user model preference persists across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)