### PR TITLE
feat(nextcloud): add Claude Opus 4.7 with xhigh effort and high-res vision

### DIFF
--- a/docs/installation/aiquila-setup.md
+++ b/docs/installation/aiquila-setup.md
@@ -93,8 +93,9 @@ sudo -u www-data php occ app:enable aiquila
 1. Navigate to **Settings → Administration → AIquila**
 2. Enter your Claude API key from [console.anthropic.com](https://console.anthropic.com)
 3. Configure settings (optional):
-   - **Claude Model**: Default is `claude-sonnet-4-5-20250929` (latest Sonnet 4.5)
-     - Other options: `claude-haiku-4-5-20251001`, `claude-opus-4-5-20251101`
+   - **Claude Model**: Default is `claude-sonnet-4-6` (adaptive thinking, medium effort)
+     - Most capable: `claude-opus-4-7` (adaptive thinking, xhigh effort — recommended for complex reasoning and agentic coding)
+     - Other options: `claude-opus-4-6`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`, `claude-opus-4-5-20251101`
    - **Max Tokens**: Response length limit (1-100,000, default: 4096)
    - **API Timeout**: Request timeout in seconds (10-1800, default: 30)
 4. Click **Save**

--- a/docs/internal-api.md
+++ b/docs/internal-api.md
@@ -126,7 +126,7 @@ Get current AIquila configuration status.
   ```php
   [
       'configured' => bool,      // Whether an API key is set
-      'model' => string,         // Claude model (e.g., 'claude-sonnet-4-20250514')
+      'model' => string,         // Claude model (e.g., 'claude-opus-4-7', 'claude-sonnet-4-6')
       'max_tokens' => int,       // Maximum tokens (1-100000)
       'timeout' => int           // API timeout in seconds (10-1800)
   ]

--- a/docs/mcp/mcp-connector.md
+++ b/docs/mcp/mcp-connector.md
@@ -20,7 +20,7 @@ import Anthropic from "@anthropic-ai/sdk";
 const anthropic = new Anthropic(); // reads ANTHROPIC_API_KEY from env
 
 const response = await (anthropic.beta.messages as any).create({
-  model: "claude-opus-4-6",
+  model: "claude-opus-4-7",
   max_tokens: 2000,
   messages: [
     {

--- a/docs/mcp/tools/apps/aiquila.md
+++ b/docs/mcp/tools/apps/aiquila.md
@@ -245,10 +245,13 @@ php occ aiquila:test --user username
 - **Validation**: Checked on first API request
 
 ### Model
-Current Claude models (as of January 2025):
-- `claude-sonnet-4-5-20250929` - Latest Sonnet (recommended)
-- `claude-opus-4-5-20250929` - Most capable, slower
-- `claude-3-5-sonnet-20241022` - Previous Sonnet version
+Current Claude models:
+- `claude-opus-4-7` - Most capable; adaptive thinking, xhigh effort (recommended for complex reasoning and agentic coding)
+- `claude-opus-4-6` - Frontier model with adaptive thinking, high effort
+- `claude-sonnet-4-6` - Adaptive thinking, medium effort (**default**)
+- `claude-sonnet-4-5-20250929` - Fast, cost-effective
+- `claude-haiku-4-5-20251001` - Fastest, most economical
+- `claude-opus-4-5-20251101` - Previous Opus generation
 
 ### Max Tokens
 - **Range**: 1 - 100,000

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -2546,9 +2546,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "AIquila - MCP server for Nextcloud integration",
   "type": "module",
   "main": "dist/index.js",
@@ -37,7 +37,8 @@
     "dist/"
   ],
   "overrides": {
-    "brace-expansion": "^2.0.3"
+    "brace-expansion": "^2.0.3",
+    "hono": "^4.12.14"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,13 +18,13 @@
       ]
     }
   ],
-  "version": "0.3.0",
+  "version": "0.3.1",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -52,7 +52,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.0",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.1",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/tools/apps/aiquila.ts
+++ b/mcp-server/src/tools/apps/aiquila.ts
@@ -64,7 +64,9 @@ export const configureTool = {
     model: z
       .string()
       .optional()
-      .describe("Claude model to use (e.g., 'claude-opus-4-6', 'claude-sonnet-4-5-20250929')"),
+      .describe(
+        "Claude model to use (e.g., 'claude-opus-4-7', 'claude-sonnet-4-6', 'claude-sonnet-4-5-20250929')"
+      ),
     maxTokens: z.number().optional().describe('Maximum tokens for responses (default: 4096)'),
     timeout: z.number().optional().describe('Request timeout in seconds (default: 60)'),
   }),

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.0</version>
+    <version>0.3.1</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/composer.json
+++ b/nextcloud-app/composer.json
@@ -5,7 +5,7 @@
     "license": "AGPL-3.0-or-later",
     "require": {
         "php": "^8.4",
-        "anthropic-ai/sdk": "^0.8.0",
+        "anthropic-ai/sdk": "^0.16.0",
         "psr/log": "*",
         "symfony/http-client": "^8.0",
         "nyholm/psr7": "^1.8"

--- a/nextcloud-app/composer.lock
+++ b/nextcloud-app/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48f5b9dba4d69cb561f8b5295ba4f43f",
+    "content-hash": "035f3e930aea7e7f21a2f60e19fa8d4b",
     "packages": [
         {
             "name": "anthropic-ai/sdk",
-            "version": "v0.8.0",
+            "version": "v0.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/anthropics/anthropic-sdk-php.git",
-                "reference": "7d49eb04a1b1a57e08879c94c655e7ecd506424b"
+                "reference": "ac047bba73d41f1319b99a27b295b309e0f07ec4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/anthropics/anthropic-sdk-php/zipball/7d49eb04a1b1a57e08879c94c655e7ecd506424b",
-                "reference": "7d49eb04a1b1a57e08879c94c655e7ecd506424b",
+                "url": "https://api.github.com/repos/anthropics/anthropic-sdk-php/zipball/ac047bba73d41f1319b99a27b295b309e0f07ec4",
+                "reference": "ac047bba73d41f1319b99a27b295b309e0f07ec4",
                 "shasum": ""
             },
             "require": {
@@ -42,7 +42,7 @@
                 "symfony/http-client": "^7"
             },
             "suggest": {
-                "aws/aws-sdk-php": "Allows using the AWS Bedrock SDK",
+                "aws/aws-sdk-php": "Allows using the AWS Bedrock, AWS gateway, and Bedrock Mantle SDKs",
                 "google/auth": "Allows using the Google Vertex SDK"
             },
             "type": "library",
@@ -61,9 +61,9 @@
             "description": "Anthropic PHP SDK",
             "support": {
                 "issues": "https://github.com/anthropics/anthropic-sdk-php/issues",
-                "source": "https://github.com/anthropics/anthropic-sdk-php/tree/v0.8.0"
+                "source": "https://github.com/anthropics/anthropic-sdk-php/tree/v0.16.0"
             },
-            "time": "2026-03-18T18:41:58+00:00"
+            "time": "2026-04-16T14:30:55+00:00"
         },
         {
             "name": "nyholm/psr7",

--- a/nextcloud-app/lib/Command/ConfigureCommand.php
+++ b/nextcloud-app/lib/Command/ConfigureCommand.php
@@ -36,7 +36,7 @@ class ConfigureCommand extends Base {
                 'model',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Set Claude model (e.g., claude-opus-4-6, claude-sonnet-4-5-20250929)'
+                'Set Claude model (e.g., claude-opus-4-7, claude-sonnet-4-6, claude-sonnet-4-5-20250929)'
             )
             ->addOption(
                 'max-tokens',

--- a/nextcloud-app/lib/Service/ClaudeModels.php
+++ b/nextcloud-app/lib/Service/ClaudeModels.php
@@ -32,10 +32,10 @@ class ClaudeModels {
     /** Opus 4.5 */
     public const OPUS_4_5   = 'claude-opus-4-5-20251101';
 
-    /** Sonnet 4 (legacy) */
+    /** Sonnet 4 — deprecated by Anthropic (SDK 0.15.0 dropped from typed Model enum). Constant kept so existing user_model preferences continue to resolve. */
     public const SONNET_4   = 'claude-sonnet-4-20250514';
 
-    /** Opus 4 (legacy) */
+    /** Opus 4 — deprecated by Anthropic (SDK 0.15.0 dropped from typed Model enum). Constant kept so existing user_model preferences continue to resolve. */
     public const OPUS_4     = 'claude-opus-4-20250514';
 
     // ── Application defaults ───────────────────────────────────────────────
@@ -85,6 +85,8 @@ class ClaudeModels {
 
     /**
      * Ordered model list for the admin UI datalist (most capable first).
+     * SONNET_4 / OPUS_4 are intentionally omitted — Anthropic deprecated them
+     * and the SDK removed them from its typed Model enum in 0.15.0.
      */
     public static function getAllModels(): array {
         return [
@@ -94,8 +96,6 @@ class ClaudeModels {
             self::SONNET_4_5,
             self::HAIKU_4_5,
             self::OPUS_4_5,
-            self::SONNET_4,
-            self::OPUS_4,
         ];
     }
 

--- a/nextcloud-app/lib/Service/ClaudeModels.php
+++ b/nextcloud-app/lib/Service/ClaudeModels.php
@@ -14,7 +14,10 @@ class ClaudeModels {
 
     // ── Model ID constants ─────────────────────────────────────────────────
 
-    /** Opus 4.6 – latest frontier model (adaptive thinking, 128K output) */
+    /** Opus 4.7 – most capable frontier model (adaptive thinking, 128K output, 1M context, xhigh effort) */
+    public const OPUS_4_7   = 'claude-opus-4-7';
+
+    /** Opus 4.6 – frontier model (adaptive thinking, 128K output) */
     public const OPUS_4_6   = 'claude-opus-4-6';
 
     /** Sonnet 4.6 – adaptive thinking, 64K output */
@@ -43,6 +46,7 @@ class ClaudeModels {
     // ── Per-model output token ceilings ────────────────────────────────────
 
     private const MAX_TOKENS_CEILING = [
+        self::OPUS_4_7   => 128000,
         self::OPUS_4_6   => 128000,
         self::SONNET_4_6 => 64000,
     ];
@@ -50,11 +54,13 @@ class ClaudeModels {
     // ── Capability flags ───────────────────────────────────────────────────
 
     private const SUPPORTS_THINKING = [
+        self::OPUS_4_7   => true,
         self::OPUS_4_6   => true,
         self::SONNET_4_6 => true,
     ];
 
     private const SUPPORTS_EFFORT = [
+        self::OPUS_4_7   => true,
         self::OPUS_4_6   => true,
         self::SONNET_4_6 => true,
     ];
@@ -82,6 +88,7 @@ class ClaudeModels {
      */
     public static function getAllModels(): array {
         return [
+            self::OPUS_4_7,
             self::OPUS_4_6,
             self::SONNET_4_6,
             self::SONNET_4_5,
@@ -95,6 +102,7 @@ class ClaudeModels {
     // ── Per-model effort level (app-level policy) ────────────────────────
 
     public const EFFORT_LEVEL = [
+        self::OPUS_4_7   => 'xhigh',
         self::OPUS_4_6   => 'high',
         self::SONNET_4_6 => 'medium',
     ];

--- a/nextcloud-app/lib/Service/ClaudeSDKService.php
+++ b/nextcloud-app/lib/Service/ClaudeSDKService.php
@@ -218,6 +218,7 @@ class ClaudeSDKService {
             topP: $params['top_p'] ?? null,
             topK: $params['top_k'] ?? null,
             stopSequences: $params['stop_sequences'] ?? null,
+            tools: $params['tools'] ?? null,
         );
     }
 
@@ -320,7 +321,8 @@ class ClaudeSDKService {
     }
 
     /**
-     * Log informational response metadata (inference geo, service tier) at debug level.
+     * Log informational response metadata (inference geo, service tier, refusal details)
+     * at debug level.
      */
     private function logResponseMetadata(Message $response): void {
         $meta = [];
@@ -329,6 +331,13 @@ class ClaudeSDKService {
         }
         if (isset($response->usage->serviceTier) && $response->usage->serviceTier !== null) {
             $meta['service_tier'] = $response->usage->serviceTier;
+        }
+        if (isset($response->stopDetails) && $response->stopDetails !== null) {
+            $meta['stop_details'] = [
+                'type' => $response->stopDetails->type,
+                'category' => $response->stopDetails->category ?? null,
+                'explanation' => $response->stopDetails->explanation ?? null,
+            ];
         }
         if (!empty($meta)) {
             $this->logger->debug('AIquila SDK: Response metadata', $meta);
@@ -341,28 +350,43 @@ class ClaudeSDKService {
      */
     private function handleException(\Throwable $e, string $context = ''): array {
         $prefix = $context ? "AIquila SDK: $context" : 'AIquila SDK';
+        $logCtx = $this->buildErrorLogContext($e);
         if ($e instanceof AuthenticationException) {
-            $this->logger->error("$prefix: Authentication error", ['error' => $e->getMessage()]);
+            $this->logger->error("$prefix: Authentication error", $logCtx);
             return ['error' => 'Invalid API key. Please check your configuration.'];
         }
         if ($e instanceof PermissionDeniedException) {
-            $this->logger->error("$prefix: Permission denied", ['error' => $e->getMessage()]);
+            $this->logger->error("$prefix: Permission denied", $logCtx);
             return ['error' => 'Your API key does not have permission to use this resource.'];
         }
         if ($e instanceof RateLimitException) {
-            $this->logger->error("$prefix: Rate limit exceeded", ['error' => $e->getMessage()]);
+            $this->logger->error("$prefix: Rate limit exceeded", $logCtx);
             return ['error' => 'Rate limit exceeded. Please try again later.'];
         }
         if ($e instanceof InternalServerException) {
-            $this->logger->error("$prefix: Anthropic server error", ['error' => $e->getMessage()]);
+            $this->logger->error("$prefix: Anthropic server error", $logCtx);
             return ['error' => 'Anthropic API is temporarily unavailable. Please try again later.'];
         }
         if ($e instanceof APIConnectionException || $e instanceof APITimeoutException) {
-            $this->logger->error("$prefix: Connection error", ['error' => $e->getMessage()]);
+            $this->logger->error("$prefix: Connection error", $logCtx);
             return ['error' => 'Connection to Claude API failed: ' . $e->getMessage()];
         }
-        $this->logger->error("$prefix: Error", ['error' => $e->getMessage(), 'class' => get_class($e)]);
+        $this->logger->error("$prefix: Error", $logCtx + ['class' => get_class($e)]);
         return ['error' => 'Error: ' . $e->getMessage()];
+    }
+
+    /**
+     * Build a log context for an SDK exception, including the typed
+     * ErrorType enum value when the exception carries one (SDK v0.9+).
+     *
+     * @return array{error: string, error_type?: string}
+     */
+    private function buildErrorLogContext(\Throwable $e): array {
+        $ctx = ['error' => $e->getMessage()];
+        if ($e instanceof APIStatusException && $e->type !== null) {
+            $ctx['error_type'] = $e->type->value;
+        }
+        return $ctx;
     }
 
     /**
@@ -938,22 +962,22 @@ class ClaudeSDKService {
             $this->logger->info('AIquila SDK: Stream completed successfully');
 
         } catch (AuthenticationException $e) {
-            $this->logger->error('AIquila SDK: Stream authentication error', ['error' => $e->getMessage()]);
+            $this->logger->error('AIquila SDK: Stream authentication error', $this->buildErrorLogContext($e));
             throw new \Exception('Invalid API key. Please check your configuration.');
         } catch (PermissionDeniedException $e) {
-            $this->logger->error('AIquila SDK: Stream permission denied', ['error' => $e->getMessage()]);
+            $this->logger->error('AIquila SDK: Stream permission denied', $this->buildErrorLogContext($e));
             throw new \Exception('Your API key does not have permission to use this resource.');
         } catch (RateLimitException $e) {
-            $this->logger->error('AIquila SDK: Stream rate limit exceeded', ['error' => $e->getMessage()]);
+            $this->logger->error('AIquila SDK: Stream rate limit exceeded', $this->buildErrorLogContext($e));
             throw new \Exception('Rate limit exceeded. Please try again later.');
         } catch (InternalServerException $e) {
-            $this->logger->error('AIquila SDK: Stream Anthropic server error', ['error' => $e->getMessage()]);
+            $this->logger->error('AIquila SDK: Stream Anthropic server error', $this->buildErrorLogContext($e));
             throw new \Exception('Anthropic API is temporarily unavailable. Please try again later.');
         } catch (APIConnectionException | APITimeoutException $e) {
-            $this->logger->error('AIquila SDK: Stream connection error', ['error' => $e->getMessage()]);
+            $this->logger->error('AIquila SDK: Stream connection error', $this->buildErrorLogContext($e));
             throw new \Exception('Connection to Claude API failed: ' . $e->getMessage());
         } catch (APIStatusException | \Exception $e) {
-            $this->logger->error('AIquila SDK: Stream error', ['error' => $e->getMessage(), 'class' => get_class($e)]);
+            $this->logger->error('AIquila SDK: Stream error', $this->buildErrorLogContext($e) + ['class' => get_class($e)]);
             throw new \Exception('Stream error: ' . $e->getMessage());
         }
     }

--- a/nextcloud-app/lib/Service/ImageOptimizer.php
+++ b/nextcloud-app/lib/Service/ImageOptimizer.php
@@ -10,13 +10,14 @@ use Psr\Log\LoggerInterface;
 /**
  * Optimizes images before sending to Claude Vision API.
  *
- * Resizes images whose long edge exceeds 1568 px (Claude's optimal resolution)
- * to reduce token usage without losing visual quality.  Uses the GD library
- * (bundled with PHP) and falls back gracefully when GD is unavailable.
+ * Resizes images whose long edge exceeds 2576 px (Opus 4.7's native resolution,
+ * the upper bound accepted by all current Claude models) to cap token usage
+ * while preserving visual quality.  Uses the GD library (bundled with PHP)
+ * and falls back gracefully when GD is unavailable.
  */
 class ImageOptimizer {
-    /** Claude's recommended maximum long-edge resolution. */
-    private const MAX_LONG_EDGE = 1568;
+    /** Opus 4.7 native resolution (3.75 MP); accepted by all current Claude models. */
+    private const MAX_LONG_EDGE = 2576;
 
     /** Maximum number of images Claude accepts per request. */
     public const MAX_IMAGES = 20;

--- a/nextcloud-app/package-lock.json
+++ b/nextcloud-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila",
-  "version": "0.2.13",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila",
-      "version": "0.2.13",
+      "version": "0.3.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@nextcloud/axios": "^2.5.2",
@@ -3476,9 +3476,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -3888,9 +3888,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",
@@ -23,7 +23,9 @@
     "vite": "^7.3.1"
   },
   "overrides": {
-    "brace-expansion": "^2.0.3"
+    "brace-expansion": "^2.0.3",
+    "dompurify": "^3.4.0",
+    "follow-redirects": "^1.16.0"
   },
   "dependencies": {
     "@nextcloud/axios": "^2.5.2",

--- a/nextcloud-app/tests/Unit/ClaudeModelsTest.php
+++ b/nextcloud-app/tests/Unit/ClaudeModelsTest.php
@@ -11,17 +11,20 @@ class ClaudeModelsTest extends TestCase {
         $this->assertEquals(ClaudeModels::SONNET_4_6, ClaudeModels::DEFAULT_MODEL);
     }
 
-    public function testGetAllModelsReturnsAllEightModels(): void {
+    public function testGetAllModelsReturnsCurrentModelsOnly(): void {
         $models = ClaudeModels::getAllModels();
-        $this->assertCount(8, $models);
+        $this->assertCount(6, $models);
         $this->assertContains(ClaudeModels::OPUS_4_7,   $models);
         $this->assertContains(ClaudeModels::OPUS_4_6,   $models);
         $this->assertContains(ClaudeModels::SONNET_4_6, $models);
         $this->assertContains(ClaudeModels::SONNET_4_5, $models);
         $this->assertContains(ClaudeModels::HAIKU_4_5,  $models);
         $this->assertContains(ClaudeModels::OPUS_4_5,   $models);
-        $this->assertContains(ClaudeModels::SONNET_4,   $models);
-        $this->assertContains(ClaudeModels::OPUS_4,     $models);
+        // Sonnet 4 and Opus 4 are deprecated upstream (SDK 0.15.0 dropped
+        // them from the typed Model enum); the constants remain for
+        // backward compat but we no longer advertise them in the UI.
+        $this->assertNotContains(ClaudeModels::SONNET_4, $models);
+        $this->assertNotContains(ClaudeModels::OPUS_4,   $models);
         // Most capable first
         $this->assertSame(ClaudeModels::OPUS_4_7, $models[0]);
     }

--- a/nextcloud-app/tests/Unit/ClaudeModelsTest.php
+++ b/nextcloud-app/tests/Unit/ClaudeModelsTest.php
@@ -11,9 +11,10 @@ class ClaudeModelsTest extends TestCase {
         $this->assertEquals(ClaudeModels::SONNET_4_6, ClaudeModels::DEFAULT_MODEL);
     }
 
-    public function testGetAllModelsReturnsAllSevenModels(): void {
+    public function testGetAllModelsReturnsAllEightModels(): void {
         $models = ClaudeModels::getAllModels();
-        $this->assertCount(7, $models);
+        $this->assertCount(8, $models);
+        $this->assertContains(ClaudeModels::OPUS_4_7,   $models);
         $this->assertContains(ClaudeModels::OPUS_4_6,   $models);
         $this->assertContains(ClaudeModels::SONNET_4_6, $models);
         $this->assertContains(ClaudeModels::SONNET_4_5, $models);
@@ -21,6 +22,12 @@ class ClaudeModelsTest extends TestCase {
         $this->assertContains(ClaudeModels::OPUS_4_5,   $models);
         $this->assertContains(ClaudeModels::SONNET_4,   $models);
         $this->assertContains(ClaudeModels::OPUS_4,     $models);
+        // Most capable first
+        $this->assertSame(ClaudeModels::OPUS_4_7, $models[0]);
+    }
+
+    public function testGetMaxTokenCeilingForOpus47(): void {
+        $this->assertEquals(128000, ClaudeModels::getMaxTokenCeiling(ClaudeModels::OPUS_4_7));
     }
 
     public function testGetMaxTokenCeilingForOpus46(): void {
@@ -39,6 +46,7 @@ class ClaudeModelsTest extends TestCase {
     }
 
     public function testSupportsThinkingForAdaptiveModels(): void {
+        $this->assertTrue(ClaudeModels::supportsThinking(ClaudeModels::OPUS_4_7));
         $this->assertTrue(ClaudeModels::supportsThinking(ClaudeModels::OPUS_4_6));
         $this->assertTrue(ClaudeModels::supportsThinking(ClaudeModels::SONNET_4_6));
         $this->assertFalse(ClaudeModels::supportsThinking(ClaudeModels::SONNET_4_5));
@@ -46,10 +54,15 @@ class ClaudeModelsTest extends TestCase {
     }
 
     public function testSupportsEffortForAdaptiveModels(): void {
+        $this->assertTrue(ClaudeModels::supportsEffort(ClaudeModels::OPUS_4_7));
         $this->assertTrue(ClaudeModels::supportsEffort(ClaudeModels::OPUS_4_6));
         $this->assertTrue(ClaudeModels::supportsEffort(ClaudeModels::SONNET_4_6));
         $this->assertFalse(ClaudeModels::supportsEffort(ClaudeModels::SONNET_4_5));
         $this->assertFalse(ClaudeModels::supportsEffort(ClaudeModels::HAIKU_4_5));
+    }
+
+    public function testGetEffortLevelForOpus47(): void {
+        $this->assertEquals('xhigh', ClaudeModels::getEffortLevel(ClaudeModels::OPUS_4_7));
     }
 
     public function testGetEffortLevelForOpus46(): void {
@@ -66,6 +79,7 @@ class ClaudeModelsTest extends TestCase {
 
     public function testEffortLevelConstantsArePublic(): void {
         $this->assertIsArray(ClaudeModels::EFFORT_LEVEL);
+        $this->assertArrayHasKey(ClaudeModels::OPUS_4_7, ClaudeModels::EFFORT_LEVEL);
         $this->assertArrayHasKey(ClaudeModels::OPUS_4_6, ClaudeModels::EFFORT_LEVEL);
         $this->assertArrayHasKey(ClaudeModels::SONNET_4_6, ClaudeModels::EFFORT_LEVEL);
     }

--- a/nextcloud-app/tests/Unit/ClaudeSDKServiceCapabilityTest.php
+++ b/nextcloud-app/tests/Unit/ClaudeSDKServiceCapabilityTest.php
@@ -3,6 +3,9 @@
 namespace OCA\AIquila\Tests\Unit;
 
 use Anthropic\Client;
+use Anthropic\Core\Exceptions\RateLimitException;
+use Anthropic\ErrorType;
+use Anthropic\Messages\RefusalStopDetails;
 use Anthropic\Models\ModelInfo;
 use OCA\AIquila\Service\ClaudeModels;
 use OCA\AIquila\Service\ClaudeSDKService;
@@ -256,6 +259,128 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
 
         $this->assertArrayNotHasKey('thinking', $params);
         $this->assertArrayNotHasKey('outputConfig', $params);
+    }
+
+    public function testCallCreateStreamForwardsTools(): void {
+        // Guard: callCreateStream() must forward the tools parameter to the SDK,
+        // otherwise streaming tool-calling silently degrades to tool-less behavior.
+        $ref = new \ReflectionMethod(ClaudeSDKService::class, 'callCreateStream');
+        $file = $ref->getFileName();
+        $src = file_get_contents($file);
+        $start = $ref->getStartLine() - 1;
+        $end = $ref->getEndLine();
+        $body = implode("\n", array_slice(explode("\n", $src), $start, $end - $start));
+
+        $this->assertStringContainsString(
+            "tools: \$params['tools'] ?? null",
+            $body,
+            'callCreateStream must forward tools to the SDK; see plan file stay-on-this-branch-imperative-fiddle.md change #1.'
+        );
+    }
+
+    public function testErrorTypeIncludedInExceptionLogContext(): void {
+        $this->cache->method('get')->willReturn([
+            'max_tokens' => 64000,
+            'supports_thinking' => false,
+            'supports_effort' => false,
+        ]);
+
+        // Build a RateLimitException (subclass of APIStatusException) and
+        // force the typed ErrorType via reflection — the SDK constructor
+        // needs full HTTP Request/Response objects which are awkward to mock.
+        $e = (new \ReflectionClass(RateLimitException::class))->newInstanceWithoutConstructor();
+        $typeProp = new \ReflectionProperty(\Anthropic\Core\Exceptions\APIStatusException::class, 'type');
+        $typeProp->setAccessible(true);
+        $typeProp->setValue($e, ErrorType::RATE_LIMIT_ERROR);
+        $msgProp = new \ReflectionProperty(\Exception::class, 'message');
+        $msgProp->setAccessible(true);
+        $msgProp->setValue($e, 'rate limited');
+
+        $capturedCtx = null;
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->atLeastOnce())
+            ->method('error')
+            ->willReturnCallback(function ($msg, $ctx) use (&$capturedCtx) {
+                if (str_contains($msg, 'Rate limit')) {
+                    $capturedCtx = $ctx;
+                }
+            });
+
+        $service = new class($this->config, $logger, $this->credentials, $this->cacheFactory, $e) extends ClaudeSDKService {
+            public function __construct($cfg, $log, $cred, $cf, private \Throwable $toThrow) {
+                parent::__construct($cfg, $log, $cred, $cf);
+            }
+            protected function callCreate(Client $client, array $params): \Anthropic\Messages\Message {
+                throw $this->toThrow;
+            }
+            protected function getClient(?string $userId = null): Client {
+                return (new \ReflectionClass(Client::class))->newInstanceWithoutConstructor();
+            }
+        };
+
+        $result = $service->ask('test', '', 'testuser');
+
+        $this->assertArrayHasKey('error', $result);
+        $this->assertNotNull($capturedCtx, 'Rate limit error should have been logged');
+        $this->assertArrayHasKey('error_type', $capturedCtx);
+        $this->assertEquals('rate_limit_error', $capturedCtx['error_type']);
+    }
+
+    public function testRefusalStopDetailsLoggedInResponseMetadata(): void {
+        $this->cache->method('get')->willReturn([
+            'max_tokens' => 64000,
+            'supports_thinking' => false,
+            'supports_effort' => false,
+        ]);
+
+        $capturedDebug = [];
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->method('debug')->willReturnCallback(function ($msg, $ctx = []) use (&$capturedDebug) {
+            if (str_contains($msg, 'Response metadata')) {
+                $capturedDebug[] = $ctx;
+            }
+        });
+
+        $refusal = RefusalStopDetails::with('cyber', 'I cannot help with that.');
+
+        $service = new class($this->config, $logger, $this->credentials, $this->cacheFactory, $refusal) extends ClaudeSDKService {
+            public function __construct($cfg, $log, $cred, $cf, private RefusalStopDetails $refusal) {
+                parent::__construct($cfg, $log, $cred, $cf);
+            }
+            protected function callCreate(Client $client, array $params): \Anthropic\Messages\Message {
+                $stub = (new \ReflectionClass(\Anthropic\Messages\Message::class))->newInstanceWithoutConstructor();
+                $ref = new \ReflectionClass($stub);
+                $textObj = new \stdClass();
+                $textObj->type = 'text';
+                $textObj->text = '';
+                foreach (['content' => [$textObj], 'stopReason' => 'refusal', 'stopDetails' => $this->refusal] as $prop => $val) {
+                    $p = $ref->getProperty($prop);
+                    $p->setAccessible(true);
+                    $p->setValue($stub, $val);
+                }
+                $usage = \Anthropic\Messages\Usage::with(null, null, null, null, 10, 5, null, null);
+                $p = $ref->getProperty('usage');
+                $p->setValue($stub, $usage);
+                return $stub;
+            }
+            protected function getClient(?string $userId = null): Client {
+                return (new \ReflectionClass(Client::class))->newInstanceWithoutConstructor();
+            }
+        };
+
+        $service->ask('test', '', 'testuser');
+
+        $found = null;
+        foreach ($capturedDebug as $ctx) {
+            if (isset($ctx['stop_details'])) {
+                $found = $ctx['stop_details'];
+                break;
+            }
+        }
+        $this->assertNotNull($found, 'Response metadata log should include stop_details for refusals');
+        $this->assertEquals('refusal', $found['type']);
+        $this->assertEquals('cyber', $found['category']);
+        $this->assertEquals('I cannot help with that.', $found['explanation']);
     }
 
     public function testUsageIncludesCacheTokens(): void {

--- a/nextcloud-app/tests/Unit/ClaudeSDKServiceCapabilityTest.php
+++ b/nextcloud-app/tests/Unit/ClaudeSDKServiceCapabilityTest.php
@@ -162,6 +162,54 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
         $this->assertArrayHasKey('outputConfig', $params);
     }
 
+    public function testOpus47UsesXhighEffort(): void {
+        $this->cache->method('get')->willReturn(null);
+        $this->cache->expects($this->atLeastOnce())->method('set');
+
+        $this->config = $this->createMock(IConfig::class);
+        $this->config->method('getUserValue')->willReturn('');
+        $this->config->method('getAppValue')
+            ->willReturnCallback(fn($app, $key, $default) => match ($key) {
+                'model' => ClaudeModels::OPUS_4_7,
+                'max_tokens' => '4096',
+                default => $default,
+            });
+
+        $info = ModelInfo::with(
+            ClaudeModels::OPUS_4_7,
+            [
+                'batch' => ['supported' => true],
+                'citations' => ['supported' => false],
+                'code_execution' => ['supported' => false],
+                'context_management' => ['supported' => false, 'strategies' => []],
+                'effort' => [
+                    'supported' => true,
+                    'high' => ['supported' => true],
+                    'low' => ['supported' => true],
+                    'max' => ['supported' => true],
+                    'medium' => ['supported' => true],
+                ],
+                'image_input' => ['supported' => true],
+                'pdf_input' => ['supported' => true],
+                'structured_outputs' => ['supported' => false],
+                'thinking' => ['supported' => true, 'types' => ['adaptive' => ['supported' => true]]],
+            ],
+            new \DateTime(),
+            'Claude Opus 4.7',
+            1000000,
+            128000
+        );
+
+        $service = new CapabilityTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory);
+        $service->setRetrieveModelInfo($info);
+
+        $service->ask('test', '', 'testuser');
+        $params = $service->lastCreateParams;
+
+        $this->assertEquals(['type' => 'adaptive'], $params['thinking']);
+        $this->assertEquals('xhigh', $params['outputConfig']['effort']);
+    }
+
     public function testNonThinkingModelOmitsThinkingParams(): void {
         $this->cache->method('get')->willReturn(null);
 

--- a/nextcloud-app/tests/Unit/ImageOptimizerTest.php
+++ b/nextcloud-app/tests/Unit/ImageOptimizerTest.php
@@ -71,8 +71,8 @@ class ImageOptimizerTest extends TestCase {
             $this->markTestSkipped('GD extension not available');
         }
 
-        // Create a 2000x1000 JPEG (exceeds 1568px long edge)
-        $img = imagecreatetruecolor(2000, 1000);
+        // Create a 4000x2000 JPEG (exceeds the 2576 px long edge cap).
+        $img = imagecreatetruecolor(4000, 2000);
         ob_start();
         imagejpeg($img, null, 90);
         $rawBytes = ob_get_clean();
@@ -83,10 +83,10 @@ class ImageOptimizerTest extends TestCase {
         $this->assertEquals('image/jpeg', $result['mimeType']);
         $this->assertTrue($result['resized']);
 
-        // Verify the resized image fits within 1568px
+        // Verify the resized image fits within 2576 px.
         $resizedBytes = base64_decode($result['data']);
         $dims = getimagesizefromstring($resizedBytes);
-        $this->assertLessThanOrEqual(1568, max($dims[0], $dims[1]));
+        $this->assertLessThanOrEqual(2576, max($dims[0], $dims[1]));
         // Check aspect ratio preserved (2:1)
         $this->assertEqualsWithDelta(2.0, $dims[0] / $dims[1], 0.05);
     }
@@ -96,7 +96,8 @@ class ImageOptimizerTest extends TestCase {
             $this->markTestSkipped('GD extension not available');
         }
 
-        $img = imagecreatetruecolor(2000, 2000);
+        // Exceed the 2576 px long-edge cap so the optimizer resizes.
+        $img = imagecreatetruecolor(3000, 3000);
         ob_start();
         imagepng($img);
         $rawBytes = ob_get_clean();
@@ -114,7 +115,7 @@ class ImageOptimizerTest extends TestCase {
         }
 
         // Create a large GIF — should be skipped (may be animated)
-        $img = imagecreatetruecolor(2000, 2000);
+        $img = imagecreatetruecolor(3000, 3000);
         ob_start();
         imagegif($img);
         $rawBytes = ob_get_clean();


### PR DESCRIPTION
## Summary

- Add `claude-opus-4-7` to the model registry with adaptive thinking, 128K output ceiling, and the new `xhigh` effort tier (Anthropic's coding/agentic recommendation).
- Bump `anthropic-ai/sdk` ^0.8.0 → ^0.16.0 — v0.16.0 ships both the `claude-opus-4-7` model and `Effort::XHIGH` (required to pass `effort: "xhigh"` through the SDK enum).
- Raise `ImageOptimizer::MAX_LONG_EDGE` 1568 → 2576 px to take advantage of Opus 4.7's native high-resolution vision. The cap is optimizer-only; smaller images are untouched, and older Claude models still accept 2576 px.
- Refresh the stale "as of January 2025" model list in `docs/mcp/tools/apps/aiquila.md`; add Opus 4.7 to setup docs, connector example, and internal-api example.
- Extend `ClaudeModelsTest` and `ClaudeSDKServiceCapabilityTest` with 4.7 coverage (`testOpus47UsesXhighEffort` asserts `outputConfig.effort === "xhigh"` and `thinking.type === "adaptive"`).
- **Bump both components to 0.3.1** (`mcp-server/package.json`, `mcp-server/server.json` incl. the `ghcr.io/elgorro/aiquila-mcp:0.3.1` image tag, `nextcloud-app/package.json`, `nextcloud-app/appinfo/info.xml`) — patch release, opt-in feature add.
- **Patch 3 open Dependabot alerts** via `overrides`: `dompurify` → ^3.4.0 and `follow-redirects` → ^1.16.0 (nextcloud-app), `hono` → ^4.12.14 (mcp-server). `brace-expansion` ^2.0.3 was already pinned. Remaining 7 low-severity `elliptic`-chain warnings in nextcloud-app build deps have no upstream patch and are intentionally skipped.

Closes #292.

## Defaults & scope

- `DEFAULT_MODEL` **stays `claude-sonnet-4-6`** — Opus 4.7 is opt-in via admin or user settings.
- Out of scope (separate issues if wanted): task budgets (beta `task-budgets-2026-03-13`), thinking-display UI (`display: "summarized"`), making 4.7 the default.

The existing `ClaudeSDKService` flow already uses `thinking: {type: "adaptive"}` + `outputConfig.effort` and passes no removed sampling params (`temperature`/`top_p`/`top_k`), so Opus 4.7's Messages-API breaking changes don't affect existing callers.

## Follow-up: SDK 0.16 quick-wins (commit 8f668d6)

The 0.8 → 0.16 SDK bump unlocked more than just Opus 4.7. Larger items are tracked in dedicated issues (#294–#300). This PR also lands four small, cohesive wins that don't need their own issue:

1. **Stream path now forwards `tools:`** — `callCreateStream()` matches `callCreate()`. Previously `buildRequestParams()` put tools into `$params` for streaming callers but the dispatch layer silently dropped them. Latent bug fix; no current caller was affected, but unblocks future streaming + tools work.
2. **Typed `ErrorType` enum in exception logs** (SDK v0.9+). New `buildErrorLogContext()` adds `error_type` to the log context for `APIStatusException` and its subclasses; applied symmetrically to `handleException()` and the `askStream()` catch block. **Logs-only** — user-facing error strings are unchanged in this PR.
3. **Refusal `stopDetails` surfaced** in `logResponseMetadata()` at debug level (type / category / explanation). Previously refusals were invisible beyond a `stop_reason` string.
4. **Deprecated `SONNET_4` / `OPUS_4` dropped from the admin dropdown** — SDK v0.15.0 removed them from its typed `Model` enum. Constants are retained in `ClaudeModels` so existing `user_model` preferences still resolve; they just no longer appear as selectable options.

### Out of scope (tracked as issues)

- #294 Thinking `budget_tokens` alongside adaptive
- #295 Top-level automatic `cache_control`
- #296 Hashed `metadata.user_id` per request
- #297 `service_tier` (speed mode) admin setting
- #298 Beta Files API for document workflows
- #299 Beta Batches API spike
- #300 Managed Agents vs in-house `chatWithTools` loop

## Test plan

- [x] `cd nextcloud-app && ./vendor/bin/phpunit` — 260 tests / 743 assertions passing, includes new Opus 4.7 + SDK-fix assertions
- [x] `cd mcp-server && npm run lint && npx prettier --check src/ && npm test` — 620/620 passing, 0 lint errors (pre-follow-up)
- [x] `npm run build` — TypeScript compiles clean, `server.json` re-synced to 0.3.1
- [x] `npm ls dompurify follow-redirects` in nextcloud-app — overrides resolve to 3.4.0 / 1.16.0
- [x] `vendor/bin/generate-spec` — OpenAPI spec unchanged by the follow-up commit
- [ ] Smoke in `docker/standalone`: select `claude-opus-4-7` in admin UI, run `occ aiquila:test`, verify log shows `outputConfig.effort=xhigh`
- [ ] Vision: upload a >2576 px image, confirm optimizer resizes to 2576-long-edge; upload a 2000 px image, confirm no resize
- [ ] Manual: force an APIStatusException (break API key, send request) and confirm `error_type` appears in `data/nextcloud.log`
- [ ] Admin settings page: confirm deprecated Sonnet 4 / Opus 4 no longer appear in the model dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)