### PR TITLE
fix: CI build failure masking and repo hardening

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,19 +29,7 @@ jobs:
         run: npm test
 
       - name: Build
-        run: npm run build || true
-        continue-on-error: true
-
-      - name: Verify build output
-        run: |
-          if [ ! -f dist/index.js ]; then
-            echo "Build failed - dist/index.js not created"
-            exit 1
-          fi
-          echo "Build succeeded - dist/index.js created"
-
-      # Note: Build may show TS2589 error with MCP SDK v1.22.0 + zod
-      # but still produces working output. We verify the output exists above.
+        run: npm run build
 
   nextcloud-app:
     name: Nextcloud App Tests

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ AIquila bridges your self-hosted Nextcloud instance with Claude AI. Instead of k
 
 AIquila has three components that can be used independently or together:
 
-**MCP Server** — A [Model Context Protocol](https://modelcontextprotocol.io) server that gives Claude (Desktop or Mobile) secure access to your Nextcloud. Through natural conversation, Claude can browse and manage files, read and create notes, handle tasks and bookmarks, and query recipes — all stored in your Nextcloud.
+**MCP Server** — A [Model Context Protocol](https://modelcontextprotocol.io) server that gives any MCP-compatible AI assistant secure access to your Nextcloud. Browse and manage files, read and create notes, handle tasks and bookmarks, manage projects, and query recipes — all stored in your Nextcloud.
 
 **Nextcloud App** — A native Nextcloud application that surfaces Claude AI actions directly inside the Nextcloud UI. Summarize a document, analyze a spreadsheet, or generate content without leaving your Nextcloud.
 

--- a/docker/installation/aiquila-install-hook.sh
+++ b/docker/installation/aiquila-install-hook.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 echo "=== AIquila post-installation hook ==="
 echo "[INFO] Running as: $(id)"

--- a/docker/installation/docker-compose.yml
+++ b/docker/installation/docker-compose.yml
@@ -111,7 +111,7 @@ services:
 
   # Caddy Reverse Proxy (HTTPS)
   caddy:
-    image: caddy:2-alpine
+    image: caddy:2.11.2-alpine
     container_name: aiquila-caddy
     restart: unless-stopped
     depends_on:
@@ -129,7 +129,7 @@ services:
 
   # MailHog (Email Testing)
   mailhog:
-    image: mailhog/mailhog:latest
+    image: mailhog/mailhog:v1.0.1
     container_name: aiquila-mailhog
     restart: unless-stopped
     ports:
@@ -140,7 +140,7 @@ services:
 
   # Adminer (Database UI)
   adminer:
-    image: adminer:latest
+    image: adminer:5.4.2
     container_name: aiquila-adminer
     restart: unless-stopped
     depends_on:

--- a/docker/installation/entrypoint.sh
+++ b/docker/installation/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 echo "=== AIquila Installation Test Environment ==="
 echo ""

--- a/docker/mcp-server/Dockerfile
+++ b/docker/mcp-server/Dockerfile
@@ -14,5 +14,7 @@ ENV NODE_ENV=production
 COPY package*.json ./
 RUN npm ci --omit=dev
 COPY --from=builder /app/dist ./dist
+RUN mkdir -p /app/state && chown -R node:node /app
 EXPOSE 3339
+USER node
 CMD ["node", "dist/index.js"]

--- a/docker/mcp-server/Dockerfile
+++ b/docker/mcp-server/Dockerfile
@@ -16,5 +16,7 @@ RUN npm ci --omit=dev
 COPY --from=builder /app/dist ./dist
 RUN mkdir -p /app/state && chown -R node:node /app
 EXPOSE 3339
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD node -e "fetch('http://localhost:3339/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 USER node
 CMD ["node", "dist/index.js"]

--- a/docker/standalone/docker-compose.yml
+++ b/docker/standalone/docker-compose.yml
@@ -10,7 +10,7 @@
 services:
   # MCP Server (Production image from GHCR)
   mcp-server:
-    image: ghcr.io/elgorro/aiquila-mcp:latest
+    image: ghcr.io/elgorro/aiquila-mcp:0.2.17
     container_name: aiquila-standalone-mcp
     restart: unless-stopped
     environment:
@@ -37,7 +37,7 @@ services:
 
   # Caddy Reverse Proxy (HTTPS)
   caddy:
-    image: caddy:2-alpine
+    image: caddy:2.11.2-alpine
     container_name: aiquila-standalone-caddy
     restart: unless-stopped
     depends_on:

--- a/docker/standalone/scripts/test-oauth.sh
+++ b/docker/standalone/scripts/test-oauth.sh
@@ -4,7 +4,7 @@
 # Usage: ./test-oauth.sh [base-url]
 #   base-url defaults to https://localhost:3340 (via Caddy, self-signed cert)
 
-set -e
+set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 STANDALONE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 

--- a/hetzner/cmd/aiquila-hetzner/deploy.go
+++ b/hetzner/cmd/aiquila-hetzner/deploy.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/hetzner/cmd/aiquila-hetzner/dns.go
+++ b/hetzner/cmd/aiquila-hetzner/dns.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/hetzner/cmd/aiquila-hetzner/firewall.go
+++ b/hetzner/cmd/aiquila-hetzner/firewall.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/hetzner/cmd/aiquila-hetzner/jsonlog.go
+++ b/hetzner/cmd/aiquila-hetzner/jsonlog.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/hetzner/cmd/aiquila-hetzner/main.go
+++ b/hetzner/cmd/aiquila-hetzner/main.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/hetzner/cmd/aiquila-hetzner/manage.go
+++ b/hetzner/cmd/aiquila-hetzner/manage.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/hetzner/cmd/aiquila-hetzner/network.go
+++ b/hetzner/cmd/aiquila-hetzner/network.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/hetzner/cmd/aiquila-hetzner/options.go
+++ b/hetzner/cmd/aiquila-hetzner/options.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/hetzner/cmd/aiquila-hetzner/profile.go
+++ b/hetzner/cmd/aiquila-hetzner/profile.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/hetzner/cmd/aiquila-hetzner/rebuild.go
+++ b/hetzner/cmd/aiquila-hetzner/rebuild.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/hetzner/cmd/aiquila-hetzner/snapshot.go
+++ b/hetzner/cmd/aiquila-hetzner/snapshot.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/hetzner/docker/embed.go
+++ b/hetzner/docker/embed.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // Package templates embeds the production docker stack template files.
 // These are read at build time and bundled into the aiquila-hetzner binary,
 // keeping hetzner/docker/{mcp,nextcloud,full}/ as the single source of truth

--- a/hetzner/internal/config/env.go
+++ b/hetzner/internal/config/env.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/hetzner/internal/dns/client.go
+++ b/hetzner/internal/dns/client.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // Package dns manages DNS records via the hcloud-go Zone API.
 package dns
 

--- a/hetzner/internal/firewall/setup.go
+++ b/hetzner/internal/firewall/setup.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package firewall
 
 import (

--- a/hetzner/internal/hcloud/client.go
+++ b/hetzner/internal/hcloud/client.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package hcloud
 
 import (

--- a/hetzner/internal/network/manage.go
+++ b/hetzner/internal/network/manage.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package network
 
 import (

--- a/hetzner/internal/profile/profile.go
+++ b/hetzner/internal/profile/profile.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 // Package profile manages named configuration profiles for aiquila-hetzner.
 // Profiles are stored in ~/.config/aiquila-hetzner/config.json (mode 0600).
 // Each profile stores a Hetzner API token plus optional Nextcloud credentials

--- a/hetzner/internal/provision/ssh.go
+++ b/hetzner/internal/provision/ssh.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package provision
 
 import (

--- a/hetzner/internal/provision/upload.go
+++ b/hetzner/internal/provision/upload.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package provision
 
 import (

--- a/hetzner/internal/server/create.go
+++ b/hetzner/internal/server/create.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package server
 
 import (

--- a/hetzner/internal/storagebox/mount.go
+++ b/hetzner/internal/storagebox/mount.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package storagebox
 
 import (

--- a/hetzner/internal/volume/create.go
+++ b/hetzner/internal/volume/create.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package volume
 
 import (

--- a/hetzner/scripts/integration-test.ts
+++ b/hetzner/scripts/integration-test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { randomBytes } from "node:crypto";
 import { query, type HookCallback } from "@anthropic-ai/claude-agent-sdk";
 

--- a/mcp-server/src/__tests__/auth/login.test.ts
+++ b/mcp-server/src/__tests__/auth/login.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { NextcloudOAuthProvider } from '../../auth/provider.js';
 import { loginHandler } from '../../auth/login.js';

--- a/mcp-server/src/__tests__/auth/provider.test.ts
+++ b/mcp-server/src/__tests__/auth/provider.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { NextcloudOAuthProvider, renderLoginForm } from '../../auth/provider.js';
 

--- a/mcp-server/src/__tests__/auth/store.test.ts
+++ b/mcp-server/src/__tests__/auth/store.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 vi.mock('node:fs');

--- a/mcp-server/src/__tests__/internal-token.test.ts
+++ b/mcp-server/src/__tests__/internal-token.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { NextcloudOAuthProvider } from '../auth/provider.js';
 

--- a/mcp-server/src/__tests__/server.test.ts
+++ b/mcp-server/src/__tests__/server.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock webdav (required by file tools)

--- a/mcp-server/src/__tests__/server.test.ts
+++ b/mcp-server/src/__tests__/server.test.ts
@@ -21,8 +21,9 @@ vi.mock('../client/bookmarks.js', () => ({
   fetchBookmarksAPI: vi.fn(),
 }));
 
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { createServer } from '../server.js';
-import { _resetCache } from '../tool-registry.js';
+import { _resetCache, getFilteredToolSets } from '../tool-registry.js';
 
 describe('createServer', () => {
   beforeEach(() => {
@@ -46,8 +47,30 @@ describe('createServer', () => {
 
   it('should register tools on the server', async () => {
     const server = await createServer();
-    // McpServer exposes registered tools via the internal _registeredTools map
-    // We verify by checking the server is connectable (tools registered without error)
-    expect(server).toBeDefined();
+    const tools = (server as any)._registeredTools as Record<string, unknown>;
+    const names = Object.keys(tools);
+    expect(names.length).toBeGreaterThan(0);
+    for (const name of names) {
+      expect(name).toBeTruthy();
+      expect(typeof name).toBe('string');
+    }
+  });
+
+  it('should register exactly the tools from getFilteredToolSets', async () => {
+    const server = await createServer();
+    const registeredCount = Object.keys((server as any)._registeredTools).length;
+    _resetCache();
+    const toolSets = await getFilteredToolSets();
+    const expectedCount = toolSets.reduce((sum, ts) => sum + ts.length, 0);
+    expect(registeredCount).toBe(expectedCount);
+  });
+
+  it('should connect to a transport', async () => {
+    const server = await createServer();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    await server.connect(serverTransport);
+    await clientTransport.close();
+    await server.close();
   });
 });

--- a/mcp-server/src/__tests__/sync-server-json.test.ts
+++ b/mcp-server/src/__tests__/sync-server-json.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { writeFileSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { resolve } from 'node:path';

--- a/mcp-server/src/__tests__/tags.test.ts
+++ b/mcp-server/src/__tests__/tags.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock fetch for CalDAV

--- a/mcp-server/src/__tests__/talk.test.ts
+++ b/mcp-server/src/__tests__/talk.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock fetch for OCS

--- a/mcp-server/src/__tests__/tool-registry.test.ts
+++ b/mcp-server/src/__tests__/tool-registry.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock webdav (required by file tools)

--- a/mcp-server/src/__tests__/tools-aiquila.test.ts
+++ b/mcp-server/src/__tests__/tools-aiquila.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockExecuteOCC = vi.fn();

--- a/mcp-server/src/__tests__/tools-aiquila.test.ts
+++ b/mcp-server/src/__tests__/tools-aiquila.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockExecuteOCC = vi.fn();
+
+vi.mock('../client/aiquila.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../client/aiquila.js')>('../client/aiquila.js');
+  return {
+    ...actual,
+    executeOCC: (...args: unknown[]) => mockExecuteOCC(...args),
+  };
+});
+
+describe('AIquila Internal Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXTCLOUD_URL = 'https://cloud.example.com';
+    process.env.NEXTCLOUD_USER = 'admin';
+    process.env.NEXTCLOUD_PASSWORD = 'testpass';
+  });
+
+  describe('aiquila_show_config', () => {
+    it('should return OCC output on success', async () => {
+      mockExecuteOCC.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+        stdout: 'api_key: sk-***\nmodel: claude-sonnet-4-5-20250929',
+        stderr: '',
+      });
+
+      const { showConfigTool } = await import('../tools/apps/aiquila.js');
+      const result = await showConfigTool.handler();
+
+      expect(result.content[0].text).toContain('api_key');
+      expect(result.content[0].text).toContain('model');
+      expect(mockExecuteOCC).toHaveBeenCalledWith('aiquila:show', []);
+    });
+
+    it('should handle OCC failure', async () => {
+      mockExecuteOCC.mockResolvedValue({
+        success: false,
+        exitCode: 1,
+        stdout: '',
+        stderr: 'Command not found',
+        error: 'Command not found',
+      });
+
+      const { showConfigTool } = await import('../tools/apps/aiquila.js');
+      const result = await showConfigTool.handler();
+
+      expect(result.content[0].text).toContain('Error');
+      expect(result.content[0].text).toContain('Command not found');
+    });
+
+    it('should handle thrown errors', async () => {
+      mockExecuteOCC.mockRejectedValue(new Error('Network error'));
+
+      const { showConfigTool } = await import('../tools/apps/aiquila.js');
+      const result = await showConfigTool.handler();
+
+      expect(result.content[0].text).toContain('Error');
+      expect(result.content[0].text).toContain('Network error');
+    });
+  });
+
+  describe('aiquila_configure', () => {
+    it('should pass all config args', async () => {
+      mockExecuteOCC.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+        stdout: 'Configuration updated',
+        stderr: '',
+      });
+
+      const { configureTool } = await import('../tools/apps/aiquila.js');
+      const result = await configureTool.handler({
+        apiKey: 'sk-test',
+        model: 'claude-opus-4-6',
+        maxTokens: 8192,
+        timeout: 120,
+      });
+
+      expect(result.content[0].text).toContain('Configuration updated');
+      expect(mockExecuteOCC).toHaveBeenCalledWith('aiquila:configure', [
+        '--api-key',
+        'sk-test',
+        '--model',
+        'claude-opus-4-6',
+        '--max-tokens',
+        '8192',
+        '--timeout',
+        '120',
+      ]);
+    });
+
+    it('should only pass provided args', async () => {
+      mockExecuteOCC.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+        stdout: 'Model updated',
+        stderr: '',
+      });
+
+      const { configureTool } = await import('../tools/apps/aiquila.js');
+      await configureTool.handler({ model: 'claude-sonnet-4-5-20250929' });
+
+      expect(mockExecuteOCC).toHaveBeenCalledWith('aiquila:configure', [
+        '--model',
+        'claude-sonnet-4-5-20250929',
+      ]);
+    });
+
+    it('should handle errors', async () => {
+      mockExecuteOCC.mockResolvedValue({
+        success: false,
+        exitCode: 1,
+        stdout: '',
+        stderr: 'Invalid API key',
+        error: 'Invalid API key',
+      });
+
+      const { configureTool } = await import('../tools/apps/aiquila.js');
+      const result = await configureTool.handler({ apiKey: 'bad-key' });
+
+      expect(result.content[0].text).toContain('Error');
+    });
+  });
+
+  describe('aiquila_test', () => {
+    it('should pass prompt to OCC', async () => {
+      mockExecuteOCC.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+        stdout: 'Response: Hello! How can I help you?',
+        stderr: '',
+      });
+
+      const { testTool } = await import('../tools/apps/aiquila.js');
+      const result = await testTool.handler({ prompt: 'Say hello' });
+
+      expect(result.content[0].text).toContain('Hello');
+      expect(mockExecuteOCC).toHaveBeenCalledWith('aiquila:test', ['--prompt', 'Say hello']);
+    });
+
+    it('should handle errors', async () => {
+      mockExecuteOCC.mockRejectedValue(new Error('API timeout'));
+
+      const { testTool } = await import('../tools/apps/aiquila.js');
+      const result = await testTool.handler({ prompt: 'test' });
+
+      expect(result.content[0].text).toContain('Error');
+      expect(result.content[0].text).toContain('API timeout');
+    });
+  });
+});

--- a/mcp-server/src/__tests__/tools-apps.test.ts
+++ b/mcp-server/src/__tests__/tools-apps.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the OCS client module

--- a/mcp-server/src/__tests__/tools-assistant.test.ts
+++ b/mcp-server/src/__tests__/tools-assistant.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockFetchOCS = vi.fn();

--- a/mcp-server/src/__tests__/tools-assistant.test.ts
+++ b/mcp-server/src/__tests__/tools-assistant.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFetchOCS = vi.fn();
+
+vi.mock('../client/ocs.js', () => ({
+  fetchOCS: (...args: unknown[]) => mockFetchOCS(...args),
+}));
+
+describe('Assistant / AI Task Processing Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXTCLOUD_URL = 'https://cloud.example.com';
+    process.env.NEXTCLOUD_USER = 'admin';
+    process.env.NEXTCLOUD_PASSWORD = 'testpass';
+  });
+
+  describe('list_text_tasks', () => {
+    it('should return available task types', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: {
+            types: {
+              'core:summarize': { name: 'Summarize', description: 'Summarize text' },
+              'core:headline': { name: 'Headline', description: 'Generate a headline' },
+            },
+          },
+        },
+      });
+
+      const { listTextTasksTool } = await import('../tools/apps/assistant.js');
+      const result = await listTextTasksTool.handler();
+
+      expect(result.content[0].text).toContain('Summarize');
+      expect(result.content[0].text).toContain('Headline');
+      expect(result).not.toHaveProperty('isError');
+    });
+
+    it('should handle empty task types', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: { types: {} },
+        },
+      });
+
+      const { listTextTasksTool } = await import('../tools/apps/assistant.js');
+      const result = await listTextTasksTool.handler();
+
+      expect(result.content[0].text).toContain('No AI task types');
+    });
+
+    it('should handle errors', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('API error'));
+
+      const { listTextTasksTool } = await import('../tools/apps/assistant.js');
+      const result = await listTextTasksTool.handler();
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('API error');
+    });
+  });
+
+  describe('process_text', () => {
+    it('should schedule a task and return ID', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: { task: { id: 42, type: 'core:summarize', status: 1 } },
+        },
+      });
+
+      const { processTextTool } = await import('../tools/apps/assistant.js');
+      const result = await processTextTool.handler({
+        taskType: 'core:summarize',
+        input: 'Long text to summarize',
+      });
+
+      expect(result.content[0].text).toContain('42');
+      expect(result.content[0].text).toContain('scheduled');
+      expect(mockFetchOCS).toHaveBeenCalledWith(
+        '/ocs/v2.php/taskprocessing/schedule',
+        expect.objectContaining({
+          method: 'POST',
+          jsonBody: expect.objectContaining({
+            type: 'core:summarize',
+            appId: 'aiquila-mcp',
+            input: { input: 'Long text to summarize' },
+          }),
+        })
+      );
+    });
+
+    it('should include customId when provided', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: { task: { id: 43, type: 'core:summarize', status: 1 } },
+        },
+      });
+
+      const { processTextTool } = await import('../tools/apps/assistant.js');
+      await processTextTool.handler({
+        taskType: 'core:summarize',
+        input: 'text',
+        customId: 'my-task-1',
+      });
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(
+        '/ocs/v2.php/taskprocessing/schedule',
+        expect.objectContaining({
+          jsonBody: expect.objectContaining({ customId: 'my-task-1' }),
+        })
+      );
+    });
+
+    it('should handle errors', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('Server error'));
+
+      const { processTextTool } = await import('../tools/apps/assistant.js');
+      const result = await processTextTool.handler({
+        taskType: 'core:summarize',
+        input: 'text',
+      });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('get_task_result', () => {
+    it('should return result for successful task (text output)', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: {
+            task: {
+              id: 42,
+              status: 3,
+              output: { output: 'This is the summary.' },
+            },
+          },
+        },
+      });
+
+      const { getTaskResultTool } = await import('../tools/apps/assistant.js');
+      const result = await getTaskResultTool.handler({ taskId: 42 });
+
+      expect(result.content[0].text).toContain('completed successfully');
+      expect(result.content[0].text).toContain('This is the summary.');
+      expect(result).not.toHaveProperty('isError');
+    });
+
+    it('should stringify non-text output', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: {
+            task: {
+              id: 42,
+              status: 3,
+              output: { topics: ['AI', 'ML'] },
+            },
+          },
+        },
+      });
+
+      const { getTaskResultTool } = await import('../tools/apps/assistant.js');
+      const result = await getTaskResultTool.handler({ taskId: 42 });
+
+      expect(result.content[0].text).toContain('AI');
+      expect(result.content[0].text).toContain('ML');
+    });
+
+    it('should return error for failed task', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: {
+            task: {
+              id: 42,
+              status: 4,
+              errorMessage: 'Provider unavailable',
+            },
+          },
+        },
+      });
+
+      const { getTaskResultTool } = await import('../tools/apps/assistant.js');
+      const result = await getTaskResultTool.handler({ taskId: 42 });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('failed');
+      expect(result.content[0].text).toContain('Provider unavailable');
+    });
+
+    it('should return pending status for running task', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: { task: { id: 42, status: 2 } },
+        },
+      });
+
+      const { getTaskResultTool } = await import('../tools/apps/assistant.js');
+      const result = await getTaskResultTool.handler({ taskId: 42 });
+
+      expect(result.content[0].text).toContain('running');
+      expect(result.content[0].text).toContain('Poll again');
+      expect(result).not.toHaveProperty('isError');
+    });
+
+    it('should handle errors', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('Not found'));
+
+      const { getTaskResultTool } = await import('../tools/apps/assistant.js');
+      const result = await getTaskResultTool.handler({ taskId: 999 });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('generate_image', () => {
+    it('should schedule image generation task', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: { task: { id: 50, status: 1 } },
+        },
+      });
+
+      const { generateImageTool } = await import('../tools/apps/assistant.js');
+      const result = await generateImageTool.handler({ prompt: 'A sunset over mountains' });
+
+      expect(result.content[0].text).toContain('50');
+      expect(result.content[0].text).toContain('scheduled');
+      expect(mockFetchOCS).toHaveBeenCalledWith(
+        '/ocs/v2.php/taskprocessing/schedule',
+        expect.objectContaining({
+          method: 'POST',
+          jsonBody: expect.objectContaining({
+            type: 'core:text2image',
+            input: { input: 'A sunset over mountains', numberOfImages: 1 },
+          }),
+        })
+      );
+    });
+
+    it('should include savePath in customId', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: { task: { id: 51, status: 1 } },
+        },
+      });
+
+      const { generateImageTool } = await import('../tools/apps/assistant.js');
+      const result = await generateImageTool.handler({
+        prompt: 'test',
+        savePath: '/Photos/generated.png',
+      });
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(
+        '/ocs/v2.php/taskprocessing/schedule',
+        expect.objectContaining({
+          jsonBody: expect.objectContaining({
+            customId: 'savePath:/Photos/generated.png',
+          }),
+        })
+      );
+      expect(result.content[0].text).toContain('/Photos/generated.png');
+    });
+
+    it('should handle errors', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('No provider'));
+
+      const { generateImageTool } = await import('../tools/apps/assistant.js');
+      const result = await generateImageTool.handler({ prompt: 'test' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('No provider');
+    });
+  });
+});

--- a/mcp-server/src/__tests__/tools-bookmarks.test.ts
+++ b/mcp-server/src/__tests__/tools-bookmarks.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the Bookmarks API client module

--- a/mcp-server/src/__tests__/tools-calendar.test.ts
+++ b/mcp-server/src/__tests__/tools-calendar.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock declarations

--- a/mcp-server/src/__tests__/tools-circles.test.ts
+++ b/mcp-server/src/__tests__/tools-circles.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the OCS client module

--- a/mcp-server/src/__tests__/tools-contacts.test.ts
+++ b/mcp-server/src/__tests__/tools-contacts.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock declarations

--- a/mcp-server/src/__tests__/tools-dav.test.ts
+++ b/mcp-server/src/__tests__/tools-dav.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { FileStat } from 'webdav';
 

--- a/mcp-server/src/__tests__/tools-dav.test.ts
+++ b/mcp-server/src/__tests__/tools-dav.test.ts
@@ -45,6 +45,18 @@ describe('MCP Tools', () => {
 
       expect(formatted).toBe('📁 Documents\n📄 readme.txt');
     });
+
+    it('should call handler and return JSON', async () => {
+      mockClient.getDirectoryContents.mockResolvedValue([
+        { type: 'directory', basename: 'Photos' },
+      ]);
+
+      const { listFilesTool } = await import('../tools/system/files.js');
+      const result = await listFilesTool.handler({ path: '/' });
+
+      expect(result.content[0].text).toContain('Photos');
+      expect(mockClient.getDirectoryContents).toHaveBeenCalledWith('/');
+    });
   });
 
   describe('read_file', () => {
@@ -185,6 +197,32 @@ describe('MCP Tools', () => {
 
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('404 Not Found');
+    });
+  });
+
+  describe('create_folder', () => {
+    it('should call createDirectory and return success', async () => {
+      mockClient.createDirectory.mockResolvedValue(undefined);
+
+      const { createFolderTool } = await import('../tools/system/files.js');
+      const result = await createFolderTool.handler({ path: '/NewFolder' });
+
+      expect(mockClient.createDirectory).toHaveBeenCalledWith('/NewFolder');
+      expect(result.content[0].text).toContain('Folder created successfully');
+      expect(result.content[0].text).toContain('/NewFolder');
+    });
+  });
+
+  describe('delete', () => {
+    it('should call deleteFile and return success', async () => {
+      mockClient.deleteFile.mockResolvedValue(undefined);
+
+      const { deleteTool } = await import('../tools/system/files.js');
+      const result = await deleteTool.handler({ path: '/old-file.txt' });
+
+      expect(mockClient.deleteFile).toHaveBeenCalledWith('/old-file.txt');
+      expect(result.content[0].text).toContain('Deleted successfully');
+      expect(result.content[0].text).toContain('/old-file.txt');
     });
   });
 

--- a/mcp-server/src/__tests__/tools-deck.test.ts
+++ b/mcp-server/src/__tests__/tools-deck.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockFetchDeckAPI = vi.fn();

--- a/mcp-server/src/__tests__/tools-files.test.ts
+++ b/mcp-server/src/__tests__/tools-files.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock webdav (needed because files.ts imports getWebDAVClient)

--- a/mcp-server/src/__tests__/tools-files.test.ts
+++ b/mcp-server/src/__tests__/tools-files.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock webdav (needed because files.ts imports getWebDAVClient)
+vi.mock('webdav', () => ({
+  createClient: vi.fn(() => ({})),
+}));
+
+const mockFetchAiquilaAPI = vi.fn();
+
+vi.mock('../client/aiquila.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../client/aiquila.js')>('../client/aiquila.js');
+  return {
+    ...actual,
+    fetchAiquilaAPI: (...args: unknown[]) => mockFetchAiquilaAPI(...args),
+  };
+});
+
+describe('File Tools (AIquila API)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXTCLOUD_URL = 'https://cloud.example.com';
+    process.env.NEXTCLOUD_USER = 'admin';
+    process.env.NEXTCLOUD_PASSWORD = 'testpass';
+  });
+
+  // ─── get_file_info ──────────────────────────────────────────────────
+
+  describe('get_file_info', () => {
+    it('should return file metadata as JSON', async () => {
+      mockFetchAiquilaAPI.mockResolvedValue({
+        name: 'report.pdf',
+        mimeType: 'application/pdf',
+        size: 102400,
+        modified: '2026-04-01T12:00:00Z',
+      });
+
+      const { getFileInfoTool } = await import('../tools/system/files.js');
+      const result = await getFileInfoTool.handler({ path: '/Documents/report.pdf' });
+
+      expect(result.content[0].text).toContain('report.pdf');
+      expect(result.content[0].text).toContain('application/pdf');
+      expect(result).not.toHaveProperty('isError');
+      expect(mockFetchAiquilaAPI).toHaveBeenCalledWith('/files/info', {
+        queryParams: { path: '/Documents/report.pdf' },
+      });
+    });
+
+    it('should handle errors', async () => {
+      mockFetchAiquilaAPI.mockRejectedValue(new Error('File not found'));
+
+      const { getFileInfoTool } = await import('../tools/system/files.js');
+      const result = await getFileInfoTool.handler({ path: '/nonexistent' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('File not found');
+    });
+  });
+
+  // ─── search_files ─────────────────────────────────────────────────
+
+  describe('search_files', () => {
+    it('should search with query and return results', async () => {
+      mockFetchAiquilaAPI.mockResolvedValue([{ name: 'notes.txt', path: '/Documents/notes.txt' }]);
+
+      const { searchFilesTool } = await import('../tools/system/files.js');
+      const result = await searchFilesTool.handler({ query: 'notes' });
+
+      expect(result.content[0].text).toContain('notes.txt');
+      expect(mockFetchAiquilaAPI).toHaveBeenCalledWith('/files/search', {
+        queryParams: expect.objectContaining({ query: 'notes' }),
+      });
+    });
+
+    it('should pass optional mime filter', async () => {
+      mockFetchAiquilaAPI.mockResolvedValue([]);
+
+      const { searchFilesTool } = await import('../tools/system/files.js');
+      await searchFilesTool.handler({ query: 'photo', mime: 'image/' });
+
+      expect(mockFetchAiquilaAPI).toHaveBeenCalledWith('/files/search', {
+        queryParams: expect.objectContaining({ query: 'photo', mime: 'image/' }),
+      });
+    });
+
+    it('should handle errors', async () => {
+      mockFetchAiquilaAPI.mockRejectedValue(new Error('Search error'));
+
+      const { searchFilesTool } = await import('../tools/system/files.js');
+      const result = await searchFilesTool.handler({ query: 'test' });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // ─── get_file_content ─────────────────────────────────────────────
+
+  describe('get_file_content', () => {
+    it('should return text content for text files', async () => {
+      mockFetchAiquilaAPI.mockResolvedValue({
+        name: 'readme.md',
+        mimeType: 'text/markdown',
+        size: 256,
+        encoding: 'text',
+        content: '# Hello World',
+      });
+
+      const { getFileContentTool } = await import('../tools/system/files.js');
+      const result = await getFileContentTool.handler({ path: '/readme.md' });
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('# Hello World');
+      expect(result.content[0].text).toContain('text/markdown');
+    });
+
+    it('should return image content block for images', async () => {
+      mockFetchAiquilaAPI.mockResolvedValue({
+        name: 'photo.jpg',
+        mimeType: 'image/jpeg',
+        size: 50000,
+        encoding: 'base64',
+        content: '/9j/4AAQSkZJRg==',
+      });
+
+      const { getFileContentTool } = await import('../tools/system/files.js');
+      const result = await getFileContentTool.handler({ path: '/Photos/photo.jpg' });
+
+      expect(result.content).toHaveLength(2);
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[1].type).toBe('image');
+      expect(result.content[1]).toHaveProperty('data', '/9j/4AAQSkZJRg==');
+      expect(result.content[1]).toHaveProperty('mimeType', 'image/jpeg');
+    });
+
+    it('should return base64 text for other binary files', async () => {
+      mockFetchAiquilaAPI.mockResolvedValue({
+        name: 'archive.zip',
+        mimeType: 'application/zip',
+        size: 1024,
+        encoding: 'base64',
+        content: 'UEsDBBQAAAA=',
+      });
+
+      const { getFileContentTool } = await import('../tools/system/files.js');
+      const result = await getFileContentTool.handler({ path: '/archive.zip' });
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].text).toContain('base64');
+      expect(result.content[0].text).toContain('UEsDBBQAAAA=');
+    });
+
+    it('should handle errors', async () => {
+      mockFetchAiquilaAPI.mockRejectedValue(new Error('Permission denied'));
+
+      const { getFileContentTool } = await import('../tools/system/files.js');
+      const result = await getFileContentTool.handler({ path: '/secret.dat' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Permission denied');
+    });
+  });
+
+  // ─── analyze_image ────────────────────────────────────────────────
+
+  describe('analyze_image', () => {
+    it('should analyze a single image', async () => {
+      mockFetchAiquilaAPI.mockResolvedValue({
+        name: 'receipt.jpg',
+        mimeType: 'image/jpeg',
+        size: 30000,
+        encoding: 'base64',
+        content: '/9j/base64data',
+      });
+
+      const { analyzeImageTool } = await import('../tools/system/files.js');
+      const result = await analyzeImageTool.handler({
+        path: '/Photos/receipt.jpg',
+        prompt: 'What text is in this image?',
+      });
+
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('receipt.jpg');
+      expect(result.content[0].text).toContain('What text is in this image?');
+      expect(result.content[1].type).toBe('image');
+    });
+
+    it('should analyze multiple images', async () => {
+      mockFetchAiquilaAPI
+        .mockResolvedValueOnce({
+          name: 'before.jpg',
+          mimeType: 'image/jpeg',
+          size: 20000,
+          encoding: 'base64',
+          content: 'img1data',
+        })
+        .mockResolvedValueOnce({
+          name: 'after.jpg',
+          mimeType: 'image/jpeg',
+          size: 25000,
+          encoding: 'base64',
+          content: 'img2data',
+        });
+
+      const { analyzeImageTool } = await import('../tools/system/files.js');
+      const result = await analyzeImageTool.handler({
+        paths: ['/Photos/before.jpg', '/Photos/after.jpg'],
+        prompt: 'Compare these images',
+      });
+
+      expect(result.content[0].text).toContain('Analyzing 2 images');
+      expect(result.content).toHaveLength(3); // 1 text + 2 images
+    });
+
+    it('should error when no path is provided', async () => {
+      const { analyzeImageTool } = await import('../tools/system/files.js');
+      const result = await analyzeImageTool.handler({ prompt: 'Describe this' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('No image path provided');
+    });
+
+    it('should reject non-image files', async () => {
+      mockFetchAiquilaAPI.mockResolvedValue({
+        name: 'document.pdf',
+        mimeType: 'application/pdf',
+        size: 50000,
+        encoding: 'base64',
+        content: 'pdfdata',
+      });
+
+      const { analyzeImageTool } = await import('../tools/system/files.js');
+      const result = await analyzeImageTool.handler({
+        path: '/document.pdf',
+        prompt: 'Read this',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Non-image file');
+      expect(result.content[0].text).toContain('application/pdf');
+    });
+
+    it('should handle fetch errors', async () => {
+      mockFetchAiquilaAPI.mockRejectedValue(new Error('File not found'));
+
+      const { analyzeImageTool } = await import('../tools/system/files.js');
+      const result = await analyzeImageTool.handler({
+        path: '/nonexistent.jpg',
+        prompt: 'Describe',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('File not found');
+    });
+  });
+});

--- a/mcp-server/src/__tests__/tools-groups.test.ts
+++ b/mcp-server/src/__tests__/tools-groups.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the OCS client module

--- a/mcp-server/src/__tests__/tools-mail.test.ts
+++ b/mcp-server/src/__tests__/tools-mail.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the OCS client module (needed for list_messages, read_message)

--- a/mcp-server/src/__tests__/tools-maps.test.ts
+++ b/mcp-server/src/__tests__/tools-maps.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the Maps API client module

--- a/mcp-server/src/__tests__/tools-notes.test.ts
+++ b/mcp-server/src/__tests__/tools-notes.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockFetchNotesAPI = vi.fn();

--- a/mcp-server/src/__tests__/tools-notifications.test.ts
+++ b/mcp-server/src/__tests__/tools-notifications.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockFetchOCS = vi.fn();

--- a/mcp-server/src/__tests__/tools-ocs.test.ts
+++ b/mcp-server/src/__tests__/tools-ocs.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock webdav client (needed for bulk file operations)

--- a/mcp-server/src/__tests__/tools-ocs.test.ts
+++ b/mcp-server/src/__tests__/tools-ocs.test.ts
@@ -304,6 +304,71 @@ describe('OCS-based Tools', () => {
     });
   });
 
+  // ─── Setup Checks ─────────────────────────────────────────────────────
+
+  describe('run_setup_checks', () => {
+    it('should return success output', async () => {
+      mockExecuteOCC.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+        stdout: 'All checks passed',
+        stderr: '',
+      });
+
+      const { setupChecksTool } = await import('../tools/system/status.js');
+      const result = await setupChecksTool.handler();
+
+      expect(result.content[0].text).toContain('Setup checks completed successfully');
+      expect(result.content[0].text).toContain('All checks passed');
+      expect(result.isError).toBe(false);
+    });
+
+    it('should report failure with exit code and stderr', async () => {
+      mockExecuteOCC.mockResolvedValue({
+        success: false,
+        exitCode: 1,
+        stdout: 'PHP module missing: imagick',
+        stderr: 'Warning: performance degraded',
+      });
+
+      const { setupChecksTool } = await import('../tools/system/status.js');
+      const result = await setupChecksTool.handler();
+
+      expect(result.content[0].text).toContain('found issues');
+      expect(result.content[0].text).toContain('imagick');
+      expect(result.content[0].text).toContain('stderr');
+      expect(result.content[0].text).toContain('performance degraded');
+      expect(result.isError).toBe(true);
+    });
+
+    it('should handle thrown errors', async () => {
+      mockExecuteOCC.mockRejectedValue(new Error('OCC unavailable'));
+
+      const { setupChecksTool } = await import('../tools/system/status.js');
+      const result = await setupChecksTool.handler();
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Error running setup checks');
+    });
+  });
+
+  // ─── Get Local Time ───────────────────────────────────────────────────
+
+  describe('get_local_time', () => {
+    it('should return timezone, offset, and time info', async () => {
+      const { getLocalTimeTool } = await import('../tools/system/status.js');
+      const result = await getLocalTimeTool.handler();
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveProperty('localTime');
+      expect(parsed).toHaveProperty('utcTime');
+      expect(parsed).toHaveProperty('timezone');
+      expect(parsed).toHaveProperty('utcOffset');
+      expect(parsed.utcOffset).toMatch(/^[+-]\d{2}:\d{2}$/);
+      expect(parsed.utcTime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+  });
+
   // ─── Bulk File Operations ─────────────────────────────────────────────
 
   describe('bulk_file_operations', () => {

--- a/mcp-server/src/__tests__/tools-photos.test.ts
+++ b/mcp-server/src/__tests__/tools-photos.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the CalDAV client module

--- a/mcp-server/src/__tests__/tools-projects.test.ts
+++ b/mcp-server/src/__tests__/tools-projects.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFetchAiquilaAPI = vi.fn();
+
+vi.mock('../client/aiquila.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../client/aiquila.js')>('../client/aiquila.js');
+  return {
+    ...actual,
+    fetchAiquilaAPI: (...args: unknown[]) => mockFetchAiquilaAPI(...args),
+  };
+});
+
+const sampleProject = {
+  id: 1,
+  userId: 'admin',
+  title: 'My Project',
+  description: 'A test project',
+  systemPrompt: 'You are helpful',
+  isActive: true,
+  createdAt: 1700000000,
+  updatedAt: 1700000000,
+  paths: [
+    { id: 10, projectId: 1, path: '/Documents', pathType: 'directory', createdAt: 1700000000 },
+  ],
+};
+
+describe('Project Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXTCLOUD_URL = 'https://cloud.example.com';
+    process.env.NEXTCLOUD_USER = 'admin';
+    process.env.NEXTCLOUD_PASSWORD = 'testpass';
+  });
+
+  describe('list_projects', () => {
+    it('should return formatted project list', async () => {
+      mockFetchAiquilaAPI.mockResolvedValue([sampleProject]);
+
+      const { listProjectsTool } = await import('../tools/apps/projects.js');
+      const result = await listProjectsTool.handler();
+
+      expect(result.content[0].text).toContain('My Project');
+      expect(result.content[0].text).toContain('/Documents');
+      expect(result.content[0].text).toContain('Projects (1)');
+    });
+
+    it('should handle empty list', async () => {
+      mockFetchAiquilaAPI.mockResolvedValue([]);
+
+      const { listProjectsTool } = await import('../tools/apps/projects.js');
+      const result = await listProjectsTool.handler();
+
+      expect(result.content[0].text).toContain('No projects found');
+    });
+
+    it('should handle errors', async () => {
+      mockFetchAiquilaAPI.mockRejectedValue(new Error('Connection refused'));
+
+      const { listProjectsTool } = await import('../tools/apps/projects.js');
+      const result = await listProjectsTool.handler();
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Connection refused');
+    });
+  });
+
+  describe('create_project', () => {
+    it('should create project with all fields', async () => {
+      mockFetchAiquilaAPI.mockResolvedValue(sampleProject);
+
+      const { createProjectTool } = await import('../tools/apps/projects.js');
+      const result = await createProjectTool.handler({
+        title: 'My Project',
+        description: 'A test project',
+        systemPrompt: 'You are helpful',
+      });
+
+      expect(result.content[0].text).toContain('Project created');
+      expect(result.content[0].text).toContain('My Project');
+      expect(mockFetchAiquilaAPI).toHaveBeenCalledWith('/projects', {
+        method: 'POST',
+        body: {
+          title: 'My Project',
+          description: 'A test project',
+          systemPrompt: 'You are helpful',
+        },
+      });
+    });
+
+    it('should handle errors', async () => {
+      mockFetchAiquilaAPI.mockRejectedValue(new Error('Validation error'));
+
+      const { createProjectTool } = await import('../tools/apps/projects.js');
+      const result = await createProjectTool.handler({ title: '' });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('get_project', () => {
+    it('should return formatted project', async () => {
+      mockFetchAiquilaAPI.mockResolvedValue(sampleProject);
+
+      const { getProjectTool } = await import('../tools/apps/projects.js');
+      const result = await getProjectTool.handler({ id: 1 });
+
+      expect(result.content[0].text).toContain('My Project');
+      expect(result.content[0].text).toContain('You are helpful');
+      expect(mockFetchAiquilaAPI).toHaveBeenCalledWith('/projects/1');
+    });
+
+    it('should handle errors', async () => {
+      mockFetchAiquilaAPI.mockRejectedValue(new Error('Not found'));
+
+      const { getProjectTool } = await import('../tools/apps/projects.js');
+      const result = await getProjectTool.handler({ id: 999 });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('update_project', () => {
+    it('should only send defined fields', async () => {
+      mockFetchAiquilaAPI.mockResolvedValue({ ...sampleProject, title: 'Updated' });
+
+      const { updateProjectTool } = await import('../tools/apps/projects.js');
+      const result = await updateProjectTool.handler({ id: 1, title: 'Updated' });
+
+      expect(result.content[0].text).toContain('Project updated');
+      expect(mockFetchAiquilaAPI).toHaveBeenCalledWith('/projects/1', {
+        method: 'PUT',
+        body: { title: 'Updated' },
+      });
+    });
+
+    it('should handle errors', async () => {
+      mockFetchAiquilaAPI.mockRejectedValue(new Error('Forbidden'));
+
+      const { updateProjectTool } = await import('../tools/apps/projects.js');
+      const result = await updateProjectTool.handler({ id: 1, title: 'x' });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('delete_project', () => {
+    it('should delete and return success', async () => {
+      mockFetchAiquilaAPI.mockResolvedValue(undefined);
+
+      const { deleteProjectTool } = await import('../tools/apps/projects.js');
+      const result = await deleteProjectTool.handler({ id: 1 });
+
+      expect(result.content[0].text).toContain('deleted');
+      expect(mockFetchAiquilaAPI).toHaveBeenCalledWith('/projects/1', { method: 'DELETE' });
+    });
+
+    it('should handle errors', async () => {
+      mockFetchAiquilaAPI.mockRejectedValue(new Error('Not found'));
+
+      const { deleteProjectTool } = await import('../tools/apps/projects.js');
+      const result = await deleteProjectTool.handler({ id: 999 });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('add_project_path', () => {
+    it('should add path and return details', async () => {
+      mockFetchAiquilaAPI.mockResolvedValue({
+        id: 10,
+        projectId: 1,
+        path: '/Documents/report.pdf',
+        pathType: 'file',
+        createdAt: 1700000000,
+      });
+
+      const { addProjectPathTool } = await import('../tools/apps/projects.js');
+      const result = await addProjectPathTool.handler({
+        id: 1,
+        path: '/Documents/report.pdf',
+        pathType: 'file',
+      });
+
+      expect(result.content[0].text).toContain('/Documents/report.pdf');
+      expect(result.content[0].text).toContain('file');
+      expect(mockFetchAiquilaAPI).toHaveBeenCalledWith('/projects/1/paths', {
+        method: 'POST',
+        body: { path: '/Documents/report.pdf', pathType: 'file' },
+      });
+    });
+
+    it('should handle errors', async () => {
+      mockFetchAiquilaAPI.mockRejectedValue(new Error('Path not found'));
+
+      const { addProjectPathTool } = await import('../tools/apps/projects.js');
+      const result = await addProjectPathTool.handler({
+        id: 1,
+        path: '/nonexistent',
+        pathType: 'file',
+      });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('remove_project_path', () => {
+    it('should remove path and return success', async () => {
+      mockFetchAiquilaAPI.mockResolvedValue(undefined);
+
+      const { removeProjectPathTool } = await import('../tools/apps/projects.js');
+      const result = await removeProjectPathTool.handler({ id: 1, pathId: 10 });
+
+      expect(result.content[0].text).toContain('removed');
+      expect(result.content[0].text).toContain('#10');
+      expect(mockFetchAiquilaAPI).toHaveBeenCalledWith('/projects/1/paths/10', {
+        method: 'DELETE',
+      });
+    });
+
+    it('should handle errors', async () => {
+      mockFetchAiquilaAPI.mockRejectedValue(new Error('Not found'));
+
+      const { removeProjectPathTool } = await import('../tools/apps/projects.js');
+      const result = await removeProjectPathTool.handler({ id: 1, pathId: 999 });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/mcp-server/src/__tests__/tools-projects.test.ts
+++ b/mcp-server/src/__tests__/tools-projects.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockFetchAiquilaAPI = vi.fn();

--- a/mcp-server/src/__tests__/tools-recipes.test.ts
+++ b/mcp-server/src/__tests__/tools-recipes.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockClient = {

--- a/mcp-server/src/__tests__/tools-search.test.ts
+++ b/mcp-server/src/__tests__/tools-search.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the OCS client module

--- a/mcp-server/src/__tests__/tools-security.test.ts
+++ b/mcp-server/src/__tests__/tools-security.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockExecuteOCC = vi.fn();

--- a/mcp-server/src/__tests__/tools-security.test.ts
+++ b/mcp-server/src/__tests__/tools-security.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockExecuteOCC = vi.fn();
+
+vi.mock('../client/aiquila.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../client/aiquila.js')>('../client/aiquila.js');
+  return {
+    ...actual,
+    executeOCC: (...args: unknown[]) => mockExecuteOCC(...args),
+  };
+});
+
+describe('Security & Integrity Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXTCLOUD_URL = 'https://cloud.example.com';
+    process.env.NEXTCLOUD_USER = 'admin';
+    process.env.NEXTCLOUD_PASSWORD = 'testpass';
+  });
+
+  describe('check_core_integrity', () => {
+    it('should return success on passing check', async () => {
+      mockExecuteOCC.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+        stdout: '[]',
+        stderr: '',
+      });
+
+      const { checkCoreIntegrityTool } = await import('../tools/system/security.js');
+      const result = await checkCoreIntegrityTool.handler();
+
+      expect(result.content[0].text).toContain('Core integrity check passed');
+      expect(result.isError).toBe(false);
+    });
+
+    it('should report failure with exit code', async () => {
+      mockExecuteOCC.mockResolvedValue({
+        success: false,
+        exitCode: 1,
+        stdout: '{"EXTRA_FILE": {"lib/bad.php": {}}}',
+        stderr: '',
+      });
+
+      const { checkCoreIntegrityTool } = await import('../tools/system/security.js');
+      const result = await checkCoreIntegrityTool.handler();
+
+      expect(result.content[0].text).toContain('found issues');
+      expect(result.content[0].text).toContain('EXTRA_FILE');
+      expect(result.isError).toBe(true);
+    });
+
+    it('should include stderr when present', async () => {
+      mockExecuteOCC.mockResolvedValue({
+        success: false,
+        exitCode: 1,
+        stdout: '',
+        stderr: 'Warning: something went wrong',
+      });
+
+      const { checkCoreIntegrityTool } = await import('../tools/system/security.js');
+      const result = await checkCoreIntegrityTool.handler();
+
+      expect(result.content[0].text).toContain('stderr');
+      expect(result.content[0].text).toContain('Warning: something went wrong');
+    });
+
+    it('should handle thrown errors', async () => {
+      mockExecuteOCC.mockRejectedValue(new Error('Connection refused'));
+
+      const { checkCoreIntegrityTool } = await import('../tools/system/security.js');
+      const result = await checkCoreIntegrityTool.handler();
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Error checking core integrity');
+    });
+  });
+
+  describe('check_app_integrity', () => {
+    it('should return success for a valid app', async () => {
+      mockExecuteOCC.mockResolvedValue({
+        success: true,
+        exitCode: 0,
+        stdout: '[]',
+        stderr: '',
+      });
+
+      const { checkAppIntegrityTool } = await import('../tools/system/security.js');
+      const result = await checkAppIntegrityTool.handler({ appId: 'tasks' });
+
+      expect(result.content[0].text).toContain('"tasks" integrity check passed');
+      expect(result.isError).toBe(false);
+      expect(mockExecuteOCC).toHaveBeenCalledWith('integrity:check-app', ['tasks']);
+    });
+
+    it('should report failure for a tampered app', async () => {
+      mockExecuteOCC.mockResolvedValue({
+        success: false,
+        exitCode: 1,
+        stdout: '{"INVALID_HASH": {"lib/Controller.php": {}}}',
+        stderr: '',
+      });
+
+      const { checkAppIntegrityTool } = await import('../tools/system/security.js');
+      const result = await checkAppIntegrityTool.handler({ appId: 'deck' });
+
+      expect(result.content[0].text).toContain('"deck" integrity check found issues');
+      expect(result.isError).toBe(true);
+    });
+
+    it('should handle thrown errors', async () => {
+      mockExecuteOCC.mockRejectedValue(new Error('OCC not available'));
+
+      const { checkAppIntegrityTool } = await import('../tools/system/security.js');
+      const result = await checkAppIntegrityTool.handler({ appId: 'photos' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Error checking app integrity');
+      expect(result.content[0].text).toContain('"photos"');
+    });
+  });
+});

--- a/mcp-server/src/__tests__/tools-sharing.test.ts
+++ b/mcp-server/src/__tests__/tools-sharing.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockFetchOCS = vi.fn();

--- a/mcp-server/src/__tests__/tools-tasks.test.ts
+++ b/mcp-server/src/__tests__/tools-tasks.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('webdav', () => ({ createClient: vi.fn(() => ({})) }));

--- a/mcp-server/src/__tests__/tools-user-status.test.ts
+++ b/mcp-server/src/__tests__/tools-user-status.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockFetchOCS = vi.fn();

--- a/mcp-server/src/__tests__/tools-users.test.ts
+++ b/mcp-server/src/__tests__/tools-users.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the OCS client module

--- a/mcp-server/src/__tests__/translate.test.ts
+++ b/mcp-server/src/__tests__/translate.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock fetch for OCS

--- a/mcp-server/src/__tests__/transports.test.ts
+++ b/mcp-server/src/__tests__/transports.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock createServer to avoid pulling in all tool dependencies

--- a/mcp-server/src/auth/login.ts
+++ b/mcp-server/src/auth/login.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { NextcloudOAuthProvider, renderLoginForm } from './provider.js';
 import { logger } from '../logger.js';
 

--- a/mcp-server/src/auth/provider.ts
+++ b/mcp-server/src/auth/provider.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { SignJWT, jwtVerify, type JWTPayload } from 'jose';
 import type {

--- a/mcp-server/src/auth/store.ts
+++ b/mcp-server/src/auth/store.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { randomUUID } from 'node:crypto';
 import { readFileSync, writeFileSync, mkdirSync, renameSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';

--- a/mcp-server/src/client/aiquila.ts
+++ b/mcp-server/src/client/aiquila.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { getNextcloudConfig } from '../tools/types.js';
 import { logger } from '../logger.js';
 

--- a/mcp-server/src/client/bookmarks.ts
+++ b/mcp-server/src/client/bookmarks.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { getNextcloudConfig } from '../tools/types.js';
 import { logger } from '../logger.js';
 

--- a/mcp-server/src/client/caldav.ts
+++ b/mcp-server/src/client/caldav.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { logger } from '../logger.js';
 
 /**

--- a/mcp-server/src/client/deck.ts
+++ b/mcp-server/src/client/deck.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { getNextcloudConfig } from '../tools/types.js';
 import { logger } from '../logger.js';
 import { ApiError } from './aiquila.js';

--- a/mcp-server/src/client/mail.ts
+++ b/mcp-server/src/client/mail.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { getNextcloudConfig } from '../tools/types.js';
 import { logger } from '../logger.js';
 

--- a/mcp-server/src/client/maps.ts
+++ b/mcp-server/src/client/maps.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { getNextcloudConfig } from '../tools/types.js';
 import { logger } from '../logger.js';
 

--- a/mcp-server/src/client/notes.ts
+++ b/mcp-server/src/client/notes.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { getNextcloudConfig } from '../tools/types.js';
 import { logger } from '../logger.js';
 import { ApiError } from './aiquila.js';

--- a/mcp-server/src/client/ocs.ts
+++ b/mcp-server/src/client/ocs.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { getNextcloudConfig } from '../tools/types.js';
 import { logger } from '../logger.js';
 

--- a/mcp-server/src/client/webdav.ts
+++ b/mcp-server/src/client/webdav.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { createClient, WebDAVClient } from 'webdav';
 
 const NEXTCLOUD_URL = process.env.NEXTCLOUD_URL;

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// SPDX-License-Identifier: MIT
 
 import { startStdio } from './transports/stdio.js';
 import { startHttp } from './transports/http.js';

--- a/mcp-server/src/logger.ts
+++ b/mcp-server/src/logger.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import pino from 'pino';
 
 export const logger = pino({ level: process.env.LOG_LEVEL ?? 'info' }, process.stderr);

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { createRequire } from 'node:module';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { logger } from './logger.js';

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { fetchOCS } from './client/ocs.js';
 import { logger } from './logger.js';
 

--- a/mcp-server/src/tools/apps/absence.ts
+++ b/mcp-server/src/tools/apps/absence.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchOCS } from '../../client/ocs.js';
 import { getNextcloudConfig } from '../types.js';

--- a/mcp-server/src/tools/apps/aiquila.ts
+++ b/mcp-server/src/tools/apps/aiquila.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { executeOCC } from '../../client/aiquila.js';
 

--- a/mcp-server/src/tools/apps/assistant.ts
+++ b/mcp-server/src/tools/apps/assistant.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchOCS } from '../../client/ocs.js';
 

--- a/mcp-server/src/tools/apps/bookmarks.ts
+++ b/mcp-server/src/tools/apps/bookmarks.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchBookmarksAPI } from '../../client/bookmarks.js';
 

--- a/mcp-server/src/tools/apps/calendar.ts
+++ b/mcp-server/src/tools/apps/calendar.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { decodeXmlEntities, fetchCalDAV, nsTagContent } from '../../client/caldav.js';
+import { escapeICalValue, unescapeICalValue } from '../dav-utils.js';
 import { getNextcloudConfig } from '../types.js';
 
 /**
@@ -64,22 +65,6 @@ interface ParsedAttendee {
 
 function unfoldICalLines(text: string): string {
   return text.replace(/\r?\n[ \t]/g, '');
-}
-
-function escapeICalValue(value: string): string {
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/;/g, '\\;')
-    .replace(/,/g, '\\,')
-    .replace(/\n/g, '\\n');
-}
-
-function unescapeICalValue(value: string): string {
-  return value
-    .replace(/\\n/g, '\n')
-    .replace(/\\,/g, ',')
-    .replace(/\\;/g, ';')
-    .replace(/\\\\/g, '\\');
 }
 
 function formatICalDate(icalDate: string): string {

--- a/mcp-server/src/tools/apps/calendar.ts
+++ b/mcp-server/src/tools/apps/calendar.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { decodeXmlEntities, fetchCalDAV, nsTagContent } from '../../client/caldav.js';
 import { escapeICalValue, unescapeICalValue } from '../dav-utils.js';

--- a/mcp-server/src/tools/apps/circles.ts
+++ b/mcp-server/src/tools/apps/circles.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchOCS } from '../../client/ocs.js';
 

--- a/mcp-server/src/tools/apps/contacts.ts
+++ b/mcp-server/src/tools/apps/contacts.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { decodeXmlEntities, fetchCalDAV, nsTagContent } from '../../client/caldav.js';
+import { escapeVCardValue, unescapeVCardValue } from '../dav-utils.js';
 import { getNextcloudConfig } from '../types.js';
 
 /**
@@ -63,22 +64,6 @@ interface ParsedContact {
 
 function unfoldVCardLines(text: string): string {
   return text.replace(/\r?\n[ \t]/g, '');
-}
-
-function escapeVCardValue(value: string): string {
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/;/g, '\\;')
-    .replace(/,/g, '\\,')
-    .replace(/\n/g, '\\n');
-}
-
-function unescapeVCardValue(value: string): string {
-  return value
-    .replace(/\\n/gi, '\n')
-    .replace(/\\,/g, ',')
-    .replace(/\\;/g, ';')
-    .replace(/\\\\/g, '\\');
 }
 
 /**

--- a/mcp-server/src/tools/apps/contacts.ts
+++ b/mcp-server/src/tools/apps/contacts.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { decodeXmlEntities, fetchCalDAV, nsTagContent } from '../../client/caldav.js';
 import { escapeVCardValue, unescapeVCardValue } from '../dav-utils.js';

--- a/mcp-server/src/tools/apps/cookbook.ts
+++ b/mcp-server/src/tools/apps/cookbook.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { getWebDAVClient } from '../../client/webdav.js';
 

--- a/mcp-server/src/tools/apps/deck.ts
+++ b/mcp-server/src/tools/apps/deck.ts
@@ -7,11 +7,18 @@ import {
   type DeckLabel,
 } from '../../client/deck.js';
 import { ApiError } from '../../client/aiquila.js';
+import { handleAppError } from '../error-utils.js';
 
 /**
  * Nextcloud Deck App Tools
  * Uses the Deck REST API v1.0 (/index.php/apps/deck/api/v1.0)
  */
+
+const deckStatusMap: Record<number, string | ((e: ApiError) => string)> = {
+  404: 'Not found.',
+  403: 'Permission denied.',
+  400: (e) => `Bad request: ${e.responseBody}`,
+};
 
 function formatBoard(board: DeckBoard): string {
   const flags = [
@@ -72,35 +79,6 @@ function formatCardDetail(card: DeckCard): string {
   return lines.join('\n');
 }
 
-function handleError(
-  error: unknown,
-  context: string
-): { content: { type: 'text'; text: string }[]; isError: true } {
-  if (error instanceof ApiError) {
-    if (error.statusCode === 404) {
-      return { content: [{ type: 'text', text: 'Not found.' }], isError: true };
-    }
-    if (error.statusCode === 403) {
-      return { content: [{ type: 'text', text: 'Permission denied.' }], isError: true };
-    }
-    if (error.statusCode === 400) {
-      return {
-        content: [{ type: 'text', text: `Bad request: ${error.responseBody}` }],
-        isError: true,
-      };
-    }
-  }
-  return {
-    content: [
-      {
-        type: 'text',
-        text: `${context}: ${error instanceof Error ? error.message : String(error)}`,
-      },
-    ],
-    isError: true,
-  };
-}
-
 export const listBoardsTool = {
   name: 'deck_list_boards',
   description: 'List all Deck boards. Returns id, title, owner, and label count for each board.',
@@ -122,7 +100,7 @@ export const listBoardsTool = {
         ],
       };
     } catch (error) {
-      return handleError(error, 'Error listing boards');
+      return handleAppError(error, 'Error listing boards', deckStatusMap);
     }
   },
 };
@@ -171,7 +149,7 @@ export const getBoardTool = {
 
       return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
     } catch (error) {
-      return handleError(error, 'Error getting board');
+      return handleAppError(error, 'Error getting board', deckStatusMap);
     }
   },
 };
@@ -197,7 +175,7 @@ export const createBoardTool = {
         content: [{ type: 'text' as const, text: `Board created: ${formatBoard(board)}` }],
       };
     } catch (error) {
-      return handleError(error, 'Error creating board');
+      return handleAppError(error, 'Error creating board', deckStatusMap);
     }
   },
 };
@@ -240,7 +218,7 @@ export const listStacksTool = {
         ],
       };
     } catch (error) {
-      return handleError(error, 'Error listing stacks');
+      return handleAppError(error, 'Error listing stacks', deckStatusMap);
     }
   },
 };
@@ -264,7 +242,7 @@ export const createStackTool = {
         content: [{ type: 'text' as const, text: `Stack created: ${formatStack(stack)}` }],
       };
     } catch (error) {
-      return handleError(error, 'Error creating stack');
+      return handleAppError(error, 'Error creating stack', deckStatusMap);
     }
   },
 };
@@ -285,7 +263,7 @@ export const getCardTool = {
 
       return { content: [{ type: 'text' as const, text: formatCardDetail(card) }] };
     } catch (error) {
-      return handleError(error, 'Error getting card');
+      return handleAppError(error, 'Error getting card', deckStatusMap);
     }
   },
 };
@@ -325,7 +303,7 @@ export const createCardTool = {
         content: [{ type: 'text' as const, text: `Card created: ${formatCard(card)}` }],
       };
     } catch (error) {
-      return handleError(error, 'Error creating card');
+      return handleAppError(error, 'Error creating card', deckStatusMap);
     }
   },
 };
@@ -373,7 +351,7 @@ export const updateCardTool = {
         content: [{ type: 'text' as const, text: `Card updated: ${formatCard(updated)}` }],
       };
     } catch (error) {
-      return handleError(error, 'Error updating card');
+      return handleAppError(error, 'Error updating card', deckStatusMap);
     }
   },
 };
@@ -418,7 +396,7 @@ export const moveCardTool = {
         ],
       };
     } catch (error) {
-      return handleError(error, 'Error moving card');
+      return handleAppError(error, 'Error moving card', deckStatusMap);
     }
   },
 };
@@ -449,7 +427,11 @@ export const archiveCardTool = {
         ],
       };
     } catch (error) {
-      return handleError(error, `Error ${args.archive ? 'archiving' : 'unarchiving'} card`);
+      return handleAppError(
+        error,
+        `Error ${args.archive ? 'archiving' : 'unarchiving'} card`,
+        deckStatusMap
+      );
     }
   },
 };
@@ -480,7 +462,7 @@ export const assignLabelTool = {
         ],
       };
     } catch (error) {
-      return handleError(error, 'Error assigning label');
+      return handleAppError(error, 'Error assigning label', deckStatusMap);
     }
   },
 };
@@ -510,7 +492,7 @@ export const assignUserTool = {
         ],
       };
     } catch (error) {
-      return handleError(error, 'Error assigning user');
+      return handleAppError(error, 'Error assigning user', deckStatusMap);
     }
   },
 };

--- a/mcp-server/src/tools/apps/deck.ts
+++ b/mcp-server/src/tools/apps/deck.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import {
   fetchDeckAPI,

--- a/mcp-server/src/tools/apps/groups.ts
+++ b/mcp-server/src/tools/apps/groups.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchOCS } from '../../client/ocs.js';
 

--- a/mcp-server/src/tools/apps/mail.ts
+++ b/mcp-server/src/tools/apps/mail.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchMailAPI } from '../../client/mail.js';
 import { fetchOCS } from '../../client/ocs.js';

--- a/mcp-server/src/tools/apps/maps.ts
+++ b/mcp-server/src/tools/apps/maps.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchMapsExternalAPI, fetchMapsAPI } from '../../client/maps.js';
 

--- a/mcp-server/src/tools/apps/notes.ts
+++ b/mcp-server/src/tools/apps/notes.ts
@@ -1,11 +1,17 @@
 import { z } from 'zod';
 import { fetchNotesAPI, type Note } from '../../client/notes.js';
-import { ApiError } from '../../client/aiquila.js';
+import { handleAppError } from '../error-utils.js';
 
 /**
  * Nextcloud Notes App Tools
  * Uses the Notes REST API v1 (/index.php/apps/notes/api/v1)
  */
+
+const notesStatusMap: Record<number, string> = {
+  404: 'Note not found.',
+  403: 'Note is read-only.',
+  412: 'Conflict: note was modified by someone else. Fetch the latest version and retry.',
+};
 
 function formatNote(note: Note): string {
   const date = new Date(note.modified * 1000).toISOString();
@@ -16,40 +22,6 @@ function formatNote(note: Note): string {
     .filter(Boolean)
     .join(' | ');
   return `[${note.id}] ${note.title}${meta ? ` (${meta})` : ''} — modified: ${date}`;
-}
-
-function handleError(
-  error: unknown,
-  context: string
-): { content: { type: 'text'; text: string }[]; isError: true } {
-  if (error instanceof ApiError) {
-    if (error.statusCode === 404) {
-      return { content: [{ type: 'text', text: `Note not found.` }], isError: true };
-    }
-    if (error.statusCode === 403) {
-      return { content: [{ type: 'text', text: `Note is read-only.` }], isError: true };
-    }
-    if (error.statusCode === 412) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Conflict: note was modified by someone else. Fetch the latest version and retry.`,
-          },
-        ],
-        isError: true,
-      };
-    }
-  }
-  return {
-    content: [
-      {
-        type: 'text',
-        text: `${context}: ${error instanceof Error ? error.message : String(error)}`,
-      },
-    ],
-    isError: true,
-  };
 }
 
 export const listNotesTool = {
@@ -85,7 +57,7 @@ export const listNotesTool = {
         ],
       };
     } catch (error) {
-      return handleError(error, 'Error listing notes');
+      return handleAppError(error, 'Error listing notes', notesStatusMap);
     }
   },
 };
@@ -108,7 +80,7 @@ export const getNoteTool = {
         ],
       };
     } catch (error) {
-      return handleError(error, 'Error getting note');
+      return handleAppError(error, 'Error getting note', notesStatusMap);
     }
   },
 };
@@ -147,7 +119,7 @@ export const createNoteTool = {
         ],
       };
     } catch (error) {
-      return handleError(error, 'Error creating note');
+      return handleAppError(error, 'Error creating note', notesStatusMap);
     }
   },
 };
@@ -191,7 +163,7 @@ export const updateNoteTool = {
         ],
       };
     } catch (error) {
-      return handleError(error, 'Error updating note');
+      return handleAppError(error, 'Error updating note', notesStatusMap);
     }
   },
 };
@@ -214,7 +186,7 @@ export const deleteNoteTool = {
         ],
       };
     } catch (error) {
-      return handleError(error, 'Error deleting note');
+      return handleAppError(error, 'Error deleting note', notesStatusMap);
     }
   },
 };

--- a/mcp-server/src/tools/apps/notes.ts
+++ b/mcp-server/src/tools/apps/notes.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchNotesAPI, type Note } from '../../client/notes.js';
 import { handleAppError } from '../error-utils.js';

--- a/mcp-server/src/tools/apps/notifications.ts
+++ b/mcp-server/src/tools/apps/notifications.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchOCS } from '../../client/ocs.js';
 

--- a/mcp-server/src/tools/apps/photos.ts
+++ b/mcp-server/src/tools/apps/photos.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchCalDAV, nsTagContent, decodeXmlEntities } from '../../client/caldav.js';
 import { getNextcloudConfig } from '../types.js';

--- a/mcp-server/src/tools/apps/projects.ts
+++ b/mcp-server/src/tools/apps/projects.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchAiquilaAPI } from '../../client/aiquila.js';
 

--- a/mcp-server/src/tools/apps/shares.ts
+++ b/mcp-server/src/tools/apps/shares.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchOCS } from '../../client/ocs.js';
 

--- a/mcp-server/src/tools/apps/talk.ts
+++ b/mcp-server/src/tools/apps/talk.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchOCS } from '../../client/ocs.js';
 

--- a/mcp-server/src/tools/apps/tasks.ts
+++ b/mcp-server/src/tools/apps/tasks.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { decodeXmlEntities, fetchCalDAV, nsTagContent } from '../../client/caldav.js';
 import { escapeICalValue } from '../dav-utils.js';

--- a/mcp-server/src/tools/apps/tasks.ts
+++ b/mcp-server/src/tools/apps/tasks.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { decodeXmlEntities, fetchCalDAV, nsTagContent } from '../../client/caldav.js';
+import { escapeICalValue } from '../dav-utils.js';
 import { getNextcloudConfig } from '../types.js';
 
 /**
@@ -50,17 +51,6 @@ interface ParsedTask {
  */
 function unfoldICalLines(text: string): string {
   return text.replace(/\r?\n[ \t]/g, '');
-}
-
-/**
- * Escape special characters in iCalendar text values per RFC 5545.
- */
-function escapeICalValue(value: string): string {
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/;/g, '\\;')
-    .replace(/,/g, '\\,')
-    .replace(/\n/g, '\\n');
 }
 
 /**

--- a/mcp-server/src/tools/apps/translate.ts
+++ b/mcp-server/src/tools/apps/translate.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchOCS } from '../../client/ocs.js';
 

--- a/mcp-server/src/tools/apps/trash.ts
+++ b/mcp-server/src/tools/apps/trash.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchCalDAV, decodeXmlEntities } from '../../client/caldav.js';
 import { getNextcloudConfig } from '../types.js';

--- a/mcp-server/src/tools/apps/user-status.ts
+++ b/mcp-server/src/tools/apps/user-status.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchOCS } from '../../client/ocs.js';
 

--- a/mcp-server/src/tools/apps/users.ts
+++ b/mcp-server/src/tools/apps/users.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchOCS } from '../../client/ocs.js';
 

--- a/mcp-server/src/tools/apps/versions.ts
+++ b/mcp-server/src/tools/apps/versions.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchCalDAV } from '../../client/caldav.js';
 import { getNextcloudConfig } from '../types.js';

--- a/mcp-server/src/tools/dav-utils.ts
+++ b/mcp-server/src/tools/dav-utils.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared DAV escape/unescape utilities for iCalendar and vCard values.
+ *
+ * iCalendar (RFC 5545) and vCard (RFC 6350) use nearly identical text escaping.
+ * The only difference: vCard allows uppercase \N for newlines, so unescape is
+ * case-insensitive for that sequence.
+ */
+
+export function escapeDavValue(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\n/g, '\\n');
+}
+
+export function unescapeDavValue(
+  value: string,
+  options?: { caseInsensitiveNewline?: boolean }
+): string {
+  return value
+    .replace(options?.caseInsensitiveNewline ? /\\n/gi : /\\n/g, '\n')
+    .replace(/\\,/g, ',')
+    .replace(/\\;/g, ';')
+    .replace(/\\\\/g, '\\');
+}
+
+/** Escape for iCalendar (VEVENT, VTODO) properties. */
+export const escapeICalValue = escapeDavValue;
+
+/** Unescape iCalendar property values (case-sensitive \\n). */
+export const unescapeICalValue = (value: string) => unescapeDavValue(value);
+
+/** Escape for vCard properties. */
+export const escapeVCardValue = escapeDavValue;
+
+/** Unescape vCard property values (case-insensitive \\n per RFC 6350). */
+export const unescapeVCardValue = (value: string) =>
+  unescapeDavValue(value, { caseInsensitiveNewline: true });

--- a/mcp-server/src/tools/dav-utils.ts
+++ b/mcp-server/src/tools/dav-utils.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 /**
  * Shared DAV escape/unescape utilities for iCalendar and vCard values.
  *

--- a/mcp-server/src/tools/error-utils.ts
+++ b/mcp-server/src/tools/error-utils.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { ApiError } from '../client/aiquila.js';
 
 type ErrorResult = { content: { type: 'text'; text: string }[]; isError: true };

--- a/mcp-server/src/tools/error-utils.ts
+++ b/mcp-server/src/tools/error-utils.ts
@@ -1,0 +1,36 @@
+import { ApiError } from '../client/aiquila.js';
+
+type ErrorResult = { content: { type: 'text'; text: string }[]; isError: true };
+
+/**
+ * Shared error handler for app tool modules.
+ *
+ * @param error     The caught error
+ * @param context   Human-readable context prefixed to generic messages (e.g. "Error listing notes")
+ * @param statusMap Optional map of HTTP status codes to user-facing messages.
+ *                  When the error is an ApiError whose status matches a key, the corresponding
+ *                  message is returned. The message may be a string or a function receiving the
+ *                  ApiError for dynamic messages (e.g. including the response body).
+ */
+export function handleAppError(
+  error: unknown,
+  context: string,
+  statusMap: Record<number, string | ((e: ApiError) => string)> = {}
+): ErrorResult {
+  if (error instanceof ApiError) {
+    const entry = statusMap[error.statusCode];
+    if (entry !== undefined) {
+      const text = typeof entry === 'function' ? entry(error) : entry;
+      return { content: [{ type: 'text', text }], isError: true };
+    }
+  }
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `${context}: ${error instanceof Error ? error.message : String(error)}`,
+      },
+    ],
+    isError: true,
+  };
+}

--- a/mcp-server/src/tools/system/apps.ts
+++ b/mcp-server/src/tools/system/apps.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchOCS } from '../../client/ocs.js';
 import { executeOCC } from '../../client/aiquila.js';

--- a/mcp-server/src/tools/system/files.ts
+++ b/mcp-server/src/tools/system/files.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { getWebDAVClient } from '../../client/webdav.js';
 import { fetchAiquilaAPI } from '../../client/aiquila.js';

--- a/mcp-server/src/tools/system/occ-redact.ts
+++ b/mcp-server/src/tools/system/occ-redact.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 /**
  * Redacts sensitive information from OCC command output.
  * Applied to stdout/stderr before returning results to the MCP client.

--- a/mcp-server/src/tools/system/occ.ts
+++ b/mcp-server/src/tools/system/occ.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { executeOCC, formatOccError } from '../../client/aiquila.js';
 import { redactSensitiveOutput } from './occ-redact.js';

--- a/mcp-server/src/tools/system/search.ts
+++ b/mcp-server/src/tools/system/search.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchOCS } from '../../client/ocs.js';
 

--- a/mcp-server/src/tools/system/security.ts
+++ b/mcp-server/src/tools/system/security.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { executeOCC, formatOccError } from '../../client/aiquila.js';
 

--- a/mcp-server/src/tools/system/status.ts
+++ b/mcp-server/src/tools/system/status.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchOCS, fetchStatus } from '../../client/ocs.js';
 import { executeOCC, formatOccError } from '../../client/aiquila.js';

--- a/mcp-server/src/tools/system/tags.ts
+++ b/mcp-server/src/tools/system/tags.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 import { fetchCalDAV } from '../../client/caldav.js';
 import { getNextcloudConfig } from '../types.js';

--- a/mcp-server/src/tools/types.ts
+++ b/mcp-server/src/tools/types.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { z } from 'zod';
 
 /**

--- a/mcp-server/src/tools/types.ts
+++ b/mcp-server/src/tools/types.ts
@@ -5,16 +5,6 @@ import { z } from 'zod';
  */
 
 /**
- * Standard response format for tool operations
- */
-export interface ToolResponse {
-  success: boolean;
-  message?: string;
-  data?: unknown;
-  error?: string;
-}
-
-/**
  * Zod schemas for common parameters
  */
 

--- a/mcp-server/src/transports/http.ts
+++ b/mcp-server/src/transports/http.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import https from 'node:https';
 import express from 'express';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';

--- a/mcp-server/src/transports/stdio.ts
+++ b/mcp-server/src/transports/stdio.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { createServer } from '../server.js';
 import { logger } from '../logger.js';

--- a/nextcloud-app/lib/AppInfo/Application.php
+++ b/nextcloud-app/lib/AppInfo/Application.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace OCA\AIquila\AppInfo;
 

--- a/nextcloud-app/lib/Capabilities/AIquilaCapability.php
+++ b/nextcloud-app/lib/Capabilities/AIquilaCapability.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Command/ConfigureCommand.php
+++ b/nextcloud-app/lib/Command/ConfigureCommand.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace OCA\AIquila\Command;
 

--- a/nextcloud-app/lib/Command/McpAddCommand.php
+++ b/nextcloud-app/lib/Command/McpAddCommand.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Command/TestSDKCommand.php
+++ b/nextcloud-app/lib/Command/TestSDKCommand.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace OCA\AIquila\Command;
 

--- a/nextcloud-app/lib/Controller/ChatController.php
+++ b/nextcloud-app/lib/Controller/ChatController.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace OCA\AIquila\Controller;
 

--- a/nextcloud-app/lib/Controller/ConversationController.php
+++ b/nextcloud-app/lib/Controller/ConversationController.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Controller/FileController.php
+++ b/nextcloud-app/lib/Controller/FileController.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace OCA\AIquila\Controller;
 

--- a/nextcloud-app/lib/Controller/McpServerController.php
+++ b/nextcloud-app/lib/Controller/McpServerController.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Controller/OccController.php
+++ b/nextcloud-app/lib/Controller/OccController.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace OCA\AIquila\Controller;
 

--- a/nextcloud-app/lib/Controller/PageController.php
+++ b/nextcloud-app/lib/Controller/PageController.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Controller/ProjectController.php
+++ b/nextcloud-app/lib/Controller/ProjectController.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Controller/SettingsController.php
+++ b/nextcloud-app/lib/Controller/SettingsController.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace OCA\AIquila\Controller;
 

--- a/nextcloud-app/lib/Db/Conversation.php
+++ b/nextcloud-app/lib/Db/Conversation.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/ConversationMapper.php
+++ b/nextcloud-app/lib/Db/ConversationMapper.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/Coworker.php
+++ b/nextcloud-app/lib/Db/Coworker.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/CoworkerMapper.php
+++ b/nextcloud-app/lib/Db/CoworkerMapper.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/McpServer.php
+++ b/nextcloud-app/lib/Db/McpServer.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/McpServerMapper.php
+++ b/nextcloud-app/lib/Db/McpServerMapper.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/Message.php
+++ b/nextcloud-app/lib/Db/Message.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/MessageFile.php
+++ b/nextcloud-app/lib/Db/MessageFile.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/MessageFileMapper.php
+++ b/nextcloud-app/lib/Db/MessageFileMapper.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/MessageMapper.php
+++ b/nextcloud-app/lib/Db/MessageMapper.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/Project.php
+++ b/nextcloud-app/lib/Db/Project.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/ProjectMapper.php
+++ b/nextcloud-app/lib/Db/ProjectMapper.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/ProjectPath.php
+++ b/nextcloud-app/lib/Db/ProjectPath.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/ProjectPathMapper.php
+++ b/nextcloud-app/lib/Db/ProjectPathMapper.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/Prompt.php
+++ b/nextcloud-app/lib/Db/Prompt.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/PromptMapper.php
+++ b/nextcloud-app/lib/Db/PromptMapper.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/UsageStat.php
+++ b/nextcloud-app/lib/Db/UsageStat.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Db/UsageStatMapper.php
+++ b/nextcloud-app/lib/Db/UsageStatMapper.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Listener/TaskFailedListener.php
+++ b/nextcloud-app/lib/Listener/TaskFailedListener.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Listener/TaskSuccessfulListener.php
+++ b/nextcloud-app/lib/Listener/TaskSuccessfulListener.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Migration/RepairEncryptMcpTokens.php
+++ b/nextcloud-app/lib/Migration/RepairEncryptMcpTokens.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Migration/Version0001Date20260218000000.php
+++ b/nextcloud-app/lib/Migration/Version0001Date20260218000000.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Migration/Version0002Date20260315000000.php
+++ b/nextcloud-app/lib/Migration/Version0002Date20260315000000.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Migration/Version0003Date20260320000000.php
+++ b/nextcloud-app/lib/Migration/Version0003Date20260320000000.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Migration/Version0004Date20260331000000.php
+++ b/nextcloud-app/lib/Migration/Version0004Date20260331000000.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Notifier/AIquilaNotifier.php
+++ b/nextcloud-app/lib/Notifier/AIquilaNotifier.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Public/IAIquila.php
+++ b/nextcloud-app/lib/Public/IAIquila.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace OCA\AIquila\Public;
 

--- a/nextcloud-app/lib/Search/AiquilaSearchProvider.php
+++ b/nextcloud-app/lib/Search/AiquilaSearchProvider.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Service/AIquilaService.php
+++ b/nextcloud-app/lib/Service/AIquilaService.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace OCA\AIquila\Service;
 

--- a/nextcloud-app/lib/Service/ClaudeModels.php
+++ b/nextcloud-app/lib/Service/ClaudeModels.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace OCA\AIquila\Service;
 

--- a/nextcloud-app/lib/Service/ClaudeSDKService.php
+++ b/nextcloud-app/lib/Service/ClaudeSDKService.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace OCA\AIquila\Service;
 

--- a/nextcloud-app/lib/Service/CredentialService.php
+++ b/nextcloud-app/lib/Service/CredentialService.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Service/FileService.php
+++ b/nextcloud-app/lib/Service/FileService.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace OCA\AIquila\Service;
 

--- a/nextcloud-app/lib/Service/ImageOptimizer.php
+++ b/nextcloud-app/lib/Service/ImageOptimizer.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Service/McpClientService.php
+++ b/nextcloud-app/lib/Service/McpClientService.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Settings/AdminDeclarativeSettings.php
+++ b/nextcloud-app/lib/Settings/AdminDeclarativeSettings.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Settings/AdminSection.php
+++ b/nextcloud-app/lib/Settings/AdminSection.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace OCA\AIquila\Settings;
 

--- a/nextcloud-app/lib/Settings/AdminSettings.php
+++ b/nextcloud-app/lib/Settings/AdminSettings.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace OCA\AIquila\Settings;
 

--- a/nextcloud-app/lib/Settings/UserDeclarativeSettings.php
+++ b/nextcloud-app/lib/Settings/UserDeclarativeSettings.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/Settings/UserSettings.php
+++ b/nextcloud-app/lib/Settings/UserSettings.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace OCA\AIquila\Settings;
 

--- a/nextcloud-app/lib/SetupCheck/AnthropicApiReachable.php
+++ b/nextcloud-app/lib/SetupCheck/AnthropicApiReachable.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/SetupCheck/ApiKeyConfigured.php
+++ b/nextcloud-app/lib/SetupCheck/ApiKeyConfigured.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/SetupCheck/PhpExtensions.php
+++ b/nextcloud-app/lib/SetupCheck/PhpExtensions.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeAnalyzeImagesProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeAnalyzeImagesProvider.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeChangeToneProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeChangeToneProvider.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeFormalizationProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeFormalizationProvider.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeHeadlineProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeHeadlineProvider.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeImageToTextProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeImageToTextProvider.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeProofreadProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeProofreadProvider.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeReformulationProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeReformulationProvider.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeSimplificationProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeSimplificationProvider.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeSummaryProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeSummaryProvider.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeTextToTextProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeTextToTextProvider.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeTopicsProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeTopicsProvider.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeTranslateProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeTranslateProvider.php
@@ -1,4 +1,5 @@
 <?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 

--- a/nextcloud-app/src/App.vue
+++ b/nextcloud-app/src/App.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
 	<NcContent app-name="aiquila">
 		<NcAppNavigation>

--- a/nextcloud-app/src/api.js
+++ b/nextcloud-app/src/api.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 

--- a/nextcloud-app/src/components/AskClaudeModal.vue
+++ b/nextcloud-app/src/components/AskClaudeModal.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
 	<NcModal
 		:name="t('aiquila', 'Ask Claude about {filename}', { filename: file.basename })"

--- a/nextcloud-app/src/components/ChatInput.vue
+++ b/nextcloud-app/src/components/ChatInput.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
 	<div class="chat-input"
 		@dragover.prevent="onDragOver"

--- a/nextcloud-app/src/components/ChatSidebar.vue
+++ b/nextcloud-app/src/components/ChatSidebar.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
 	<div style="display: contents">
 	<NcAppNavigationNew :text="t('aiquila', 'New chat')"

--- a/nextcloud-app/src/components/ChatView.vue
+++ b/nextcloud-app/src/components/ChatView.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
 	<div class="chat-view">
 		<div v-if="conversation.projectId && projectName" class="project-badge">

--- a/nextcloud-app/src/components/CoworkSidebar.vue
+++ b/nextcloud-app/src/components/CoworkSidebar.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
 	<div class="cowork-sidebar">
 		<div class="sidebar-header">

--- a/nextcloud-app/src/components/CoworkView.vue
+++ b/nextcloud-app/src/components/CoworkView.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
 	<div class="cowork-view">
 		<div class="cowork-header">

--- a/nextcloud-app/src/components/MessageBubble.vue
+++ b/nextcloud-app/src/components/MessageBubble.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
 	<div :class="['message-bubble', `message-${message.role}`]">
 		<div class="message-header">

--- a/nextcloud-app/src/components/NavigationSettings.vue
+++ b/nextcloud-app/src/components/NavigationSettings.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
 	<div class="nav-settings">
 		<details class="settings-section" open>

--- a/nextcloud-app/src/components/ProjectEditor.vue
+++ b/nextcloud-app/src/components/ProjectEditor.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
 	<div v-if="project" class="project-editor">
 		<h2 class="editor-title">{{ project.title }}</h2>

--- a/nextcloud-app/src/components/ProjectManager.vue
+++ b/nextcloud-app/src/components/ProjectManager.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
 	<NcDialog :name="t('aiquila', 'Manage Projects')"
 		size="normal"

--- a/nextcloud-app/src/components/ProjectSidebar.vue
+++ b/nextcloud-app/src/components/ProjectSidebar.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
 	<div style="display: contents">
 	<NcAppNavigationNew :text="t('aiquila', 'New project')"

--- a/nextcloud-app/src/components/TabSelector.vue
+++ b/nextcloud-app/src/components/TabSelector.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
 	<div class="tab-selector">
 		<button v-for="tab in tabs"

--- a/nextcloud-app/src/fileactions-simple.js
+++ b/nextcloud-app/src/fileactions-simple.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * AIquila File Actions - Simple Implementation
  * Registers "Ask Claude" action in Files app without Vue dependencies

--- a/nextcloud-app/src/fileactions.js
+++ b/nextcloud-app/src/fileactions.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * AIquila File Actions - Modern Vue Implementation
  * Registers "Ask Claude" action in Files app

--- a/nextcloud-app/src/main.js
+++ b/nextcloud-app/src/main.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import { createApp } from 'vue'
 import App from './App.vue'
 

--- a/nextcloud-app/src/styles/markdown.css
+++ b/nextcloud-app/src/styles/markdown.css
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: AGPL-3.0-or-later */
+
 /* Markdown content styles for MessageBubble */
 
 .markdown-body {

--- a/nextcloud-app/src/utils/markdown.js
+++ b/nextcloud-app/src/utils/markdown.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import { marked } from 'marked'
 import hljs from 'highlight.js/lib/core'
 


### PR DESCRIPTION
## Summary
- Remove build failure masking in CI so TypeScript compilation errors properly fail the workflow
- Run Docker container as non-root user and add HEALTHCHECK
- Remove unused `ToolResponse` interface
- Extract shared DAV escape/unescape utilities and error handler for notes/deck
- Add unit tests for previously untested tools and improve server.test.ts
- Pin Docker image tags in dev compose files
- Add `-u` flag to shell scripts for undefined variable safety
- Update README MCP description
- Add SPDX license headers to all 200 source files

Closes #273, closes #274, closes #275, closes #276, closes #277, closes #278, closes #279, closes #280, closes #281, closes #282, closes #283, closes #284

## Test plan
- [ ] CI passes (lint, prettier, tests, build)
- [ ] `npm test` in `mcp-server/` passes
- [ ] SPDX headers present in all source files
- [ ] Docker image runs as non-root (`docker inspect`)
- [ ] HEALTHCHECK configured in image

🤖 Generated with [Claude Code](https://claude.com/claude-code)