### PR TITLE
fix(mcp): quote etag in Notes If-Match header

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "AIquila - MCP server for Nextcloud integration",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,13 +18,13 @@
       ]
     }
   ],
-  "version": "0.3.2",
+  "version": "0.3.3",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -52,7 +52,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.2",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.3",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/__tests__/client-notes.test.ts
+++ b/mcp-server/src/__tests__/client-notes.test.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fetchNotesAPI } from '../client/notes.js';
+
+describe('fetchNotesAPI', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    process.env.NEXTCLOUD_URL = 'https://cloud.example.com';
+    process.env.NEXTCLOUD_USER = 'admin';
+    process.env.NEXTCLOUD_PASSWORD = 'testpass';
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function okJson(body: unknown) {
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    };
+  }
+
+  it('wraps unquoted If-Match etag in quotes (Notes API returns raw hash)', async () => {
+    fetchMock.mockResolvedValue(okJson({ id: 1 }));
+
+    await fetchNotesAPI('/notes/1', {
+      method: 'PUT',
+      ifMatch: '4257c67ab42607fb04f2f1302e2a9d4e',
+      body: { title: 't', content: 'c', category: '', favorite: false },
+    });
+
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers['If-Match']).toBe('"4257c67ab42607fb04f2f1302e2a9d4e"');
+  });
+
+  it('preserves already-quoted If-Match etag', async () => {
+    fetchMock.mockResolvedValue(okJson({ id: 1 }));
+
+    await fetchNotesAPI('/notes/1', {
+      method: 'PUT',
+      ifMatch: '"already-quoted"',
+      body: {},
+    });
+
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers['If-Match']).toBe('"already-quoted"');
+  });
+
+  it('omits If-Match header when ifMatch is not provided', async () => {
+    fetchMock.mockResolvedValue(okJson({ id: 1 }));
+
+    await fetchNotesAPI('/notes/1');
+
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers['If-Match']).toBeUndefined();
+  });
+});

--- a/mcp-server/src/client/notes.ts
+++ b/mcp-server/src/client/notes.ts
@@ -45,7 +45,10 @@ export async function fetchNotesAPI<T = unknown>(
   };
 
   if (options.ifMatch) {
-    headers['If-Match'] = options.ifMatch;
+    // Notes API returns etag as an unquoted hash in JSON but requires a quoted
+    // value in the If-Match header per RFC 7232. Wrap if not already quoted.
+    const tag = options.ifMatch;
+    headers['If-Match'] = tag.startsWith('"') ? tag : `"${tag}"`;
   }
 
   let body: string | undefined;


### PR DESCRIPTION
## Summary

- `update_note` always returned `412 Precondition Failed` because the Notes API's JSON `etag` field is unquoted but the `If-Match` request header requires the RFC 7232 quoted form.
- Wrap the etag in double quotes (if not already) when building the header.
- Bump mcp-server to 0.3.3.

Fixes #302.

## Test plan

- [x] New unit test `src/__tests__/client-notes.test.ts` asserts `If-Match` is quoted for raw hashes and preserved when already quoted.
- [x] Full `npm test` suite passes (623 tests).
- [x] End-to-end verified against the local standalone stack: `create_note` + `update_note` now succeeds (previously 412).

🤖 Generated with [Claude Code](https://claude.com/claude-code)