### PR TITLE
infra(mcp): tag Docker image as stable after successful publish

### DIFF
--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -287,3 +287,26 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  tag-stable:
+    name: Tag Docker Image as Stable
+    needs: [check-version, npm-publish, mcp-registry-publish, docker-publish]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag image as stable
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/aiquila-mcp
+          VERSION: ${{ needs.check-version.outputs.version }}
+        run: |
+          docker buildx imagetools create \
+            --tag "${IMAGE}:stable" \
+            "${IMAGE}:${VERSION}"


### PR DESCRIPTION
## Summary
- Adds a `tag-stable` job to the MCP release pipeline that tags the Docker image with `:stable` after npm, MCP registry, and Docker publish all succeed
- Uses `docker buildx imagetools create` to retag without pulling/pushing (works for multi-platform images)

Closes #221

## Test plan
- [ ] Verify workflow YAML is valid
- [ ] Trigger a release and confirm `:stable` tag appears on `ghcr.io/elgorro/aiquila-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)