### PR TITLE
fix(nextcloud): declarative SELECT fix + admin page reorganization

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "AIquila - MCP server for Nextcloud integration",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,13 +18,13 @@
       ]
     }
   ],
-  "version": "0.3.1",
+  "version": "0.3.2",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -52,7 +52,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.1",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.2",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/composer.lock
+++ b/nextcloud-app/composer.lock
@@ -1220,16 +1220,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "14.0.0",
+            "version": "14.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "24f1d7300e54e910197ee65e83d27a1e4bdc917e"
+                "reference": "24dc6fcf9f2a983de5b3f1199fb01e88d68e7474"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/24f1d7300e54e910197ee65e83d27a1e4bdc917e",
-                "reference": "24f1d7300e54e910197ee65e83d27a1e4bdc917e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/24dc6fcf9f2a983de5b3f1199fb01e88d68e7474",
+                "reference": "24dc6fcf9f2a983de5b3f1199fb01e88d68e7474",
                 "shasum": ""
             },
             "require": {
@@ -1240,7 +1240,7 @@
                 "php": ">=8.4",
                 "phpunit/php-text-template": "^6.0",
                 "sebastian/complexity": "^6.0",
-                "sebastian/environment": "^9.1",
+                "sebastian/environment": "^9.2",
                 "sebastian/git-state": "^1.0",
                 "sebastian/lines-of-code": "^5.0",
                 "sebastian/version": "^7.0",
@@ -1256,7 +1256,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "14.0.x-dev"
+                    "dev-main": "14.1.x-dev"
                 }
             },
             "autoload": {
@@ -1285,7 +1285,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.0.0"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.1.3"
             },
             "funding": [
                 {
@@ -1305,7 +1305,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-03T05:11:05+00:00"
+            "time": "2026-04-18T05:41:54+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1602,16 +1602,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "13.1.0",
+            "version": "13.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "97f27488f84718f8e7f9a2a31b5ca9f20698b06f"
+                "reference": "c3c414ea438e5a37d00697eaea43e6e05e201a42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/97f27488f84718f8e7f9a2a31b5ca9f20698b06f",
-                "reference": "97f27488f84718f8e7f9a2a31b5ca9f20698b06f",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c3c414ea438e5a37d00697eaea43e6e05e201a42",
+                "reference": "c3c414ea438e5a37d00697eaea43e6e05e201a42",
                 "shasum": ""
             },
             "require": {
@@ -1625,16 +1625,16 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.4.1",
-                "phpunit/php-code-coverage": "^14.0",
+                "phpunit/php-code-coverage": "^14.1.2",
                 "phpunit/php-file-iterator": "^7.0.0",
                 "phpunit/php-invoker": "^7.0.0",
                 "phpunit/php-text-template": "^6.0.0",
                 "phpunit/php-timer": "^9.0.0",
                 "sebastian/cli-parser": "^5.0.0",
-                "sebastian/comparator": "^8.0.0",
-                "sebastian/diff": "^8.0.0",
-                "sebastian/environment": "^9.1.0",
-                "sebastian/exporter": "^8.0.0",
+                "sebastian/comparator": "^8.1.2",
+                "sebastian/diff": "^8.1.0",
+                "sebastian/environment": "^9.3.0",
+                "sebastian/exporter": "^8.0.2",
                 "sebastian/git-state": "^1.0",
                 "sebastian/global-state": "^9.0.0",
                 "sebastian/object-enumerator": "^8.0.0",
@@ -1681,7 +1681,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.0"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.6"
             },
             "funding": [
                 {
@@ -1689,7 +1689,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-04-03T05:29:00+00:00"
+            "time": "2026-04-17T12:52:50+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1762,23 +1762,23 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "8.0.0",
+            "version": "8.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "29b232ddc29c2b114c0358c69b3084e7c3da0d58"
+                "reference": "b3d09f4360ad97dcad8f82d1c047ad16ff38b7e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/29b232ddc29c2b114c0358c69b3084e7c3da0d58",
-                "reference": "29b232ddc29c2b114c0358c69b3084e7c3da0d58",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/b3d09f4360ad97dcad8f82d1c047ad16ff38b7e1",
+                "reference": "b3d09f4360ad97dcad8f82d1c047ad16ff38b7e1",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
                 "php": ">=8.4",
-                "sebastian/diff": "^8.0",
+                "sebastian/diff": "^8.1",
                 "sebastian/exporter": "^8.0"
             },
             "require-dev": {
@@ -1790,7 +1790,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.0-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -1830,7 +1830,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/8.0.0"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/8.1.2"
             },
             "funding": [
                 {
@@ -1850,7 +1850,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-06T04:40:39+00:00"
+            "time": "2026-04-14T08:24:42+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -1924,16 +1924,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "8.0.0",
+            "version": "8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "a2b6d09d7729ee87d605a439469f9dcc39be5ea3"
+                "reference": "9c957d730257f49c873f3761674559bd90098a7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/a2b6d09d7729ee87d605a439469f9dcc39be5ea3",
-                "reference": "a2b6d09d7729ee87d605a439469f9dcc39be5ea3",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/9c957d730257f49c873f3761674559bd90098a7d",
+                "reference": "9c957d730257f49c873f3761674559bd90098a7d",
                 "shasum": ""
             },
             "require": {
@@ -1946,7 +1946,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.0-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -1979,7 +1979,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/8.0.0"
+                "source": "https://github.com/sebastianbergmann/diff/tree/8.1.0"
             },
             "funding": [
                 {
@@ -1999,20 +1999,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-06T04:42:27+00:00"
+            "time": "2026-04-05T12:02:33+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "9.1.0",
+            "version": "9.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "c4a2dc54b1a24e13ef1839cbb5947b967cbae853"
+                "reference": "6767059a30e4277ac95ee034809e793528464768"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/c4a2dc54b1a24e13ef1839cbb5947b967cbae853",
-                "reference": "c4a2dc54b1a24e13ef1839cbb5947b967cbae853",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6767059a30e4277ac95ee034809e793528464768",
+                "reference": "6767059a30e4277ac95ee034809e793528464768",
                 "shasum": ""
             },
             "require": {
@@ -2027,7 +2027,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.1-dev"
+                    "dev-main": "9.3-dev"
                 }
             },
             "autoload": {
@@ -2055,7 +2055,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/9.1.0"
+                "source": "https://github.com/sebastianbergmann/environment/tree/9.3.0"
             },
             "funding": [
                 {
@@ -2075,20 +2075,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-22T06:31:50+00:00"
+            "time": "2026-04-15T12:14:03+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "8.0.0",
+            "version": "8.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "dc31f1f8e0186c8f0bb3e48fd4d51421d8905fea"
+                "reference": "9cee180ebe62259e3ed48df2212d1fc8cfd971bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/dc31f1f8e0186c8f0bb3e48fd4d51421d8905fea",
-                "reference": "dc31f1f8e0186c8f0bb3e48fd4d51421d8905fea",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/9cee180ebe62259e3ed48df2212d1fc8cfd971bb",
+                "reference": "9cee180ebe62259e3ed48df2212d1fc8cfd971bb",
                 "shasum": ""
             },
             "require": {
@@ -2145,7 +2145,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/8.0.0"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/8.0.2"
             },
             "funding": [
                 {
@@ -2165,7 +2165,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-06T04:44:28+00:00"
+            "time": "2026-04-15T12:38:05+00:00"
         },
         {
             "name": "sebastian/git-state",

--- a/nextcloud-app/lib/AppInfo/Application.php
+++ b/nextcloud-app/lib/AppInfo/Application.php
@@ -28,8 +28,10 @@ class Application extends App implements IBootstrap {
             return $c->get(AIquilaService::class);
         });
 
-        // Declarative Settings — model, max_tokens, api_timeout
-        $context->registerDeclarativeSettings(\OCA\AIquila\Settings\AdminDeclarativeSettings::class);
+        // Declarative Settings — admin page split into model / request params / search cards
+        $context->registerDeclarativeSettings(\OCA\AIquila\Settings\AdminModelDeclarativeSettings::class);
+        $context->registerDeclarativeSettings(\OCA\AIquila\Settings\AdminRequestParamsDeclarativeSettings::class);
+        $context->registerDeclarativeSettings(\OCA\AIquila\Settings\AdminSearchDeclarativeSettings::class);
         $context->registerDeclarativeSettings(\OCA\AIquila\Settings\UserDeclarativeSettings::class);
 
         // Expose app capabilities via /ocs/v2.php/cloud/capabilities

--- a/nextcloud-app/lib/Capabilities/AIquilaCapability.php
+++ b/nextcloud-app/lib/Capabilities/AIquilaCapability.php
@@ -43,7 +43,7 @@ class AIquilaCapability implements ICapability {
                 'model'          => $this->config->getAppValue(self::APP_ID, 'model', ClaudeModels::DEFAULT_MODEL),
                 'providers'      => $providers,
                 'api_configured' => $this->credentialService->getApiKey(null) !== '',
-                'search_enabled' => $this->config->getAppValue(self::APP_ID, 'search_enabled', 'yes') === 'yes',
+                'search_enabled' => $this->config->getAppValue(self::APP_ID, 'search_enabled', '1') !== '0',
             ],
         ];
     }

--- a/nextcloud-app/lib/Settings/AdminDeclarativeSettings.php
+++ b/nextcloud-app/lib/Settings/AdminDeclarativeSettings.php
@@ -12,11 +12,6 @@ use OCP\Settings\IDeclarativeSettingsForm;
 class AdminDeclarativeSettings implements IDeclarativeSettingsForm {
 
 	public function getSchema(): array {
-		$modelOptions = array_map(
-			fn (string $id) => ['name' => $id, 'value' => $id],
-			ClaudeModels::getAllModels()
-		);
-
 		return [
 			'id' => 'aiquila_admin',
 			'priority' => 20,
@@ -31,7 +26,7 @@ class AdminDeclarativeSettings implements IDeclarativeSettingsForm {
 					'title' => 'Default Claude Model',
 					'description' => 'The Claude model used for all requests unless overridden by a user.',
 					'type' => DeclarativeSettingsTypes::SELECT,
-					'options' => $modelOptions,
+					'options' => ClaudeModels::getAllModels(),
 					'default' => ClaudeModels::DEFAULT_MODEL,
 				],
 				[

--- a/nextcloud-app/lib/Settings/AdminModelDeclarativeSettings.php
+++ b/nextcloud-app/lib/Settings/AdminModelDeclarativeSettings.php
@@ -1,0 +1,35 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Settings;
+
+use OCA\AIquila\Service\ClaudeModels;
+use OCP\Settings\DeclarativeSettingsTypes;
+use OCP\Settings\IDeclarativeSettingsForm;
+
+class AdminModelDeclarativeSettings implements IDeclarativeSettingsForm {
+
+	public function getSchema(): array {
+		return [
+			'id' => 'aiquila_admin_model',
+			'priority' => 10,
+			'section_type' => DeclarativeSettingsTypes::SECTION_TYPE_ADMIN,
+			'section_id' => 'aiquila',
+			'storage_type' => DeclarativeSettingsTypes::STORAGE_TYPE_INTERNAL,
+			'title' => 'Default Claude model',
+			'description' => 'Pick the model AIquila uses for every request, unless a user picks their own in their personal settings. Opus is the most capable (and most expensive); Haiku is the fastest and cheapest; Sonnet sits in the middle.',
+			'fields' => [
+				[
+					'id' => 'model',
+					'title' => 'Default model',
+					'description' => 'Applied to every request from every user that has not set a personal preference. Takes effect immediately on save.',
+					'type' => DeclarativeSettingsTypes::SELECT,
+					'options' => ClaudeModels::getAllModels(),
+					'default' => ClaudeModels::DEFAULT_MODEL,
+				],
+			],
+		];
+	}
+}

--- a/nextcloud-app/lib/Settings/AdminRequestParamsDeclarativeSettings.php
+++ b/nextcloud-app/lib/Settings/AdminRequestParamsDeclarativeSettings.php
@@ -9,38 +9,30 @@ use OCA\AIquila\Service\ClaudeModels;
 use OCP\Settings\DeclarativeSettingsTypes;
 use OCP\Settings\IDeclarativeSettingsForm;
 
-class AdminDeclarativeSettings implements IDeclarativeSettingsForm {
+class AdminRequestParamsDeclarativeSettings implements IDeclarativeSettingsForm {
 
 	public function getSchema(): array {
 		return [
-			'id' => 'aiquila_admin',
+			'id' => 'aiquila_admin_params',
 			'priority' => 20,
 			'section_type' => DeclarativeSettingsTypes::SECTION_TYPE_ADMIN,
 			'section_id' => 'aiquila',
 			'storage_type' => DeclarativeSettingsTypes::STORAGE_TYPE_INTERNAL,
-			'title' => 'Claude Model Settings',
-			'description' => 'Configure the default Claude model and generation parameters.',
+			'title' => 'Request parameters',
+			'description' => 'Tune how AIquila talks to the Claude API. The defaults work well — only change these if you understand the tradeoff.',
 			'fields' => [
 				[
-					'id' => 'model',
-					'title' => 'Default Claude Model',
-					'description' => 'The Claude model used for all requests unless overridden by a user.',
-					'type' => DeclarativeSettingsTypes::SELECT,
-					'options' => ClaudeModels::getAllModels(),
-					'default' => ClaudeModels::DEFAULT_MODEL,
-				],
-				[
 					'id' => 'max_tokens',
-					'title' => 'Max Response Tokens',
-					'description' => 'Maximum number of output tokens per response (1–128 000).',
+					'title' => 'Max response tokens',
+					'description' => 'Upper bound on how long a single reply can be. Higher = longer answers at higher cost and latency. Automatically clamped to the selected model\'s ceiling (64K for Sonnet 4.6, 128K for Opus 4.x). Range 1–100 000.',
 					'type' => DeclarativeSettingsTypes::TEXT,
 					'placeholder' => '16384',
 					'default' => (string)ClaudeModels::DEFAULT_MAX_TOKENS,
 				],
 				[
 					'id' => 'api_timeout',
-					'title' => 'API Timeout (seconds)',
-					'description' => 'HTTP timeout for Claude API requests (10–1 800).',
+					'title' => 'API timeout (seconds)',
+					'description' => 'How long to wait for Claude\'s reply before giving up. Requests that run longer than this fail with a timeout error. Range 10–1 800; 30–60 seconds is typical.',
 					'type' => DeclarativeSettingsTypes::TEXT,
 					'placeholder' => '30',
 					'default' => '30',

--- a/nextcloud-app/lib/Settings/AdminSearchDeclarativeSettings.php
+++ b/nextcloud-app/lib/Settings/AdminSearchDeclarativeSettings.php
@@ -1,0 +1,33 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Settings;
+
+use OCP\Settings\DeclarativeSettingsTypes;
+use OCP\Settings\IDeclarativeSettingsForm;
+
+class AdminSearchDeclarativeSettings implements IDeclarativeSettingsForm {
+
+	public function getSchema(): array {
+		return [
+			'id' => 'aiquila_admin_search',
+			'priority' => 30,
+			'section_type' => DeclarativeSettingsTypes::SECTION_TYPE_ADMIN,
+			'section_id' => 'aiquila',
+			'storage_type' => DeclarativeSettingsTypes::STORAGE_TYPE_INTERNAL,
+			'title' => 'Search integration',
+			'description' => 'Controls whether AIquila chat conversations appear in Nextcloud\'s unified search results.',
+			'fields' => [
+				[
+					'id' => 'search_enabled',
+					'title' => 'Show AIquila conversations in unified search',
+					'description' => 'When enabled, past AIquila chats are indexed and can be found via the magnifying glass. Disable if you do not want chat content to appear in search.',
+					'type' => DeclarativeSettingsTypes::CHECKBOX,
+					'default' => '1',
+				],
+			],
+		];
+	}
+}

--- a/nextcloud-app/lib/Settings/UserDeclarativeSettings.php
+++ b/nextcloud-app/lib/Settings/UserDeclarativeSettings.php
@@ -6,25 +6,33 @@ declare(strict_types=1);
 namespace OCA\AIquila\Settings;
 
 use OCA\AIquila\Service\ClaudeModels;
+use OCP\IConfig;
 use OCP\Settings\DeclarativeSettingsTypes;
 use OCP\Settings\IDeclarativeSettingsForm;
 
 class UserDeclarativeSettings implements IDeclarativeSettingsForm {
 
+	public function __construct(
+		private IConfig $config,
+	) {
+	}
+
 	public function getSchema(): array {
+		$adminModel = $this->config->getAppValue('aiquila', 'model', ClaudeModels::DEFAULT_MODEL);
+
 		return [
 			'id' => 'aiquila_user',
 			'priority' => 20,
 			'section_type' => DeclarativeSettingsTypes::SECTION_TYPE_PERSONAL,
 			'section_id' => 'aiquila',
 			'storage_type' => DeclarativeSettingsTypes::STORAGE_TYPE_INTERNAL,
-			'title' => 'Claude Model Preference',
-			'description' => 'Override the default Claude model for your requests.',
+			'title' => 'Claude model preference',
+			'description' => 'Pick a specific Claude model for your own requests, or stick with whatever the admin has chosen.',
 			'fields' => [
 				[
 					'id' => 'user_model',
-					'title' => 'Preferred Model',
-					'description' => 'Leave on the blank entry to use the instance-wide model.',
+					'title' => 'Preferred model',
+					'description' => "Leave blank to use the instance default (currently: {$adminModel}). Pick a specific model to override the default for your requests only.",
 					'type' => DeclarativeSettingsTypes::SELECT,
 					'options' => array_merge([''], ClaudeModels::getAllModels()),
 					'placeholder' => '(admin default)',

--- a/nextcloud-app/lib/Settings/UserDeclarativeSettings.php
+++ b/nextcloud-app/lib/Settings/UserDeclarativeSettings.php
@@ -12,11 +12,6 @@ use OCP\Settings\IDeclarativeSettingsForm;
 class UserDeclarativeSettings implements IDeclarativeSettingsForm {
 
 	public function getSchema(): array {
-		$modelOptions = [['name' => '(admin default)', 'value' => '']];
-		foreach (ClaudeModels::getAllModels() as $id) {
-			$modelOptions[] = ['name' => $id, 'value' => $id];
-		}
-
 		return [
 			'id' => 'aiquila_user',
 			'priority' => 20,
@@ -29,9 +24,10 @@ class UserDeclarativeSettings implements IDeclarativeSettingsForm {
 				[
 					'id' => 'user_model',
 					'title' => 'Preferred Model',
-					'description' => 'Leave on "(admin default)" to use the instance-wide model.',
+					'description' => 'Leave on the blank entry to use the instance-wide model.',
 					'type' => DeclarativeSettingsTypes::SELECT,
-					'options' => $modelOptions,
+					'options' => array_merge([''], ClaudeModels::getAllModels()),
+					'placeholder' => '(admin default)',
 					'default' => '',
 				],
 			],

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",

--- a/nextcloud-app/templates/admin.php
+++ b/nextcloud-app/templates/admin.php
@@ -5,37 +5,49 @@ style('aiquila', 'admin');
 ?>
 
 <div id="aiquila-admin" class="section">
-    <h2>AIquila API &amp; Connections</h2>
-
+    <h2>AIquila</h2>
     <p class="settings-hint">
-        Configure your Claude API key. Get one from
-        <a href="https://console.anthropic.com/" target="_blank">console.anthropic.com</a>
+        AIquila connects Nextcloud to Anthropic's Claude models so your users can chat, summarise, translate and more directly inside Nextcloud. You need an Anthropic API key to get started; model and request tuning live in the cards further down this page.
     </p>
 
-    <form id="aiquila-admin-form">
-        <div class="form-group">
-            <label for="aiquila-api-key">Claude API Key</label>
-            <input type="password"
-                   id="aiquila-api-key"
-                   name="api_key"
-                   placeholder="<?php echo $_['has_key'] ? 'API key configured' : 'sk-ant-...'; ?>"
-                   value="">
+    <div class="section">
+        <h3>Claude API key</h3>
+        <p class="settings-hint">
+            Paste your Anthropic API key below. Get one from
+            <a href="https://console.anthropic.com/" target="_blank" rel="noopener noreferrer">console.anthropic.com</a>.
+            The key is stored encrypted in Nextcloud's credential manager and used for every request unless a user provides their own in personal settings. Use <em>Test Configuration</em> after saving to confirm the key actually reaches Anthropic.
+        </p>
+
+        <form id="aiquila-admin-form">
+            <div class="form-group">
+                <label for="aiquila-api-key">Claude API Key</label>
+                <input type="password"
+                       id="aiquila-api-key"
+                       name="api_key"
+                       placeholder="<?php echo $_['has_key'] ? 'API key configured' : 'sk-ant-...'; ?>"
+                       value="">
+            </div>
+
+            <button type="submit" class="primary">Save</button>
+            <button type="button" id="aiquila-test-config" class="secondary">Test Configuration</button>
+            <span id="aiquila-status"></span>
+        </form>
+
+        <div id="aiquila-test-result" style="display: none;">
+            <h4>Test Result</h4>
+            <pre id="aiquila-test-output"></pre>
         </div>
-
-        <button type="submit" class="primary">Save</button>
-        <button type="button" id="aiquila-test-config" class="secondary">Test Configuration</button>
-        <span id="aiquila-status"></span>
-    </form>
-
-    <div id="aiquila-test-result" style="display: none;">
-        <h3>Test Result</h3>
-        <pre id="aiquila-test-output"></pre>
     </div>
 
     <div id="aiquila-mcp-servers" class="section">
-        <h3>MCP Servers</h3>
+        <h3>MCP servers</h3>
         <p class="settings-hint">
-            Connect MCP servers to give Claude access to tools (files, calendar, notes, etc.)
+            Model Context Protocol (MCP) servers give Claude tools — files, calendar, notes, and so on — that it can call during a conversation. Each server you add here becomes available to every user on this instance.
+            New to MCP? Read
+            <a href="https://modelcontextprotocol.io/docs/getting-started/intro" target="_blank" rel="noopener noreferrer">What's MCP?</a>
+            or follow the
+            <a href="https://github.com/elgorro/aiquila/tree/main/docs/installation/mcp-installation.md" target="_blank" rel="noopener noreferrer">free MCP installation guide</a>
+            to run the bundled AIquila MCP server.
         </p>
 
         <div id="mcp-server-list"></div>
@@ -76,20 +88,12 @@ style('aiquila', 'admin');
         </div>
     </div>
 
-    <div class="aiquila-resources">
-        <h3>MCP</h3>
-        <ul>
-            <li><a href="https://github.com/elgorro/aiquila/tree/main/docs/installation/mcp-installation.md" target="_blank" rel="noopener noreferrer">🧭 Free MCP Installation</a></li>
-            <li><a href="https://modelcontextprotocol.io/docs/getting-started/intro" target="_blank" rel="noopener noreferrer">📖 What's MCP?</a></li>
-        </ul>
-    </div>
-
-    <div class="aiquila-resources">
+    <div class="aiquila-resources section">
         <h3>Resources</h3>
         <ul>
-            <li><a href="https://github.com/elgorro/aiquila" target="_blank" rel="noopener noreferrer">📦 GitHub Repository</a></li>
+            <li><a href="https://github.com/elgorro/aiquila" target="_blank" rel="noopener noreferrer">📦 GitHub repository</a></li>
             <li><a href="https://github.com/elgorro/aiquila/tree/main/docs" target="_blank" rel="noopener noreferrer">📖 Documentation</a></li>
-            <li><a href="https://github.com/elgorro/aiquila/issues" target="_blank" rel="noopener noreferrer">🐛 Report Issues</a></li>
+            <li><a href="https://github.com/elgorro/aiquila/issues" target="_blank" rel="noopener noreferrer">🐛 Report issues</a></li>
             <li><a href="https://github.com/elgorro/aiquila/discussions" target="_blank" rel="noopener noreferrer">💬 Discussions</a></li>
         </ul>
     </div>

--- a/nextcloud-app/tests/Unit/AIquilaCapabilityTest.php
+++ b/nextcloud-app/tests/Unit/AIquilaCapabilityTest.php
@@ -59,7 +59,7 @@ class AIquilaCapabilityTest extends TestCase {
         $this->config->method('getAppValue')
             ->willReturnMap([
                 ['aiquila', 'model', ClaudeModels::DEFAULT_MODEL, 'claude-opus-4-20250514'],
-                ['aiquila', 'search_enabled', 'yes', 'yes'],
+                ['aiquila', 'search_enabled', '1', '1'],
             ]);
         $this->credentialService->method('getApiKey')->willReturn('');
 
@@ -97,7 +97,7 @@ class AIquilaCapabilityTest extends TestCase {
         $this->config->method('getAppValue')
             ->willReturnMap([
                 ['aiquila', 'model', ClaudeModels::DEFAULT_MODEL, ClaudeModels::DEFAULT_MODEL],
-                ['aiquila', 'search_enabled', 'yes', 'no'],
+                ['aiquila', 'search_enabled', '1', '0'],
             ]);
         $this->credentialService->method('getApiKey')->willReturn('');
 
@@ -111,7 +111,7 @@ class AIquilaCapabilityTest extends TestCase {
         $this->config->method('getAppValue')
             ->willReturnMap([
                 ['aiquila', 'model', ClaudeModels::DEFAULT_MODEL, ClaudeModels::DEFAULT_MODEL],
-                ['aiquila', 'search_enabled', 'yes', 'yes'],
+                ['aiquila', 'search_enabled', '1', '1'],
             ]);
         $this->credentialService->method('getApiKey')->willReturn('');
 

--- a/nextcloud-app/tests/Unit/Settings/AdminDeclarativeSettingsTest.php
+++ b/nextcloud-app/tests/Unit/Settings/AdminDeclarativeSettingsTest.php
@@ -33,8 +33,7 @@ class AdminDeclarativeSettingsTest extends TestCase {
 		$this->assertSame(DeclarativeSettingsTypes::SELECT, $model['type']);
 		$this->assertSame(ClaudeModels::DEFAULT_MODEL, $model['default']);
 
-		$optionValues = array_column($model['options'], 'value');
-		$this->assertSame(ClaudeModels::getAllModels(), $optionValues);
+		$this->assertSame(ClaudeModels::getAllModels(), $model['options']);
 	}
 
 	public function testMaxTokensField(): void {

--- a/nextcloud-app/tests/Unit/Settings/AdminModelDeclarativeSettingsTest.php
+++ b/nextcloud-app/tests/Unit/Settings/AdminModelDeclarativeSettingsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace OCA\AIquila\Tests\Unit\Settings;
+
+use OCA\AIquila\Service\ClaudeModels;
+use OCA\AIquila\Settings\AdminModelDeclarativeSettings;
+use OCP\Settings\DeclarativeSettingsTypes;
+use PHPUnit\Framework\TestCase;
+
+class AdminModelDeclarativeSettingsTest extends TestCase {
+	private AdminModelDeclarativeSettings $settings;
+
+	protected function setUp(): void {
+		$this->settings = new AdminModelDeclarativeSettings();
+	}
+
+	public function testSchemaStructure(): void {
+		$schema = $this->settings->getSchema();
+
+		$this->assertSame('aiquila_admin_model', $schema['id']);
+		$this->assertSame(DeclarativeSettingsTypes::SECTION_TYPE_ADMIN, $schema['section_type']);
+		$this->assertSame('aiquila', $schema['section_id']);
+		$this->assertSame(DeclarativeSettingsTypes::STORAGE_TYPE_INTERNAL, $schema['storage_type']);
+		$this->assertNotEmpty($schema['title']);
+		$this->assertIsArray($schema['fields']);
+		$this->assertCount(1, $schema['fields']);
+	}
+
+	public function testModelField(): void {
+		$fields = $this->settings->getSchema()['fields'];
+		$model = $this->findField($fields, 'model');
+
+		$this->assertNotNull($model, 'model field should exist');
+		$this->assertSame(DeclarativeSettingsTypes::SELECT, $model['type']);
+		$this->assertSame(ClaudeModels::DEFAULT_MODEL, $model['default']);
+
+		$this->assertSame(ClaudeModels::getAllModels(), $model['options']);
+	}
+
+	public function testDoesNotContainApiKey(): void {
+		$fields = $this->settings->getSchema()['fields'];
+		$this->assertNull($this->findField($fields, 'api_key'), 'api_key must not be in declarative settings');
+	}
+
+	private function findField(array $fields, string $id): ?array {
+		foreach ($fields as $field) {
+			if ($field['id'] === $id) {
+				return $field;
+			}
+		}
+		return null;
+	}
+}

--- a/nextcloud-app/tests/Unit/Settings/AdminRequestParamsDeclarativeSettingsTest.php
+++ b/nextcloud-app/tests/Unit/Settings/AdminRequestParamsDeclarativeSettingsTest.php
@@ -3,37 +3,27 @@
 namespace OCA\AIquila\Tests\Unit\Settings;
 
 use OCA\AIquila\Service\ClaudeModels;
-use OCA\AIquila\Settings\AdminDeclarativeSettings;
+use OCA\AIquila\Settings\AdminRequestParamsDeclarativeSettings;
 use OCP\Settings\DeclarativeSettingsTypes;
 use PHPUnit\Framework\TestCase;
 
-class AdminDeclarativeSettingsTest extends TestCase {
-	private AdminDeclarativeSettings $settings;
+class AdminRequestParamsDeclarativeSettingsTest extends TestCase {
+	private AdminRequestParamsDeclarativeSettings $settings;
 
 	protected function setUp(): void {
-		$this->settings = new AdminDeclarativeSettings();
+		$this->settings = new AdminRequestParamsDeclarativeSettings();
 	}
 
 	public function testSchemaStructure(): void {
 		$schema = $this->settings->getSchema();
 
-		$this->assertSame('aiquila_admin', $schema['id']);
+		$this->assertSame('aiquila_admin_params', $schema['id']);
 		$this->assertSame(DeclarativeSettingsTypes::SECTION_TYPE_ADMIN, $schema['section_type']);
 		$this->assertSame('aiquila', $schema['section_id']);
 		$this->assertSame(DeclarativeSettingsTypes::STORAGE_TYPE_INTERNAL, $schema['storage_type']);
 		$this->assertNotEmpty($schema['title']);
 		$this->assertIsArray($schema['fields']);
-	}
-
-	public function testModelField(): void {
-		$fields = $this->settings->getSchema()['fields'];
-		$model = $this->findField($fields, 'model');
-
-		$this->assertNotNull($model, 'model field should exist');
-		$this->assertSame(DeclarativeSettingsTypes::SELECT, $model['type']);
-		$this->assertSame(ClaudeModels::DEFAULT_MODEL, $model['default']);
-
-		$this->assertSame(ClaudeModels::getAllModels(), $model['options']);
+		$this->assertCount(2, $schema['fields']);
 	}
 
 	public function testMaxTokensField(): void {
@@ -54,9 +44,9 @@ class AdminDeclarativeSettingsTest extends TestCase {
 		$this->assertSame('30', $field['default']);
 	}
 
-	public function testDoesNotContainApiKey(): void {
+	public function testDoesNotContainModel(): void {
 		$fields = $this->settings->getSchema()['fields'];
-		$this->assertNull($this->findField($fields, 'api_key'), 'api_key must not be in declarative settings');
+		$this->assertNull($this->findField($fields, 'model'), 'model field lives in its own form');
 	}
 
 	private function findField(array $fields, string $id): ?array {

--- a/nextcloud-app/tests/Unit/Settings/AdminSearchDeclarativeSettingsTest.php
+++ b/nextcloud-app/tests/Unit/Settings/AdminSearchDeclarativeSettingsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace OCA\AIquila\Tests\Unit\Settings;
+
+use OCA\AIquila\Settings\AdminSearchDeclarativeSettings;
+use OCP\Settings\DeclarativeSettingsTypes;
+use PHPUnit\Framework\TestCase;
+
+class AdminSearchDeclarativeSettingsTest extends TestCase {
+	private AdminSearchDeclarativeSettings $settings;
+
+	protected function setUp(): void {
+		$this->settings = new AdminSearchDeclarativeSettings();
+	}
+
+	public function testSchemaStructure(): void {
+		$schema = $this->settings->getSchema();
+
+		$this->assertSame('aiquila_admin_search', $schema['id']);
+		$this->assertSame(DeclarativeSettingsTypes::SECTION_TYPE_ADMIN, $schema['section_type']);
+		$this->assertSame('aiquila', $schema['section_id']);
+		$this->assertSame(DeclarativeSettingsTypes::STORAGE_TYPE_INTERNAL, $schema['storage_type']);
+		$this->assertNotEmpty($schema['title']);
+		$this->assertIsArray($schema['fields']);
+		$this->assertCount(1, $schema['fields']);
+	}
+
+	public function testSearchEnabledField(): void {
+		$fields = $this->settings->getSchema()['fields'];
+		$field = $this->findField($fields, 'search_enabled');
+
+		$this->assertNotNull($field, 'search_enabled field should exist');
+		$this->assertSame(DeclarativeSettingsTypes::CHECKBOX, $field['type']);
+		$this->assertSame('1', $field['default']);
+	}
+
+	private function findField(array $fields, string $id): ?array {
+		foreach ($fields as $field) {
+			if ($field['id'] === $id) {
+				return $field;
+			}
+		}
+		return null;
+	}
+}

--- a/nextcloud-app/tests/Unit/Settings/UserDeclarativeSettingsTest.php
+++ b/nextcloud-app/tests/Unit/Settings/UserDeclarativeSettingsTest.php
@@ -4,17 +4,23 @@ namespace OCA\AIquila\Tests\Unit\Settings;
 
 use OCA\AIquila\Service\ClaudeModels;
 use OCA\AIquila\Settings\UserDeclarativeSettings;
+use OCP\IConfig;
 use OCP\Settings\DeclarativeSettingsTypes;
 use PHPUnit\Framework\TestCase;
 
 class UserDeclarativeSettingsTest extends TestCase {
 	private UserDeclarativeSettings $settings;
+	private IConfig $config;
 
 	protected function setUp(): void {
-		$this->settings = new UserDeclarativeSettings();
+		$this->config = $this->createMock(IConfig::class);
+		$this->settings = new UserDeclarativeSettings($this->config);
 	}
 
 	public function testSchemaStructure(): void {
+		$this->config->method('getAppValue')
+			->willReturn(ClaudeModels::DEFAULT_MODEL);
+
 		$schema = $this->settings->getSchema();
 
 		$this->assertSame('aiquila_user', $schema['id']);
@@ -26,10 +32,13 @@ class UserDeclarativeSettingsTest extends TestCase {
 	}
 
 	public function testModelField(): void {
+		$this->config->method('getAppValue')
+			->willReturn(ClaudeModels::DEFAULT_MODEL);
+
 		$fields = $this->settings->getSchema()['fields'];
 		$model = $this->findField($fields, 'user_model');
 
-		$this->assertNotNull($model, 'model field should exist');
+		$this->assertNotNull($model, 'user_model field should exist');
 		$this->assertSame(DeclarativeSettingsTypes::SELECT, $model['type']);
 		$this->assertSame('', $model['default']);
 
@@ -43,7 +52,32 @@ class UserDeclarativeSettingsTest extends TestCase {
 		);
 	}
 
+	public function testDescriptionShowsCurrentAdminModel(): void {
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('aiquila', 'model', ClaudeModels::DEFAULT_MODEL)
+			->willReturn('claude-opus-4-7');
+
+		$fields = $this->settings->getSchema()['fields'];
+		$model = $this->findField($fields, 'user_model');
+
+		$this->assertStringContainsString('claude-opus-4-7', $model['description']);
+	}
+
+	public function testDescriptionFallsBackToClaudeModelsDefault(): void {
+		$this->config->method('getAppValue')
+			->willReturnCallback(static fn ($app, $key, $default) => $default);
+
+		$fields = $this->settings->getSchema()['fields'];
+		$model = $this->findField($fields, 'user_model');
+
+		$this->assertStringContainsString(ClaudeModels::DEFAULT_MODEL, $model['description']);
+	}
+
 	public function testDoesNotContainApiKey(): void {
+		$this->config->method('getAppValue')
+			->willReturn(ClaudeModels::DEFAULT_MODEL);
+
 		$fields = $this->settings->getSchema()['fields'];
 		$this->assertNull($this->findField($fields, 'api_key'), 'api_key must not be in declarative settings');
 	}

--- a/nextcloud-app/tests/Unit/Settings/UserDeclarativeSettingsTest.php
+++ b/nextcloud-app/tests/Unit/Settings/UserDeclarativeSettingsTest.php
@@ -33,12 +33,14 @@ class UserDeclarativeSettingsTest extends TestCase {
 		$this->assertSame(DeclarativeSettingsTypes::SELECT, $model['type']);
 		$this->assertSame('', $model['default']);
 
-		// First option should be the admin-default placeholder
-		$this->assertSame('', $model['options'][0]['value']);
+		// First option is the empty-string admin-default sentinel
+		$this->assertSame('', $model['options'][0]);
 
-		// Remaining options should be all available models
-		$optionValues = array_column(array_slice($model['options'], 1), 'value');
-		$this->assertSame(ClaudeModels::getAllModels(), $optionValues);
+		// Remaining options are all available models
+		$this->assertSame(
+			ClaudeModels::getAllModels(),
+			array_values(array_slice($model['options'], 1))
+		);
 	}
 
 	public function testDoesNotContainApiKey(): void {


### PR DESCRIPTION
## Summary

Two-part change on the same branch:

### 1. Declarative SELECT options must be plain strings (original fix)

- Admin page (`/settings/admin/aiquila`) and personal page (`/settings/user/aiquila`) rendered every Claude model as the literal text **undefined**.
- Root cause: `AdminDeclarativeSettings` / `UserDeclarativeSettings` declared SELECT options as `[{name, value}]` objects. Nextcloud's declarative `SELECT` expects a plain array of strings — NC core's `DeclarativeSection.vue` hands `formField.options` straight to `NcSelect` with no `label` / `:reduce` prop, so vue-select fell back to the missing `label` key and rendered "undefined".
- Fix: switch both schemas to plain string arrays. User schema keeps `""` as the first entry (preserves the existing "empty == admin default" fallback in `ClaudeSDKService`) plus a `placeholder` so the blank row is meaningful.

### 2. Admin settings page reorganization + copy rewrite

- **Three admin cards instead of one** — the old single form is split into:
  - **Default Claude model** (priority 10) — just the `model` field
  - **Request parameters** (priority 20) — `max_tokens` + `api_timeout`
  - **Search integration** (priority 30, new) — exposes the previously UI-less `search_enabled` flag as a checkbox
- **Rewritten copy** — every field title + description explains *why* an admin would touch the knob, not just what it does (Opus/Sonnet/Haiku tradeoff, cost/latency impact of `max_tokens`, consequences of short `api_timeout`, etc.).
- **User settings** — now injects `IConfig`, interpolates the current admin model into the "Preferred model" description (e.g. *"Leave blank to use the instance default (currently: claude-sonnet-4-6)"*) and fixes the typo ("Leave on the blank entry" → "Leave blank").
- **Legacy `templates/admin.php` reorganized** — page-level intro, rename top section to "Claude API key" with a clearer hint, inline the "What's MCP?" link into the MCP section intro (not dangling at the bottom), merge the two sibling link lists into a single **Resources** section.
- **`search_enabled` storage migrated** `'yes'`/`'no'` → `'1'`/`'0'` to match `CHECKBOX`'s native format; `AIquilaCapability` reader updated accordingly. No prod data has ever used this key (no UI wrote to it), so no migration needed.

Version bump `0.3.1 → 0.3.2` (unchanged from the first commit).

## Test plan

- [x] `cd nextcloud-app && ./vendor/bin/phpunit --filter DeclarativeSettings` — pass
- [x] `cd nextcloud-app && ./vendor/bin/phpunit` — 266/266 pass
- [x] `cd docker/installation && make reset && make test` — functional stack boots, app installs cleanly, `/settings/admin/aiquila` renders without PHP errors and without any "undefined" strings
- [x] `occ config:app:set aiquila search_enabled --value=0` → `/ocs/v2.php/cloud/capabilities` returns `"search_enabled": false`; `--value=1` → `true`
- [ ] Manually open `/settings/admin/aiquila`: three separate cards appear in order (Default Claude model → Request parameters → Search integration); new copy reads clearly
- [ ] Open `/settings/user/aiquila`: the "Preferred model" description shows the actual admin default (e.g. "currently: claude-sonnet-4-6"); picking the blank row falls back to the admin model

🤖 Generated with [Claude Code](https://claude.com/claude-code)