### PR TITLE
fix: NC34 compat, version bump to 0.2.18, sync & cleanup

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,12 +1,12 @@
 # AIquila MCP Server
 
-MCP (Model Context Protocol) server that gives Claude full access to your Nextcloud instance — files, calendar, tasks, contacts, mail, maps, bookmarks, notes, and more. 126 tools across 20 categories.
+MCP (Model Context Protocol) server that gives any MCP client full access to your Nextcloud instance — files, calendar, tasks, contacts, mail, talk, maps, bookmarks, notes, and more. 198 tools across 31 categories.
 
 ## Quick Start
 
-### Claude Desktop (stdio)
+### Stdio (Claude Desktop, Claude Code, Cursor, etc.)
 
-Add to `~/.config/claude/claude_desktop_config.json`:
+Add to your MCP client configuration (example for Claude Desktop `~/.config/claude/claude_desktop_config.json`):
 
 ```json
 {
@@ -26,35 +26,58 @@ Add to `~/.config/claude/claude_desktop_config.json`:
 
 Generate an App Password in Nextcloud: **Settings → Security → Devices & sessions**.
 
-### Docker / Claude.ai / Claude Mobile (HTTP transport)
+### HTTP Transport (Docker, Claude.ai, remote clients)
 
-See the [Docker setup guide](https://github.com/elgorro/aiquila/blob/main/docs/mcp/setup.md#docker--claudeai-http-transport) for running AIquila as an HTTP server with OAuth for Claude.ai and Claude Mobile.
+See the [Docker setup guide](https://github.com/elgorro/aiquila/blob/main/docs/mcp/setup.md#docker--claudeai-http-transport) for running AIquila as an HTTP server with OAuth for remote MCP clients.
 
 ## What It Can Do
 
-| Category             |   Tools |
-| -------------------- | ------: |
-| Files                |      11 |
-| Status & Diagnostics |       3 |
-| App Management       |       6 |
-| Tags                 |       6 |
-| Security             |       2 |
-| Search               |       2 |
-| OCC Command          |       1 |
-| Shares               |       4 |
-| Tasks                |       6 |
-| Calendar             |       6 |
-| Notes                |       5 |
-| Contacts             |       6 |
-| Cookbook             |       6 |
-| Bookmarks            |      13 |
-| Mail                 |       8 |
-| Maps                 |      26 |
-| Assistant / AI       |       4 |
-| Users                |       4 |
-| Groups               |       4 |
-| AIquila              |       3 |
-| **Total**            | **126** |
+### Core (always available)
+
+| Category   | Tools |
+| ---------- | ----: |
+| Files      |    12 |
+| Status     |     3 |
+| Apps       |     6 |
+| Tags       |     6 |
+| Search     |     2 |
+| Users      |     4 |
+| Groups     |     4 |
+| Shares     |    10 |
+| Absence    |     3 |
+| Trash      |     3 |
+| Versions   |     2 |
+
+### AIquila app
+
+| Category   | Tools |
+| ---------- | ----: |
+| AIquila    |     3 |
+| Security   |     2 |
+| OCC        |     1 |
+| Projects   |     7 |
+
+### Optional Nextcloud apps
+
+| Category      | Tools |
+| ------------- | ----: |
+| Calendar      |     6 |
+| Tasks         |     6 |
+| Contacts      |     6 |
+| Notes         |     5 |
+| Mail          |     8 |
+| Deck          |    12 |
+| Cookbook       |     6 |
+| Maps          |    25 |
+| Photos        |    11 |
+| Talk          |    10 |
+| Circles       |     8 |
+| Bookmarks     |    13 |
+| Assistant     |     4 |
+| Translate     |     1 |
+| User Status   |     5 |
+| Notifications |     4 |
+| **Total**     | **198** |
 
 ## Configuration
 
@@ -64,7 +87,7 @@ See the [Docker setup guide](https://github.com/elgorro/aiquila/blob/main/docs/m
 | `NEXTCLOUD_USER`     | Yes      |                                               |
 | `NEXTCLOUD_PASSWORD` | Yes      | use an App Password                           |
 | `MCP_TRANSPORT`      | No       | `stdio` (default) or `http`                   |
-| `MCP_AUTH_ENABLED`   | No       | `true` to enable OAuth for Claude.ai          |
+| `MCP_AUTH_ENABLED`   | No       | `true` to enable OAuth for remote clients     |
 | `MCP_AUTH_SECRET`    | If auth  | `openssl rand -hex 32`                        |
 | `MCP_AUTH_ISSUER`    | If auth  | public HTTPS URL of this server               |
 | `LOG_LEVEL`          | No       | `trace`/`debug`/`info`/`warn`/`error`/`fatal` |
@@ -74,12 +97,12 @@ See the [Docker setup guide](https://github.com/elgorro/aiquila/blob/main/docs/m
 - Node.js 24+
 - A Nextcloud instance with an App Password
 
-Optional Nextcloud apps unlock additional tool categories: Tasks, Calendar, Contacts, Notes, Cookbook, Bookmarks, Mail, Maps.
+Optional Nextcloud apps unlock additional tool categories: Tasks, Calendar, Contacts, Notes, Cookbook, Deck, Bookmarks, Mail, Maps, Photos, Talk, Circles, and more.
 
 ## Documentation
 
 - [Setup Guide](https://github.com/elgorro/aiquila/blob/main/docs/mcp/setup.md) — detailed installation and configuration
-- [Tools Reference](https://github.com/elgorro/aiquila/blob/main/docs/mcp/README.md) — all 126 tools documented
+- [Tools Reference](https://github.com/elgorro/aiquila/blob/main/docs/mcp/README.md) — all 198 tools documented
 - [Architecture](https://github.com/elgorro/aiquila/blob/main/docs/dev/mcp-server-architecture.md) — design and internals
 - [Full Documentation](https://github.com/elgorro/aiquila/blob/main/docs/) — complete docs index
 

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "AIquila - MCP server for Nextcloud integration with Claude AI",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiquila-mcp",
   "version": "0.2.18",
-  "description": "AIquila - MCP server for Nextcloud integration with Claude AI",
+  "description": "AIquila - MCP server for Nextcloud integration",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,13 +18,13 @@
       ]
     }
   ],
-  "version": "0.2.17",
+  "version": "0.2.18",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -52,7 +52,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.2.17",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.2.18",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -55,7 +55,7 @@ Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](htt
     <donation>https://liberapay.com/elgorro/donate</donation>
     <dependencies>
         <php min-version="8.4"/>
-        <nextcloud min-version="33" max-version="33"/>
+        <nextcloud min-version="33" max-version="34"/>
     </dependencies>
     <settings>
         <admin>OCA\AIquila\Settings\AdminSettings</admin>

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.2.17</version>
+    <version>0.2.18</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.2.13",
+  "version": "0.2.18",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
## Summary
- Bump `max-version` from 33 to 34 in `nextcloud-app/appinfo/info.xml` (closes #285)
- Sync `nextcloud-app/package.json` version with `info.xml` — was stuck at 0.2.13 (closes #272)
- Bump all version references to 0.2.18
- Remove client-specific "with Claude AI" from npm package description (server is client-agnostic since #269/#270)

## Files changed
- `nextcloud-app/appinfo/info.xml`
- `nextcloud-app/package.json`
- `mcp-server/package.json`
- `mcp-server/server.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)