### PR TITLE
feat(infra): migrate DNS from legacy API to hcloud-go Zone API (#265)

### DIFF
--- a/.github/workflows/hetzner-integration-test.yml
+++ b/.github/workflows/hetzner-integration-test.yml
@@ -50,7 +50,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
-      HETZNER_DNS_TOKEN: ${{ secrets.HETZNER_DNS_TOKEN }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       NC_DOMAIN: ${{ inputs.nc_domain }}
       MCP_DOMAIN: ${{ inputs.mcp_domain }}

--- a/docs/dev/ci-cd.md
+++ b/docs/dev/ci-cd.md
@@ -156,7 +156,7 @@ git push origin main
 2. Runs 6 test groups: `oauth`, `tools`, `mcp_protocol`, `nc_app`, `connector` (off by default), `infra`
 3. Always destroys servers on completion (orphan cleanup ensures no leaked resources)
 
-**Required secrets:** `HCLOUD_TOKEN`, `HETZNER_DNS_TOKEN`, `ANTHROPIC_API_KEY`
+**Required secrets:** `HCLOUD_TOKEN`, `ANTHROPIC_API_KEY`
 
 See [`docs/hetzner/ci-flow.md`](../hetzner/ci-flow.md) for the detailed timeline and cost breakdown.
 
@@ -207,11 +207,9 @@ Navigate to: **Repository Settings → Secrets and variables → Actions → New
 
 #### For Hetzner Integration Test (Required for E2E tests)
 
-5. **`HCLOUD_TOKEN`** — Hetzner Cloud API token (used to provision/destroy test servers)
+5. **`HCLOUD_TOKEN`** — Hetzner Cloud API token (used to provision/destroy test servers and DNS)
 
-6. **`HETZNER_DNS_TOKEN`** — Hetzner DNS API token (used for DNS records during provisioning)
-
-7. **`ANTHROPIC_API_KEY`** — Anthropic API key (used by the connector test group)
+6. **`ANTHROPIC_API_KEY`** — Anthropic API key (used by the connector test group)
 
 ### Setup Manual Approval Gate
 

--- a/docs/hetzner/README.md
+++ b/docs/hetzner/README.md
@@ -37,8 +37,7 @@ Three deployment configurations are supported via `--stack`:
 
 ## Prerequisites
 
-- Hetzner Cloud account + API token (`$HCLOUD_TOKEN`)
-- (Optional) Hetzner DNS token (`$HETZNER_DNS_TOKEN`) for DNS automation
+- Hetzner Cloud account + API token (`$HCLOUD_TOKEN`) — also used for DNS automation
 - For `--stack mcp`: existing Nextcloud instance with an app password
 - For `--stack nextcloud` / `full`: domain name for the Nextcloud server
 - Domain that points to (or will be pointed to) the server IP

--- a/docs/hetzner/advanced.md
+++ b/docs/hetzner/advanced.md
@@ -106,8 +106,8 @@ aiquila-hetzner create --mcp-domain mcp.example.com \
   --dns-zone example.com
 ```
 
-Requires `$HETZNER_DNS_TOKEN` or `--dns-token`. The record name is derived from
-the first label of `--mcp-domain` (e.g. `mcp` from `mcp.example.com`).
+Uses the same Cloud API token (`$HCLOUD_TOKEN`). The record name is derived from
+the server `--name` flag (e.g. `mcp` → `mcp.example.com`).
 
 ---
 

--- a/docs/hetzner/ci-flow.md
+++ b/docs/hetzner/ci-flow.md
@@ -52,8 +52,7 @@ a named reviewer before secrets are exposed.
 
 | Secret | Used for |
 |--------|----------|
-| `HCLOUD_TOKEN` | Server provisioning and destroy |
-| `HETZNER_DNS_TOKEN` | DNS A/AAAA record creation |
+| `HCLOUD_TOKEN` | Server provisioning, DNS, and destroy |
 | `ANTHROPIC_API_KEY` | Drives the Claude agent; also used by the connector test if enabled |
 
 ---

--- a/docs/hetzner/commands.md
+++ b/docs/hetzner/commands.md
@@ -74,7 +74,6 @@ Run `aiquila-hetzner options` to list all server types, locations, and images av
 | Flag | Description |
 |------|-------------|
 | `--dns-zone` | Hetzner DNS zone (e.g. `example.com`); creates `<name>.<zone>` A record |
-| `--dns-token` | Hetzner DNS token (default: `$HETZNER_DNS_TOKEN` or `$HCLOUD_TOKEN`) |
 | `--ssh-allow-cidr` | Restrict SSH to this CIDR (e.g. `203.0.113.0/24`) instead of `0.0.0.0/0` |
 | `--network` | Attach server to an existing private network |
 
@@ -113,7 +112,6 @@ Both commands are equivalent.
 | `--name` | Server name (required) |
 | `--token` | Hetzner API token |
 | `--dns-zone` | Delete `<name>.<zone>` A/AAAA records after destroy |
-| `--dns-token` | Hetzner DNS token |
 
 ---
 
@@ -213,7 +211,7 @@ Output is three tables: **Server types** (name, cores, RAM, disk, arch),
 
 ## `dns`
 
-Manage Hetzner DNS records (requires `$HETZNER_DNS_TOKEN`).
+Manage Hetzner DNS records via the Cloud Zone API (uses `$HCLOUD_TOKEN`).
 
 ```bash
 # Create A (and optionally AAAA) records
@@ -231,7 +229,7 @@ aiquila-hetzner dns delete --name mcp --zone example.com
 | `--zone` | DNS zone / apex domain (required) |
 | `--ip` | IPv4 address for the A record (required for `create`) |
 | `--ipv6` | IPv6 address for the AAAA record |
-| `--dns-token` | Hetzner DNS token (default: `$HETZNER_DNS_TOKEN` or `$HCLOUD_TOKEN`) |
+| `--token` | Hetzner API token (default: `$HCLOUD_TOKEN` or profile) |
 
 ---
 

--- a/docs/hetzner/configuration.md
+++ b/docs/hetzner/configuration.md
@@ -79,7 +79,6 @@ aiquila-hetzner rebuild --config hetzner/examples/deploy-mcp.yaml
 | `network` | string | `--network` | Attach to an existing private network |
 | `labels` | []string | `--label` | Resource labels `key=value` (repeatable) |
 | `dns_zone` | string | `--dns-zone` | Hetzner DNS zone for auto-record creation |
-| `dns_token` | string | `--dns-token` | Hetzner DNS API token |
 | `ssh_allow_cidr` | string | `--ssh-allow-cidr` | Restrict SSH to this CIDR |
 | `packages` | []string | `--package` | Extra OS packages via cloud-init (repeatable) |
 
@@ -143,8 +142,7 @@ directly.
 
 | Variable | Used by | Notes |
 |----------|---------|-------|
-| `HCLOUD_TOKEN` | All commands | Hetzner Cloud API token |
-| `HETZNER_DNS_TOKEN` | `dns`, `create --dns-zone`, `destroy --dns-zone` | Defaults to `HCLOUD_TOKEN` if unset |
+| `HCLOUD_TOKEN` | All commands (incl. DNS) | Hetzner Cloud API token |
 | `NEXTCLOUD_URL` | `create`, `rebuild` (MCP/full stacks) | Falls back to active profile |
 | `NEXTCLOUD_USER` | `create`, `rebuild` (MCP/full stacks) | Falls back to active profile |
 | `NEXTCLOUD_PASSWORD` | `create`, `rebuild` (MCP/full stacks) | Falls back to active profile |

--- a/docs/hetzner/integration-test.md
+++ b/docs/hetzner/integration-test.md
@@ -116,8 +116,7 @@ Actions → Hetzner Integration Test → Run workflow
 
 | Secret | Description |
 |--------|-------------|
-| `HCLOUD_TOKEN` | Hetzner Cloud API token |
-| `HETZNER_DNS_TOKEN` | Hetzner DNS token (A record creation/deletion) |
+| `HCLOUD_TOKEN` | Hetzner Cloud API token (also used for DNS) |
 | `ANTHROPIC_API_KEY` | Drives the Claude agent; also used by the connector test if enabled |
 
 ---
@@ -126,7 +125,6 @@ Actions → Hetzner Integration Test → Run workflow
 
 ```bash
 export HCLOUD_TOKEN=...
-export HETZNER_DNS_TOKEN=...
 export ANTHROPIC_API_KEY=...
 export NC_DOMAIN=nc-inttest.example.com
 export MCP_DOMAIN=mcp-inttest.example.com

--- a/hetzner/cmd/aiquila-hetzner/dns.go
+++ b/hetzner/cmd/aiquila-hetzner/dns.go
@@ -6,21 +6,22 @@ import (
 	"net"
 
 	"github.com/elgorro/aiquila/hetzner/internal/dns"
+	hcloudclient "github.com/elgorro/aiquila/hetzner/internal/hcloud"
 	"github.com/spf13/cobra"
 )
 
 var (
 	// dns create flags
-	dnsCreateName     string
-	dnsCreateZone     string
-	dnsCreateIP       string
-	dnsCreateIPv6     string
-	dnsCreateDNSToken string
+	dnsCreateName  string
+	dnsCreateZone  string
+	dnsCreateIP    string
+	dnsCreateIPv6  string
+	dnsCreateToken string
 
 	// dns delete flags
-	dnsDeleteName     string
-	dnsDeleteZone     string
-	dnsDeleteDNSToken string
+	dnsDeleteName  string
+	dnsDeleteZone  string
+	dnsDeleteToken string
 )
 
 // buildDNSCmd returns the 'dns' parent command with create/delete subcommands.
@@ -28,13 +29,9 @@ func buildDNSCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dns",
 		Short: "Manage Hetzner DNS records for an AIquila deployment",
-		Long: `Manage DNS records via the Hetzner DNS API (dns.hetzner.com).
+		Long: `Manage DNS records via the Hetzner Cloud Zone API.
 
-Token resolution order (first non-empty wins):
-  1. --dns-token flag
-  2. $HETZNER_DNS_TOKEN
-  3. $HCLOUD_TOKEN
-  4. dns_token field in the active profile`,
+Uses the same API token as all other commands (--token / $HCLOUD_TOKEN / profile).`,
 	}
 	cmd.AddCommand(buildDNSCreateCmd())
 	cmd.AddCommand(buildDNSDeleteCmd())
@@ -61,7 +58,7 @@ Examples:
 	cmd.Flags().StringVar(&dnsCreateZone, "zone", "", "DNS zone / apex domain (e.g. example.com) (required)")
 	cmd.Flags().StringVar(&dnsCreateIP, "ip", "", "IPv4 address for the A record (required)")
 	cmd.Flags().StringVar(&dnsCreateIPv6, "ipv6", "", "IPv6 address for the AAAA record (optional)")
-	cmd.Flags().StringVar(&dnsCreateDNSToken, "dns-token", "", "Hetzner DNS API token (default: $HETZNER_DNS_TOKEN or $HCLOUD_TOKEN)")
+	cmd.Flags().StringVar(&dnsCreateToken, "token", "", "Hetzner API token (default: $HCLOUD_TOKEN or profile)")
 	_ = cmd.MarkFlagRequired("name")
 	_ = cmd.MarkFlagRequired("zone")
 	_ = cmd.MarkFlagRequired("ip")
@@ -76,7 +73,7 @@ func runDNSCreate(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("--ipv6 %q is not a valid IP address", dnsCreateIPv6)
 	}
 
-	token, err := dns.ResolveToken(dnsCreateDNSToken, globalProfile)
+	client, err := hcloudclient.NewClient(dnsCreateToken, globalProfile)
 	if err != nil {
 		return err
 	}
@@ -84,12 +81,12 @@ func runDNSCreate(_ *cobra.Command, _ []string) error {
 	ctx := context.Background()
 	fmt.Printf("==> Creating DNS records for %s.%s\n", dnsCreateName, dnsCreateZone)
 
-	if err := dns.EnsureRecord(ctx, token, dnsCreateZone, dnsCreateName, dnsCreateIP, "A"); err != nil {
+	if err := dns.EnsureRecord(ctx, client, dnsCreateZone, dnsCreateName, dnsCreateIP, "A"); err != nil {
 		return err
 	}
 
 	if dnsCreateIPv6 != "" {
-		if err := dns.EnsureRecord(ctx, token, dnsCreateZone, dnsCreateName, dnsCreateIPv6, "AAAA"); err != nil {
+		if err := dns.EnsureRecord(ctx, client, dnsCreateZone, dnsCreateName, dnsCreateIPv6, "AAAA"); err != nil {
 			return err
 		}
 	}
@@ -112,14 +109,14 @@ Example:
 	}
 	cmd.Flags().StringVar(&dnsDeleteName, "name", "", "DNS record name / subdomain (required)")
 	cmd.Flags().StringVar(&dnsDeleteZone, "zone", "", "DNS zone / apex domain (required)")
-	cmd.Flags().StringVar(&dnsDeleteDNSToken, "dns-token", "", "Hetzner DNS API token (default: $HETZNER_DNS_TOKEN or $HCLOUD_TOKEN)")
+	cmd.Flags().StringVar(&dnsDeleteToken, "token", "", "Hetzner API token (default: $HCLOUD_TOKEN or profile)")
 	_ = cmd.MarkFlagRequired("name")
 	_ = cmd.MarkFlagRequired("zone")
 	return cmd
 }
 
 func runDNSDelete(_ *cobra.Command, _ []string) error {
-	token, err := dns.ResolveToken(dnsDeleteDNSToken, globalProfile)
+	client, err := hcloudclient.NewClient(dnsDeleteToken, globalProfile)
 	if err != nil {
 		return err
 	}
@@ -127,7 +124,7 @@ func runDNSDelete(_ *cobra.Command, _ []string) error {
 	ctx := context.Background()
 	fmt.Printf("==> Deleting DNS records for %s.%s\n", dnsDeleteName, dnsDeleteZone)
 
-	if err := dns.DeleteRecords(ctx, token, dnsDeleteZone, dnsDeleteName); err != nil {
+	if err := dns.DeleteRecords(ctx, client, dnsDeleteZone, dnsDeleteName); err != nil {
 		return err
 	}
 

--- a/hetzner/cmd/aiquila-hetzner/main.go
+++ b/hetzner/cmd/aiquila-hetzner/main.go
@@ -59,8 +59,7 @@ var (
 	createDryRun     bool
 	createNoConfirm  bool
 	createLabels        []string
-	createDNSZone       string
-	createDNSToken      string
+	createDNSZone string
 	createSSHAllowCIDR  string
 	createNetworkName   string
 	createSwap          string
@@ -70,8 +69,7 @@ var (
 	// destroy flags
 	destroyName     string
 	destroyToken    string
-	destroyDNSZone  string
-	destroyDNSToken string
+	destroyDNSZone string
 )
 
 func main() {
@@ -161,7 +159,6 @@ func buildCreateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&createDryRun, "dry-run", false, "Print what would be created without making any API calls")
 	cmd.Flags().StringArrayVar(&createLabels, "label", nil, "Resource label key=value (repeatable, applied to server/firewall/key/volume)")
 	cmd.Flags().StringVar(&createDNSZone, "dns-zone", "", "Hetzner DNS zone (e.g. example.com) — creates <name>.<zone> A record after server IP is known")
-	cmd.Flags().StringVar(&createDNSToken, "dns-token", "", "Hetzner DNS API token (default: $HETZNER_DNS_TOKEN or $HCLOUD_TOKEN)")
 	cmd.Flags().StringVar(&createSSHAllowCIDR, "ssh-allow-cidr", "", "Restrict SSH (port 22) to this CIDR instead of 0.0.0.0/0 (e.g. 203.0.113.0/24)")
 	cmd.Flags().StringVar(&createNetworkName, "network", "", "Attach server to this private network (must exist; create with 'network create')")
 	cmd.Flags().StringVar(&createSwap, "swap", "", "Create a swap file of this size (e.g. 1G, 2G) — useful for cpx11/cx22 instances")
@@ -277,9 +274,6 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 	}
 	if createDNSZone == "" && fileCfg.DNSZone != "" {
 		createDNSZone = fileCfg.DNSZone
-	}
-	if createDNSToken == "" && fileCfg.DNSToken != "" {
-		createDNSToken = fileCfg.DNSToken
 	}
 	if createSSHAllowCIDR == "" && fileCfg.SSHAllowCIDR != "" {
 		createSSHAllowCIDR = fileCfg.SSHAllowCIDR
@@ -451,11 +445,7 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 		// ── 10. DNS record (before Traefik starts requesting certs) ───────────
 		if createDNSZone != "" {
 			fmt.Println("\n── DNS")
-			dnsToken, err := dns.ResolveToken(createDNSToken, globalProfile)
-			if err != nil {
-				return err
-			}
-			if err := dns.EnsureRecord(ctx, dnsToken, createDNSZone, createName, serverIP, "A"); err != nil {
+			if err := dns.EnsureRecord(ctx, client, createDNSZone, createName, serverIP, "A"); err != nil {
 				return err
 			}
 			ipv6 := srv.PublicNet.IPv6.IP
@@ -463,7 +453,7 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 				// Use the first host address of the /64 prefix (/64 → ::1 suffix).
 				ipv6Host := ipv6.Mask(srv.PublicNet.IPv6.Network.Mask)
 				ipv6Host[len(ipv6Host)-1] = 1
-				if err := dns.EnsureRecord(ctx, dnsToken, createDNSZone, createName, ipv6Host.String(), "AAAA"); err != nil {
+				if err := dns.EnsureRecord(ctx, client, createDNSZone, createName, ipv6Host.String(), "AAAA"); err != nil {
 					return err
 				}
 			}
@@ -587,11 +577,11 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 		printPartialSummary(provisionedSrv, privKeyPath)
 		if createNoConfirm {
 			fmt.Println("\n  --noconfirm set — deleting partial deployment…")
-			_ = cleanupServer(ctx, client, createName, createDNSZone, createDNSToken)
+			_ = cleanupServer(ctx, client, createName, createDNSZone)
 		} else {
 			if !askKeepOrDelete() {
 				fmt.Println("\n── Deleting partial deployment")
-				_ = cleanupServer(ctx, client, createName, createDNSZone, createDNSToken)
+				_ = cleanupServer(ctx, client, createName, createDNSZone)
 			} else {
 				fmt.Printf("\n  Keeping server.  To delete later:\n"+
 					"    aiquila-hetzner delete --name %s\n", createName)
@@ -1133,7 +1123,6 @@ func buildDestroyCmd() *cobra.Command {
 	cmd.Flags().StringVar(&destroyName, "name", "", "Server name to destroy (required)")
 	cmd.Flags().StringVar(&destroyToken, "token", "", "Hetzner API token (default: $HCLOUD_TOKEN)")
 	cmd.Flags().StringVar(&destroyDNSZone, "dns-zone", "", "Hetzner DNS zone — deletes <name>.<zone> A/AAAA records")
-	cmd.Flags().StringVar(&destroyDNSToken, "dns-token", "", "Hetzner DNS API token (default: $HETZNER_DNS_TOKEN or $HCLOUD_TOKEN)")
 	_ = cmd.MarkFlagRequired("name")
 
 	return cmd
@@ -1147,7 +1136,7 @@ func runDestroy(_ *cobra.Command, _ []string) error {
 	}
 	appLog.Info("start", "destroying server", "name", destroyName)
 	fmt.Printf("==> Destroying %q and associated resources\n", destroyName)
-	return cleanupServer(ctx, client, destroyName, destroyDNSZone, destroyDNSToken)
+	return cleanupServer(ctx, client, destroyName, destroyDNSZone)
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────

--- a/hetzner/cmd/aiquila-hetzner/manage.go
+++ b/hetzner/cmd/aiquila-hetzner/manage.go
@@ -34,8 +34,7 @@ var (
 	// delete flags
 	deleteName     string
 	deleteToken    string
-	deleteDNSZone  string
-	deleteDNSToken string
+	deleteDNSZone string
 )
 
 // ── list ──────────────────────────────────────────────────────────────────────
@@ -272,7 +271,6 @@ and the Cloud Volume (<name>-vol) if present. Equivalent to 'destroy'.`,
 	cmd.Flags().StringVar(&deleteName, "name", "", "Server name to delete (required)")
 	cmd.Flags().StringVar(&deleteToken, "token", "", "Hetzner API token (default: $HCLOUD_TOKEN)")
 	cmd.Flags().StringVar(&deleteDNSZone, "dns-zone", "", "Hetzner DNS zone — deletes <name>.<zone> A/AAAA records")
-	cmd.Flags().StringVar(&deleteDNSToken, "dns-token", "", "Hetzner DNS API token (default: $HETZNER_DNS_TOKEN or $HCLOUD_TOKEN)")
 	_ = cmd.MarkFlagRequired("name")
 	return cmd
 }
@@ -285,7 +283,7 @@ func runDelete(_ *cobra.Command, _ []string) error {
 	}
 	appLog.Info("start", "deleting server", "name", deleteName)
 	fmt.Printf("==> Deleting %q and associated resources\n", deleteName)
-	return cleanupServer(ctx, client, deleteName, deleteDNSZone, deleteDNSToken)
+	return cleanupServer(ctx, client, deleteName, deleteDNSZone)
 }
 
 // cleanupServer deletes the server plus all resources created by 'create':
@@ -293,15 +291,11 @@ func runDelete(_ *cobra.Command, _ []string) error {
 // Resources are deleted in the safest order: server first (auto-detaches the
 // volume), then firewall, SSH key, and finally the volume.
 // If dnsZone is non-empty, DNS A/AAAA records for <name>.<dnsZone> are deleted first.
-func cleanupServer(ctx context.Context, client *hcloud.Client, name, dnsZone, dnsToken string) error {
+func cleanupServer(ctx context.Context, client *hcloud.Client, name, dnsZone string) error {
 	// 0. DNS records (before server deletion so zone lookup doesn't depend on server)
 	if dnsZone != "" {
 		fmt.Println("── DNS")
-		tok, err := dns.ResolveToken(dnsToken, globalProfile)
-		if err != nil {
-			return err
-		}
-		if err := dns.DeleteRecords(ctx, tok, dnsZone, name); err != nil {
+		if err := dns.DeleteRecords(ctx, client, dnsZone, name); err != nil {
 			return err
 		}
 	}

--- a/hetzner/cmd/aiquila-hetzner/profile.go
+++ b/hetzner/cmd/aiquila-hetzner/profile.go
@@ -13,8 +13,7 @@ import (
 var (
 	profileAddName     string
 	profileAddToken    string
-	profileAddDNSToken string
-	profileAddNCURL    string
+	profileAddNCURL string
 	profileAddNCUser   string
 	profileAddNCPass   string
 	profileAddEmail    string
@@ -55,8 +54,7 @@ func buildProfileAddCmd() *cobra.Command {
 		RunE:  runProfileAdd,
 	}
 	cmd.Flags().StringVar(&profileAddName, "name", "", "Profile name (required)")
-	cmd.Flags().StringVar(&profileAddToken, "token", "", "Hetzner Cloud API token for this profile")
-	cmd.Flags().StringVar(&profileAddDNSToken, "dns-token", "", "Hetzner DNS API token (if different from --token)")
+	cmd.Flags().StringVar(&profileAddToken, "token", "", "Hetzner Cloud API token (covers Cloud + DNS)")
 	cmd.Flags().StringVar(&profileAddNCURL, "nc-url", "", "Nextcloud URL")
 	cmd.Flags().StringVar(&profileAddNCUser, "nc-user", "", "Nextcloud username")
 	cmd.Flags().StringVar(&profileAddNCPass, "nc-password", "", "Nextcloud app password")
@@ -79,9 +77,6 @@ func runProfileAdd(_ *cobra.Command, _ []string) error {
 	// Merge: only overwrite fields that were explicitly set.
 	if profileAddToken != "" {
 		existing.Token = profileAddToken
-	}
-	if profileAddDNSToken != "" {
-		existing.DNSToken = profileAddDNSToken
 	}
 	if profileAddNCURL != "" {
 		existing.NextcloudURL = profileAddNCURL
@@ -191,7 +186,6 @@ func runProfileShow(_ *cobra.Command, _ []string) error {
 	}
 	fmt.Printf("Profile: %s%s\n\n", name, current)
 	fmt.Printf("  token:              %s\n", profilepkg.MaskSecret(p.Token))
-	fmt.Printf("  dns_token:          %s\n", profilepkg.MaskSecret(p.DNSToken))
 	fmt.Printf("  nextcloud_url:      %s\n", orNotSet(p.NextcloudURL))
 	fmt.Printf("  nextcloud_user:     %s\n", orNotSet(p.NextcloudUser))
 	fmt.Printf("  nextcloud_password: %s\n", profilepkg.MaskSecret(p.NextcloudPassword))

--- a/hetzner/cmd/aiquila-hetzner/rebuild.go
+++ b/hetzner/cmd/aiquila-hetzner/rebuild.go
@@ -44,7 +44,7 @@ type DeployConfig struct {
 	Labels     []string `yaml:"labels"    json:"labels"`
 	// DNS
 	DNSZone  string `yaml:"dns_zone"  json:"dns_zone"`
-	DNSToken string `yaml:"dns_token" json:"dns_token"`
+	DNSToken string `yaml:"dns_token" json:"dns_token"` // deprecated: DNS uses the Cloud API token
 	// SSH
 	SSHAllowCIDR string `yaml:"ssh_allow_cidr" json:"ssh_allow_cidr"`
 	// Nextcloud self-hosted (--stack nextcloud/full)

--- a/hetzner/examples/deploy-mcp.yaml
+++ b/hetzner/examples/deploy-mcp.yaml
@@ -65,13 +65,11 @@ nc_password: YOUR_NEXTCLOUD_APP_PASSWORD
 #
 # monitoring: false
 
-# ── Automatic DNS (Hetzner DNS API) ───────────────────────────────────────────
+# ── Automatic DNS (Hetzner Cloud Zone API) ────────────────────────────────────
 # When set, an A record is created / updated automatically for `domain`.
-# Falls back to the HETZNER_DNS_TOKEN environment variable when dns_token is
-# omitted but dns_zone is present.
+# Uses the same Cloud API token (--token / $HCLOUD_TOKEN).
 #
 # dns_zone:  example.com
-# dns_token: YOUR_HETZNER_DNS_TOKEN
 
 # ── Firewall: SSH access restriction ─────────────────────────────────────────
 # Restrict SSH (port 22) to a specific CIDR range.  Default: unrestricted.

--- a/hetzner/examples/deploy-nc.yaml
+++ b/hetzner/examples/deploy-nc.yaml
@@ -70,13 +70,11 @@ nc_admin_password: CHANGE_ME_STRONG_PASSWORD
 #
 # acme_email: ops@example.com
 
-# ── Automatic DNS (Hetzner DNS API) ───────────────────────────────────────────
+# ── Automatic DNS (Hetzner Cloud Zone API) ────────────────────────────────────
 # When set, an A record is created / updated automatically for `nc_domain`.
-# Falls back to the HETZNER_DNS_TOKEN environment variable when dns_token is
-# omitted but dns_zone is present.
+# Uses the same Cloud API token (--token / $HCLOUD_TOKEN).
 #
 # dns_zone:  example.com
-# dns_token: YOUR_HETZNER_DNS_TOKEN
 
 # ── Firewall: SSH access restriction ─────────────────────────────────────────
 # Restrict SSH (port 22) to a specific CIDR range.  Default: unrestricted.

--- a/hetzner/examples/deploy.yaml
+++ b/hetzner/examples/deploy.yaml
@@ -76,14 +76,11 @@ nc_admin_password: CHANGE_ME_STRONG_PASSWORD
 #
 # acme_email: ops@example.com
 
-# ── Automatic DNS (Hetzner DNS API) ───────────────────────────────────────────
+# ── Automatic DNS (Hetzner Cloud Zone API) ────────────────────────────────────
 # When set, A records are created / updated automatically for both `domain`
-# and `nc_domain`.
-# Falls back to the HETZNER_DNS_TOKEN environment variable when dns_token is
-# omitted but dns_zone is present.
+# and `nc_domain`. Uses the same Cloud API token (--token / $HCLOUD_TOKEN).
 #
 # dns_zone:  example.com
-# dns_token: YOUR_HETZNER_DNS_TOKEN
 
 # ── Firewall: SSH access restriction ─────────────────────────────────────────
 # Restrict SSH (port 22) to a specific CIDR range.  Default: unrestricted.

--- a/hetzner/internal/dns/client.go
+++ b/hetzner/internal/dns/client.go
@@ -1,272 +1,87 @@
-// Package dns provides a minimal client for the Hetzner DNS API.
-// API base: https://dns.hetzner.com/api/v1
-//
-// Token resolution order for helpers:
-//  1. flagToken argument (--dns-token)
-//  2. HETZNER_DNS_TOKEN environment variable
-//  3. HCLOUD_TOKEN environment variable (same token works for both APIs)
-//  4. dns_token field in the active profile
+// Package dns manages DNS records via the hcloud-go Zone API.
 package dns
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
-	"os"
 
-	"github.com/elgorro/aiquila/hetzner/internal/profile"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-const baseURL = "https://dns.hetzner.com/api/v1"
-
-// ── API types ─────────────────────────────────────────────────────────────────
-
-type zone struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-}
-
-type record struct {
-	ID     string `json:"id"`
-	ZoneID string `json:"zone_id"`
-	Type   string `json:"type"`
-	Name   string `json:"name"`
-	Value  string `json:"value"`
-	TTL    int    `json:"ttl"`
-}
-
-type zonesResponse struct {
-	Zones []zone `json:"zones"`
-}
-
-type recordsResponse struct {
-	Records []record `json:"records"`
-}
-
-type upsertRecordRequest struct {
-	ZoneID string `json:"zone_id"`
-	Type   string `json:"type"`
-	Name   string `json:"name"`
-	Value  string `json:"value"`
-	TTL    int    `json:"ttl"`
-}
-
-type apiError struct {
-	Message string `json:"message"`
-}
-
-// ── Public API ────────────────────────────────────────────────────────────────
+const defaultTTL = 300
 
 // EnsureRecord creates or updates an A or AAAA record.
-// zone is the apex domain (e.g. "example.com"), name is the subdomain
+// zoneName is the apex domain (e.g. "example.com"), name is the subdomain
 // (e.g. "mcp" → "mcp.example.com"), recordType is "A" or "AAAA".
 // If a matching record already exists with the same value it is a no-op.
-func EnsureRecord(ctx context.Context, token, zoneName, name, ip, recordType string) error {
-	zoneID, err := lookupZoneID(ctx, token, zoneName)
+func EnsureRecord(ctx context.Context, client *hcloud.Client, zoneName, name, ip, recordType string) error {
+	zone, _, err := client.Zone.GetByName(ctx, zoneName)
 	if err != nil {
-		return err
+		return fmt.Errorf("DNS: look up zone %q: %w", zoneName, err)
+	}
+	if zone == nil {
+		return fmt.Errorf("DNS zone %q not found — does the zone exist in your Hetzner account?", zoneName)
 	}
 
-	existing, err := findRecord(ctx, token, zoneID, name, recordType)
+	rrsetType := hcloud.ZoneRRSetType(recordType)
+
+	existing, _, err := client.Zone.GetRRSetByNameAndType(ctx, zone, name, rrsetType)
 	if err != nil {
-		return err
+		return fmt.Errorf("DNS: look up %s record %s.%s: %w", recordType, name, zoneName, err)
 	}
 
 	if existing != nil {
-		if existing.Value == ip {
+		if len(existing.Records) == 1 && existing.Records[0].Value == ip {
 			fmt.Printf("  DNS %s %s.%s → %s already up to date\n", recordType, name, zoneName, ip)
 			return nil
 		}
 		fmt.Printf("  Updating DNS %s %s.%s → %s\n", recordType, name, zoneName, ip)
-		return updateRecord(ctx, token, existing.ID, zoneID, recordType, name, ip, existing.TTL)
+		_, _, err := client.Zone.SetRRSetRecords(ctx, existing, hcloud.ZoneRRSetSetRecordsOpts{
+			Records: []hcloud.ZoneRRSetRecord{{Value: ip}},
+		})
+		if err != nil {
+			return fmt.Errorf("DNS: update %s record %s.%s: %w", recordType, name, zoneName, err)
+		}
+		return nil
 	}
 
 	fmt.Printf("  Creating DNS %s %s.%s → %s\n", recordType, name, zoneName, ip)
-	return createRecord(ctx, token, zoneID, recordType, name, ip)
+	ttl := defaultTTL
+	_, _, err = client.Zone.CreateRRSet(ctx, zone, hcloud.ZoneRRSetCreateOpts{
+		Name:    name,
+		Type:    rrsetType,
+		TTL:     &ttl,
+		Records: []hcloud.ZoneRRSetRecord{{Value: ip}},
+	})
+	if err != nil {
+		return fmt.Errorf("DNS: create %s record %s.%s: %w", recordType, name, zoneName, err)
+	}
+	return nil
 }
 
-// DeleteRecords removes A and AAAA records for name in zone.
+// DeleteRecords removes A and AAAA RRSets for name in zone.
 // Missing records are silently skipped.
-func DeleteRecords(ctx context.Context, token, zoneName, name string) error {
-	zoneID, err := lookupZoneID(ctx, token, zoneName)
+func DeleteRecords(ctx context.Context, client *hcloud.Client, zoneName, name string) error {
+	zone, _, err := client.Zone.GetByName(ctx, zoneName)
 	if err != nil {
-		return err
+		return fmt.Errorf("DNS: look up zone %q: %w", zoneName, err)
+	}
+	if zone == nil {
+		return fmt.Errorf("DNS zone %q not found — does the zone exist in your Hetzner account?", zoneName)
 	}
 
-	for _, t := range []string{"A", "AAAA"} {
-		rec, err := findRecord(ctx, token, zoneID, name, t)
+	for _, t := range []hcloud.ZoneRRSetType{hcloud.ZoneRRSetTypeA, hcloud.ZoneRRSetTypeAAAA} {
+		rrset, _, err := client.Zone.GetRRSetByNameAndType(ctx, zone, name, t)
 		if err != nil {
-			return err
+			return fmt.Errorf("DNS: look up %s record %s.%s: %w", t, name, zoneName, err)
 		}
-		if rec == nil {
+		if rrset == nil {
 			continue
 		}
-		if err := deleteRecord(ctx, token, rec.ID); err != nil {
-			return fmt.Errorf("delete DNS %s %s.%s: %w", t, name, zoneName, err)
+		if _, _, err := client.Zone.DeleteRRSet(ctx, rrset); err != nil {
+			return fmt.Errorf("DNS: delete %s %s.%s: %w", t, name, zoneName, err)
 		}
-		fmt.Printf("  Deleted DNS %s %s.%s (id=%s)\n", t, name, zoneName, rec.ID)
+		fmt.Printf("  Deleted DNS %s %s.%s\n", t, name, zoneName)
 	}
 	return nil
-}
-
-// ResolveToken resolves the DNS API token.
-// Order: flagToken → $HETZNER_DNS_TOKEN → $HCLOUD_TOKEN → profile dns_token.
-func ResolveToken(flagToken, profileName string) (string, error) {
-	if flagToken != "" {
-		return flagToken, nil
-	}
-	if t := os.Getenv("HETZNER_DNS_TOKEN"); t != "" {
-		return t, nil
-	}
-	if t := os.Getenv("HCLOUD_TOKEN"); t != "" {
-		return t, nil
-	}
-	cfg, err := profile.Load()
-	if err == nil {
-		if p, _, ok := cfg.Active(profileName); ok && p.DNSToken != "" {
-			return p.DNSToken, nil
-		}
-	}
-	return "", fmt.Errorf(
-		"no DNS API token: use --dns-token, $HETZNER_DNS_TOKEN, $HCLOUD_TOKEN, or configure a profile with 'aiquila-hetzner profile add --dns-token'",
-	)
-}
-
-// ── Internal helpers ──────────────────────────────────────────────────────────
-
-func lookupZoneID(ctx context.Context, token, zoneName string) (string, error) {
-	resp, err := doGet(ctx, token, "/zones?name="+url.QueryEscape(zoneName))
-	if err != nil {
-		return "", fmt.Errorf("DNS: look up zone %q: %w", zoneName, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("DNS: look up zone %q: HTTP %d", zoneName, resp.StatusCode)
-	}
-
-	var result zonesResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", fmt.Errorf("DNS: parse zone response: %w", err)
-	}
-	if len(result.Zones) == 0 {
-		return "", fmt.Errorf("DNS zone %q not found — does the zone exist in your Hetzner DNS account?", zoneName)
-	}
-	return result.Zones[0].ID, nil
-}
-
-func findRecord(ctx context.Context, token, zoneID, name, recordType string) (*record, error) {
-	path := fmt.Sprintf("/records?zone_id=%s", url.QueryEscape(zoneID))
-	resp, err := doGet(ctx, token, path)
-	if err != nil {
-		return nil, fmt.Errorf("DNS: list records: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("DNS: list records: HTTP %d", resp.StatusCode)
-	}
-
-	var result recordsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("DNS: parse records response: %w", err)
-	}
-	for i, r := range result.Records {
-		if r.Name == name && r.Type == recordType {
-			return &result.Records[i], nil
-		}
-	}
-	return nil, nil
-}
-
-func createRecord(ctx context.Context, token, zoneID, recordType, name, ip string) error {
-	body := upsertRecordRequest{
-		ZoneID: zoneID,
-		Type:   recordType,
-		Name:   name,
-		Value:  ip,
-		TTL:    300,
-	}
-	resp, err := doJSON(ctx, token, http.MethodPost, "/records", body)
-	if err != nil {
-		return fmt.Errorf("DNS: create %s record: %w", recordType, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-		return apiErrorFrom(resp, fmt.Sprintf("DNS: create %s record", recordType))
-	}
-	return nil
-}
-
-func updateRecord(ctx context.Context, token, id, zoneID, recordType, name, ip string, ttl int) error {
-	body := upsertRecordRequest{
-		ZoneID: zoneID,
-		Type:   recordType,
-		Name:   name,
-		Value:  ip,
-		TTL:    ttl,
-	}
-	resp, err := doJSON(ctx, token, http.MethodPut, "/records/"+id, body)
-	if err != nil {
-		return fmt.Errorf("DNS: update %s record: %w", recordType, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return apiErrorFrom(resp, fmt.Sprintf("DNS: update %s record", recordType))
-	}
-	return nil
-}
-
-func deleteRecord(ctx context.Context, token, id string) error {
-	resp, err := doRequest(ctx, token, http.MethodDelete, "/records/"+id, nil)
-	if err != nil {
-		return fmt.Errorf("DNS: delete record %s: %w", id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return apiErrorFrom(resp, "DNS: delete record")
-	}
-	return nil
-}
-
-// ── HTTP helpers ──────────────────────────────────────────────────────────────
-
-func doGet(ctx context.Context, token, path string) (*http.Response, error) {
-	return doRequest(ctx, token, http.MethodGet, path, nil)
-}
-
-func doJSON(ctx context.Context, token, method, path string, body interface{}) (*http.Response, error) {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	return doRequest(ctx, token, method, path, bytes.NewReader(data))
-}
-
-func doRequest(ctx context.Context, token, method, path string, body io.Reader) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, method, baseURL+path, body)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Auth-API-Token", token)
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return http.DefaultClient.Do(req)
-}
-
-func apiErrorFrom(resp *http.Response, prefix string) error {
-	var ae apiError
-	data, _ := io.ReadAll(resp.Body)
-	if err := json.Unmarshal(data, &ae); err == nil && ae.Message != "" {
-		return fmt.Errorf("%s: HTTP %d — %s", prefix, resp.StatusCode, ae.Message)
-	}
-	return fmt.Errorf("%s: HTTP %d", prefix, resp.StatusCode)
 }

--- a/hetzner/scripts/integration-test.ts
+++ b/hetzner/scripts/integration-test.ts
@@ -69,7 +69,7 @@ const PROMPT = `
 You are an integration test agent for AIquila on Hetzner Cloud.
 
 Environment variables available:
-  HCLOUD_TOKEN, HETZNER_DNS_TOKEN, ANTHROPIC_API_KEY
+  HCLOUD_TOKEN, ANTHROPIC_API_KEY
   NC_DOMAIN, MCP_DOMAIN, DNS_ZONE
   NC_SERVER_TYPE (default: cpx21), MCP_SERVER_TYPE (default: cpx11)
   SSH_KEY_PATH (optional)


### PR DESCRIPTION
Replace the hand-rolled HTTP client targeting dns.hetzner.com/api/v1 with the native hcloud-go Zone/RRSet API (GA since v2.30.0). This unifies token handling — DNS now uses the same Cloud API token as all other commands, eliminating the separate --dns-token flag and $HETZNER_DNS_TOKEN env var.

Close #265 

## Description
Brief description of the changes.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Component
- [ ] MCP Server
- [ ] Nextcloud App
- [ ] Documentation
- [ ] CI/CD

## Checklist
- [ ] I have tested my changes locally
- [ ] I have added tests for new functionality
- [ ] I have updated the documentation if needed
- [ ] My code follows the project's style guidelines

## Related Issues
Fixes #

## Screenshots (if applicable)
