### PR TITLE
feat(mcp): Forms integration

### DIFF
--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -36,6 +36,7 @@ Nextcloud apps and administration:
 - **Maps** — Favorites, GPS devices/tracks, photo geotagging, custom maps, import/export
 - **Notes** — Markdown notes with categories and search
 - **Polls** — Create text/date polls, vote, comment, and share
+- **Forms** — Build surveys, collect responses, and export results
 - **Cookbook** — Recipe management with schema.org format
 - **Assistant** — Nextcloud AI task processing and image generation
 - **Shares** — File share CRUD and auditing
@@ -222,6 +223,35 @@ Nextcloud apps and administration:
 | `add_poll_share` | Share via link/user/email | [Polls](tools/apps/polls.md#add_poll_share) |
 | `delete_poll_share` | Revoke a share | [Polls](tools/apps/polls.md#delete_poll_share) |
 | `set_poll_subscription` | Subscribe/unsubscribe to updates | [Polls](tools/apps/polls.md#set_poll_subscription) |
+
+#### Forms (25 tools)
+| Tool | Description | Documentation |
+|------|-------------|---------------|
+| `list_forms` | List owned/shared/partial forms | [Forms](tools/apps/forms.md#list_forms) |
+| `get_form` | Get a form with questions and shares | [Forms](tools/apps/forms.md#get_form) |
+| `create_form` | Create a new empty form | [Forms](tools/apps/forms.md#create_form) |
+| `clone_form` | Clone an existing form | [Forms](tools/apps/forms.md#clone_form) |
+| `update_form` | Update form title, state, expiration, flags | [Forms](tools/apps/forms.md#update_form) |
+| `transfer_form_owner` | Transfer form ownership | [Forms](tools/apps/forms.md#transfer_form_owner) |
+| `delete_form` | Delete a form | [Forms](tools/apps/forms.md#delete_form) |
+| `list_form_questions` | List questions on a form | [Forms](tools/apps/forms.md#list_form_questions) |
+| `create_form_question` | Add a question | [Forms](tools/apps/forms.md#create_form_question) |
+| `update_form_question` | Update a question | [Forms](tools/apps/forms.md#update_form_question) |
+| `reorder_form_questions` | Reorder questions | [Forms](tools/apps/forms.md#reorder_form_questions) |
+| `delete_form_question` | Delete a question | [Forms](tools/apps/forms.md#delete_form_question) |
+| `create_form_options` | Add options to a choice question | [Forms](tools/apps/forms.md#create_form_options) |
+| `update_form_option` | Update an option | [Forms](tools/apps/forms.md#update_form_option) |
+| `reorder_form_options` | Reorder options | [Forms](tools/apps/forms.md#reorder_form_options) |
+| `delete_form_option` | Delete an option | [Forms](tools/apps/forms.md#delete_form_option) |
+| `create_form_share` | Share with a user, group, or public link | [Forms](tools/apps/forms.md#create_form_share) |
+| `update_form_share` | Change share permissions | [Forms](tools/apps/forms.md#update_form_share) |
+| `delete_form_share` | Revoke a share | [Forms](tools/apps/forms.md#delete_form_share) |
+| `list_form_submissions` | List submissions (search/paginate) | [Forms](tools/apps/forms.md#list_form_submissions) |
+| `get_form_submission` | Get a single submission | [Forms](tools/apps/forms.md#get_form_submission) |
+| `create_form_submission` | Submit answers to a form | [Forms](tools/apps/forms.md#create_form_submission) |
+| `delete_form_submission` | Delete a submission | [Forms](tools/apps/forms.md#delete_form_submission) |
+| `delete_all_form_submissions` | Delete all submissions | [Forms](tools/apps/forms.md#delete_all_form_submissions) |
+| `export_form_submissions` | Export submissions to Nextcloud storage | [Forms](tools/apps/forms.md#export_form_submissions) |
 
 #### Cookbook (6 tools)
 | Tool | Description | Documentation |

--- a/docs/mcp/tools/apps/forms.md
+++ b/docs/mcp/tools/apps/forms.md
@@ -1,0 +1,209 @@
+# Nextcloud Forms Tools
+
+Integration with the [Nextcloud Forms](https://apps.nextcloud.com/apps/forms) app. Build surveys and questionnaires, gather responses, and export results — all via MCP.
+
+## Prerequisites
+
+- Nextcloud Forms app installed and enabled (app ID: `forms`)
+- The MCP user has permission to create/read forms on the target Nextcloud
+
+## API
+
+Uses the documented Forms OCS API v3 at `/ocs/v2.php/apps/forms/api/v3/…`. All requests send `OCS-APIRequest: true` and Basic auth; responses are the unwrapped `ocs.data`.
+
+## Available Tools
+
+### Forms
+
+#### `list_forms`
+List forms visible to the current user.
+
+**Parameters:**
+- `type` (`"owned"` | `"shared"` | `"partial"`, optional) — defaults to `owned`. `partial` returns forms with unfinished drafts.
+
+#### `get_form`
+Get a single form with its questions, options, shares, and metadata.
+
+**Parameters:** `formId` (number, required).
+
+#### `create_form`
+Create a new empty form. Set title/description afterwards with `update_form`, then add questions with `create_form_question`.
+
+**Parameters:** none.
+
+#### `clone_form`
+Duplicate an existing form into a new form (questions, options, and settings are copied).
+
+**Parameters:** `formId` (number, required).
+
+#### `update_form`
+Update any subset of a form's properties. Only the fields you pass are changed.
+
+**Parameters (all optional except `formId`):**
+- `formId` (number, required)
+- `title`, `description`, `submissionMessage` (string)
+- `expires` (number) — unix timestamp; `0` disables expiration
+- `isAnonymous`, `submitMultiple`, `allowEditSubmissions`, `showExpiration` (boolean)
+- `state` (`0` = active, `1` = closed, `2` = archived)
+
+#### `transfer_form_owner`
+Transfer ownership of a form to another Nextcloud user.
+
+**Parameters:** `formId` (number), `ownerId` (string — the new owner's user ID).
+
+#### `delete_form`
+Permanently delete a form and all its submissions.
+
+**Parameters:** `formId` (number).
+
+### Questions
+
+#### `list_form_questions`
+List all questions on a form, in display order.
+
+**Parameters:** `formId` (number).
+
+#### `create_form_question`
+Add a question. For choice questions (`multiple`, `multiple_unique`, `dropdown`), call `create_form_options` afterwards.
+
+**Parameters:**
+- `formId` (number)
+- `type` (`short` | `long` | `multiple` | `multiple_unique` | `dropdown` | `date` | `datetime` | `time` | `file` | `linearscale` | `color`)
+- `text` (string, optional) — question text
+
+#### `update_form_question`
+Update question properties (text, requirement, type, extra settings).
+
+**Parameters (all optional except `formId` + `questionId`):**
+- `formId`, `questionId` (number)
+- `text`, `name` (string)
+- `isRequired` (boolean)
+- `type` (enum — same values as `create_form_question`)
+- `extraSettings` (object) — question-type-specific settings (`validationRegex`, `allowedFileTypes`, date/time bounds, linear-scale labels, …)
+
+#### `reorder_form_questions`
+Reorder all questions on a form. Pass the complete list of question IDs in the desired order.
+
+**Parameters:** `formId` (number), `newOrder` (array of numbers).
+
+#### `delete_form_question`
+Delete a question.
+
+**Parameters:** `formId` (number), `questionId` (number).
+
+### Options
+
+#### `create_form_options`
+Add one or more options to a choice question.
+
+**Parameters:**
+- `formId` (number)
+- `questionId` (number) — must be a choice-type question
+- `optionTexts` (array of strings)
+
+#### `update_form_option`
+Update an option's text (and optionally its `order`).
+
+**Parameters:** `formId`, `questionId`, `optionId` (numbers), `text` (string, optional), `order` (number, optional).
+
+#### `reorder_form_options`
+Reorder all options on a question. Pass the full list of option IDs in the desired order.
+
+**Parameters:** `formId` (number), `questionId` (number), `newOrder` (array of numbers).
+
+#### `delete_form_option`
+Delete one option.
+
+**Parameters:** `formId`, `questionId`, `optionId` (numbers).
+
+### Shares
+
+#### `create_form_share`
+Share a form with a user, group, or as a public link.
+
+**Parameters:**
+- `formId` (number)
+- `type` (`user` | `group` | `link`)
+- `shareWith` (string) — user ID (`type=user`) or group ID (`type=group`); omitted for `type=link`
+- `permissions` (array of `edit` | `results` | `results_delete` | `submit` | `embed`, optional) — defaults to `["submit"]`
+
+#### `update_form_share`
+Change the permissions on an existing share.
+
+**Parameters:** `formId` (number), `shareId` (number), `permissions` (array).
+
+#### `delete_form_share`
+Revoke a share.
+
+**Parameters:** `formId` (number), `shareId` (number).
+
+### Submissions
+
+#### `list_form_submissions`
+List submissions for a form (owner / admin only). Supports free-text search and pagination.
+
+**Parameters:**
+- `formId` (number)
+- `query` (string, optional) — search across answer values
+- `limit` (number, 1–500, optional)
+- `offset` (number ≥ 0, optional)
+
+#### `get_form_submission`
+Get a single submission and its answers.
+
+**Parameters:** `formId` (number), `submissionId` (number).
+
+#### `create_form_submission`
+Record answers to a form. `answers` is keyed by **question ID**, and every value is an array:
+- text / long / date / time / number / email / phone / color questions → `["text answer"]`
+- `multiple` / `multiple_unique` / `dropdown` → `[optionId1, optionId2]` (numeric option IDs)
+- `linearscale` → `[3]`
+
+**Parameters:**
+- `formId` (number)
+- `answers` (record of `questionId → (string|number)[]`)
+- `shareHash` (string, optional) — required when submitting via a public link
+
+#### `delete_form_submission`
+Delete one submission.
+
+**Parameters:** `formId` (number), `submissionId` (number).
+
+#### `delete_all_form_submissions`
+Delete every submission for a form (the form itself is kept).
+
+**Parameters:** `formId` (number).
+
+#### `export_form_submissions`
+Export all submissions to the user's Nextcloud storage. Returns the destination path; use `read_file` / `get_file_info` to work with it afterwards.
+
+**Parameters:**
+- `formId` (number)
+- `path` (string) — destination folder inside the user's Nextcloud (e.g. `/Exports`)
+- `fileFormat` (`csv` | `ods` | `xlsx`)
+
+## Example Workflow
+
+```
+User: "Create a short feedback form with two questions and share a public link."
+Claude:
+  1. create_form()                                                      → formId = 42
+  2. update_form(formId: 42, title: "Sprint retro", state: 0)
+  3. create_form_question(formId: 42, type: "short", text: "What went well?")
+  4. create_form_question(formId: 42, type: "long",  text: "What would you change?")
+  5. create_form_share(formId: 42, type: "link")
+```
+
+## Limitations / Not Implemented
+
+- **Binary export download** (`GET /submissions?fileFormat=…`) — exposes bytes over HTTP; not a natural fit for the text-based MCP tool surface. Use `export_form_submissions` to land a file in Nextcloud, then `read_file`.
+- **File-upload answers** (`POST /submissions/files/{questionId}`) — requires multipart form-data; not in the initial integration. Text/choice/date/etc. questions are fully supported.
+- **Question clone** (`POST /questions?fromId=X`) — can be added later if needed.
+
+## References
+
+- [Nextcloud Forms app](https://apps.nextcloud.com/apps/forms)
+- [Forms API v3 documentation](https://github.com/nextcloud/forms/blob/main/docs/API_v3.md)
+- [Forms data structures](https://github.com/nextcloud/forms/blob/main/docs/DataStructure.md)
+- Source: [`mcp-server/src/tools/apps/forms.ts`](../../../../mcp-server/src/tools/apps/forms.ts)
+- Client: [`mcp-server/src/client/forms.ts`](../../../../mcp-server/src/client/forms.ts)

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,6 +1,6 @@
 # AIquila MCP Server
 
-MCP (Model Context Protocol) server that gives any MCP client full access to your Nextcloud instance — files, calendar, tasks, contacts, mail, talk, maps, bookmarks, notes, polls, and more. 219 tools across 32 categories.
+MCP (Model Context Protocol) server that gives any MCP client full access to your Nextcloud instance — files, calendar, tasks, contacts, mail, talk, maps, bookmarks, notes, polls, forms, and more. 244 tools across 33 categories.
 
 ## Quick Start
 
@@ -74,11 +74,12 @@ See the [Docker setup guide](https://github.com/elgorro/aiquila/blob/main/docs/m
 | Circles       |     8 |
 | Bookmarks     |    13 |
 | Polls         |    21 |
+| Forms         |    25 |
 | Assistant     |     4 |
 | Translate     |     1 |
 | User Status   |     5 |
 | Notifications |     4 |
-| **Total**     | **219** |
+| **Total**     | **244** |
 
 ## Configuration
 

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.3",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "AIquila - MCP server for Nextcloud integration",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,13 +18,13 @@
       ]
     }
   ],
-  "version": "0.3.4",
+  "version": "0.3.5",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -52,7 +52,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.4",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.5",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/__tests__/tools-forms.test.ts
+++ b/mcp-server/src/__tests__/tools-forms.test.ts
@@ -1,0 +1,562 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFetchFormsAPI = vi.fn();
+vi.mock('../client/forms.js', () => ({
+  fetchFormsAPI: (...args: unknown[]) => mockFetchFormsAPI(...args),
+}));
+
+const sampleForm = {
+  id: 42,
+  hash: 'abcd1234',
+  title: 'Lunch survey',
+  description: 'Help us plan the team lunch',
+  ownerId: 'alice',
+  created: 1714078369,
+  access: { permitAllUsers: false, showToAllUsers: false },
+  expires: 0,
+  isAnonymous: false,
+  state: 0 as const,
+  submitMultiple: false,
+  allowEditSubmissions: false,
+  showExpiration: false,
+  canSubmit: true,
+  permissions: ['edit', 'results', 'submit'] as const,
+  submissionCount: 3,
+};
+
+const sampleQuestion = {
+  id: 7,
+  formId: 42,
+  order: 1,
+  type: 'short' as const,
+  isRequired: true,
+  text: 'What is your favourite cuisine?',
+  name: 'favourite',
+  options: [],
+  extraSettings: {},
+};
+
+const sampleSubmission = {
+  id: 99,
+  formId: 42,
+  userId: 'bob',
+  userDisplayName: 'Bob',
+  timestamp: 1714078400,
+  answers: [{ id: 1, submissionId: 99, questionId: 7, questionName: 'favourite', text: 'Italian' }],
+};
+
+describe('Forms Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXTCLOUD_URL = 'https://cloud.example.com';
+    process.env.NEXTCLOUD_USER = 'alice';
+    process.env.NEXTCLOUD_PASSWORD = 'testpass';
+  });
+
+  describe('list_forms', () => {
+    it('returns a formatted form list', async () => {
+      mockFetchFormsAPI.mockResolvedValue([
+        sampleForm,
+        { ...sampleForm, id: 43, title: 'Retro feedback', state: 1 as const },
+      ]);
+      const { listFormsTool } = await import('../tools/apps/forms.js');
+      const result = await listFormsTool.handler({});
+      expect(result.content[0].text).toContain('Forms (2)');
+      expect(result.content[0].text).toContain('Lunch survey');
+      expect(result.content[0].text).toContain('Retro feedback');
+    });
+
+    it('handles empty list', async () => {
+      mockFetchFormsAPI.mockResolvedValue([]);
+      const { listFormsTool } = await import('../tools/apps/forms.js');
+      const result = await listFormsTool.handler({});
+      expect(result.content[0].text).toContain('No forms found');
+    });
+
+    it('passes type=shared as a query param', async () => {
+      mockFetchFormsAPI.mockResolvedValue([]);
+      const { listFormsTool } = await import('../tools/apps/forms.js');
+      await listFormsTool.handler({ type: 'shared' });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms', {
+        queryParams: { type: 'shared' },
+      });
+    });
+
+    it('maps 403 to access denied', async () => {
+      const { ApiError } = await import('../client/aiquila.js');
+      mockFetchFormsAPI.mockRejectedValue(new ApiError(403, 'Forbidden', ''));
+      const { listFormsTool } = await import('../tools/apps/forms.js');
+      const result = await listFormsTool.handler({});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Access denied');
+    });
+  });
+
+  describe('get_form', () => {
+    it('renders details', async () => {
+      mockFetchFormsAPI.mockResolvedValue({ ...sampleForm, questions: [sampleQuestion] });
+      const { getFormTool } = await import('../tools/apps/forms.js');
+      const result = await getFormTool.handler({ formId: 42 });
+      expect(result.content[0].text).toContain('Lunch survey');
+      expect(result.content[0].text).toContain('Description: Help us plan');
+      expect(result.content[0].text).toContain('Questions: 1');
+    });
+
+    it('handles 404', async () => {
+      const { ApiError } = await import('../client/aiquila.js');
+      mockFetchFormsAPI.mockRejectedValue(new ApiError(404, 'Not Found', ''));
+      const { getFormTool } = await import('../tools/apps/forms.js');
+      const result = await getFormTool.handler({ formId: 999 });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('not found');
+    });
+  });
+
+  describe('create_form', () => {
+    it('posts an empty body', async () => {
+      mockFetchFormsAPI.mockResolvedValue(sampleForm);
+      const { createFormTool } = await import('../tools/apps/forms.js');
+      const result = await createFormTool.handler();
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms', { method: 'POST', body: {} });
+      expect(result.content[0].text).toContain('Form created');
+    });
+  });
+
+  describe('clone_form', () => {
+    it('posts with fromId query param', async () => {
+      mockFetchFormsAPI.mockResolvedValue({ ...sampleForm, id: 100 });
+      const { cloneFormTool } = await import('../tools/apps/forms.js');
+      await cloneFormTool.handler({ formId: 42 });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms', {
+        method: 'POST',
+        body: {},
+        queryParams: { fromId: '42' },
+      });
+    });
+  });
+
+  describe('update_form', () => {
+    it('PATCHes only provided fields (no wrapping)', async () => {
+      mockFetchFormsAPI.mockResolvedValue(sampleForm);
+      const { updateFormTool } = await import('../tools/apps/forms.js');
+      await updateFormTool.handler({ formId: 42, title: 'New title', submitMultiple: true });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42', {
+        method: 'PATCH',
+        body: { title: 'New title', submitMultiple: true },
+      });
+    });
+
+    it('errors if no fields provided', async () => {
+      const { updateFormTool } = await import('../tools/apps/forms.js');
+      const result = await updateFormTool.handler({ formId: 42 });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('No fields');
+      expect(mockFetchFormsAPI).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('transfer_form_owner', () => {
+    it('PATCHes ownerId', async () => {
+      mockFetchFormsAPI.mockResolvedValue({ ...sampleForm, ownerId: 'bob' });
+      const { transferFormOwnerTool } = await import('../tools/apps/forms.js');
+      await transferFormOwnerTool.handler({ formId: 42, ownerId: 'bob' });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42', {
+        method: 'PATCH',
+        body: { ownerId: 'bob' },
+      });
+    });
+  });
+
+  describe('delete_form', () => {
+    it('calls DELETE', async () => {
+      mockFetchFormsAPI.mockResolvedValue(undefined);
+      const { deleteFormTool } = await import('../tools/apps/forms.js');
+      const result = await deleteFormTool.handler({ formId: 42 });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42', { method: 'DELETE' });
+      expect(result.content[0].text).toContain('deleted');
+    });
+  });
+
+  describe('list_form_questions', () => {
+    it('lists questions in order', async () => {
+      mockFetchFormsAPI.mockResolvedValue([
+        sampleQuestion,
+        { ...sampleQuestion, id: 8, order: 2, text: 'Dietary restrictions?', type: 'long' },
+      ]);
+      const { listFormQuestionsTool } = await import('../tools/apps/forms.js');
+      const result = await listFormQuestionsTool.handler({ formId: 42 });
+      expect(result.content[0].text).toContain('Questions (2)');
+      expect(result.content[0].text).toContain('favourite cuisine');
+      expect(result.content[0].text).toContain('Dietary restrictions');
+    });
+  });
+
+  describe('create_form_question', () => {
+    it('posts type and optional text', async () => {
+      mockFetchFormsAPI.mockResolvedValue(sampleQuestion);
+      const { createFormQuestionTool } = await import('../tools/apps/forms.js');
+      await createFormQuestionTool.handler({ formId: 42, type: 'short', text: 'Name?' });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/questions', {
+        method: 'POST',
+        body: { type: 'short', text: 'Name?' },
+      });
+    });
+
+    it('omits text when not provided', async () => {
+      mockFetchFormsAPI.mockResolvedValue(sampleQuestion);
+      const { createFormQuestionTool } = await import('../tools/apps/forms.js');
+      await createFormQuestionTool.handler({ formId: 42, type: 'dropdown' });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/questions', {
+        method: 'POST',
+        body: { type: 'dropdown' },
+      });
+    });
+  });
+
+  describe('update_form_question', () => {
+    it('PATCHes direct fields', async () => {
+      mockFetchFormsAPI.mockResolvedValue(sampleQuestion);
+      const { updateFormQuestionTool } = await import('../tools/apps/forms.js');
+      await updateFormQuestionTool.handler({
+        formId: 42,
+        questionId: 7,
+        text: 'New text',
+        isRequired: false,
+      });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/questions/7', {
+        method: 'PATCH',
+        body: { text: 'New text', isRequired: false },
+      });
+    });
+
+    it('errors on empty update', async () => {
+      const { updateFormQuestionTool } = await import('../tools/apps/forms.js');
+      const result = await updateFormQuestionTool.handler({ formId: 42, questionId: 7 });
+      expect(result.isError).toBe(true);
+      expect(mockFetchFormsAPI).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reorder_form_questions', () => {
+    it('sends newOrder array', async () => {
+      mockFetchFormsAPI.mockResolvedValue(undefined);
+      const { reorderFormQuestionsTool } = await import('../tools/apps/forms.js');
+      const result = await reorderFormQuestionsTool.handler({
+        formId: 42,
+        newOrder: [3, 1, 2],
+      });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/questions', {
+        method: 'PATCH',
+        body: { newOrder: [3, 1, 2] },
+      });
+      expect(result.content[0].text).toContain('Reordered 3 questions');
+    });
+  });
+
+  describe('delete_form_question', () => {
+    it('DELETEs at the question URL', async () => {
+      mockFetchFormsAPI.mockResolvedValue(undefined);
+      const { deleteFormQuestionTool } = await import('../tools/apps/forms.js');
+      await deleteFormQuestionTool.handler({ formId: 42, questionId: 7 });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/questions/7', {
+        method: 'DELETE',
+      });
+    });
+  });
+
+  describe('create_form_options', () => {
+    it('sends optionTexts array', async () => {
+      mockFetchFormsAPI.mockResolvedValue([
+        { id: 1, questionId: 7, order: 1, text: 'Pizza' },
+        { id: 2, questionId: 7, order: 2, text: 'Sushi' },
+      ]);
+      const { createFormOptionsTool } = await import('../tools/apps/forms.js');
+      const result = await createFormOptionsTool.handler({
+        formId: 42,
+        questionId: 7,
+        optionTexts: ['Pizza', 'Sushi'],
+      });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/questions/7/options', {
+        method: 'POST',
+        body: { optionTexts: ['Pizza', 'Sushi'] },
+      });
+      expect(result.content[0].text).toContain('Options created (2)');
+      expect(result.content[0].text).toContain('Pizza');
+    });
+  });
+
+  describe('update_form_option', () => {
+    it('PATCHes direct fields', async () => {
+      mockFetchFormsAPI.mockResolvedValue({ id: 1, questionId: 7, order: 2, text: 'Ramen' });
+      const { updateFormOptionTool } = await import('../tools/apps/forms.js');
+      await updateFormOptionTool.handler({
+        formId: 42,
+        questionId: 7,
+        optionId: 1,
+        text: 'Ramen',
+      });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/questions/7/options/1', {
+        method: 'PATCH',
+        body: { text: 'Ramen' },
+      });
+    });
+  });
+
+  describe('reorder_form_options', () => {
+    it('hits the reorder endpoint', async () => {
+      mockFetchFormsAPI.mockResolvedValue(undefined);
+      const { reorderFormOptionsTool } = await import('../tools/apps/forms.js');
+      await reorderFormOptionsTool.handler({ formId: 42, questionId: 7, newOrder: [2, 1] });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/questions/7/options/reorder', {
+        method: 'PATCH',
+        body: { newOrder: [2, 1] },
+      });
+    });
+  });
+
+  describe('delete_form_option', () => {
+    it('DELETEs the option URL', async () => {
+      mockFetchFormsAPI.mockResolvedValue(undefined);
+      const { deleteFormOptionTool } = await import('../tools/apps/forms.js');
+      await deleteFormOptionTool.handler({ formId: 42, questionId: 7, optionId: 1 });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/questions/7/options/1', {
+        method: 'DELETE',
+      });
+    });
+  });
+
+  describe('create_form_share', () => {
+    it('user share sends shareType=0', async () => {
+      mockFetchFormsAPI.mockResolvedValue({
+        id: 1,
+        formId: 42,
+        shareType: 0,
+        shareWith: 'bob',
+        permissions: ['submit'],
+      });
+      const { createFormShareTool } = await import('../tools/apps/forms.js');
+      await createFormShareTool.handler({ formId: 42, type: 'user', shareWith: 'bob' });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/shares', {
+        method: 'POST',
+        body: { shareType: '0', shareWith: 'bob', permissions: ['submit'] },
+      });
+    });
+
+    it('link share does not need shareWith', async () => {
+      mockFetchFormsAPI.mockResolvedValue({
+        id: 2,
+        formId: 42,
+        shareType: 3,
+        shareWith: 'hash1234',
+      });
+      const { createFormShareTool } = await import('../tools/apps/forms.js');
+      await createFormShareTool.handler({ formId: 42, type: 'link' });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/shares', {
+        method: 'POST',
+        body: { shareType: '3', shareWith: '', permissions: ['submit'] },
+      });
+    });
+
+    it('user share requires shareWith', async () => {
+      const { createFormShareTool } = await import('../tools/apps/forms.js');
+      const result = await createFormShareTool.handler({ formId: 42, type: 'user' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('shareWith');
+      expect(mockFetchFormsAPI).not.toHaveBeenCalled();
+    });
+
+    it('custom permissions pass through', async () => {
+      mockFetchFormsAPI.mockResolvedValue({
+        id: 3,
+        formId: 42,
+        shareType: 1,
+        shareWith: 'admins',
+      });
+      const { createFormShareTool } = await import('../tools/apps/forms.js');
+      await createFormShareTool.handler({
+        formId: 42,
+        type: 'group',
+        shareWith: 'admins',
+        permissions: ['submit', 'results'],
+      });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/shares', {
+        method: 'POST',
+        body: { shareType: '1', shareWith: 'admins', permissions: ['submit', 'results'] },
+      });
+    });
+  });
+
+  describe('update_form_share', () => {
+    it('PATCHes permissions', async () => {
+      mockFetchFormsAPI.mockResolvedValue({
+        id: 1,
+        formId: 42,
+        shareType: 0,
+        shareWith: 'bob',
+        permissions: ['submit', 'results'],
+      });
+      const { updateFormShareTool } = await import('../tools/apps/forms.js');
+      await updateFormShareTool.handler({
+        formId: 42,
+        shareId: 1,
+        permissions: ['submit', 'results'],
+      });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/shares/1', {
+        method: 'PATCH',
+        body: { permissions: ['submit', 'results'] },
+      });
+    });
+  });
+
+  describe('delete_form_share', () => {
+    it('DELETEs the share', async () => {
+      mockFetchFormsAPI.mockResolvedValue(undefined);
+      const { deleteFormShareTool } = await import('../tools/apps/forms.js');
+      await deleteFormShareTool.handler({ formId: 42, shareId: 1 });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/shares/1', {
+        method: 'DELETE',
+      });
+    });
+  });
+
+  describe('list_form_submissions', () => {
+    it('formats submissions with answers', async () => {
+      mockFetchFormsAPI.mockResolvedValue({
+        submissions: [sampleSubmission],
+        questions: [sampleQuestion],
+      });
+      const { listFormSubmissionsTool } = await import('../tools/apps/forms.js');
+      const result = await listFormSubmissionsTool.handler({ formId: 42 });
+      expect(result.content[0].text).toContain('Submissions (1)');
+      expect(result.content[0].text).toContain('Bob');
+      expect(result.content[0].text).toContain('favourite: Italian');
+    });
+
+    it('forwards query/limit/offset', async () => {
+      mockFetchFormsAPI.mockResolvedValue({ submissions: [] });
+      const { listFormSubmissionsTool } = await import('../tools/apps/forms.js');
+      await listFormSubmissionsTool.handler({
+        formId: 42,
+        query: 'pizza',
+        limit: 50,
+        offset: 0,
+      });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/submissions', {
+        queryParams: { query: 'pizza', limit: '50', offset: '0' },
+      });
+    });
+
+    it('handles empty', async () => {
+      mockFetchFormsAPI.mockResolvedValue({ submissions: [] });
+      const { listFormSubmissionsTool } = await import('../tools/apps/forms.js');
+      const result = await listFormSubmissionsTool.handler({ formId: 42 });
+      expect(result.content[0].text).toContain('No submissions');
+    });
+  });
+
+  describe('get_form_submission', () => {
+    it('returns a single submission', async () => {
+      mockFetchFormsAPI.mockResolvedValue(sampleSubmission);
+      const { getFormSubmissionTool } = await import('../tools/apps/forms.js');
+      const result = await getFormSubmissionTool.handler({ formId: 42, submissionId: 99 });
+      expect(result.content[0].text).toContain('Bob');
+      expect(result.content[0].text).toContain('favourite: Italian');
+    });
+  });
+
+  describe('create_form_submission', () => {
+    it('posts answers keyed by question id', async () => {
+      mockFetchFormsAPI.mockResolvedValue(undefined);
+      const { createFormSubmissionTool } = await import('../tools/apps/forms.js');
+      const result = await createFormSubmissionTool.handler({
+        formId: 42,
+        answers: { '7': ['Italian'], '8': [27, 32] },
+      });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/submissions', {
+        method: 'POST',
+        body: { answers: { '7': ['Italian'], '8': [27, 32] } },
+      });
+      expect(result.content[0].text).toContain('recorded');
+    });
+
+    it('includes shareHash when provided', async () => {
+      mockFetchFormsAPI.mockResolvedValue(undefined);
+      const { createFormSubmissionTool } = await import('../tools/apps/forms.js');
+      await createFormSubmissionTool.handler({
+        formId: 42,
+        answers: { '7': ['Thai'] },
+        shareHash: 'public-link-hash',
+      });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/submissions', {
+        method: 'POST',
+        body: { answers: { '7': ['Thai'] }, shareHash: 'public-link-hash' },
+      });
+    });
+  });
+
+  describe('delete_form_submission', () => {
+    it('DELETEs a single submission', async () => {
+      mockFetchFormsAPI.mockResolvedValue(undefined);
+      const { deleteFormSubmissionTool } = await import('../tools/apps/forms.js');
+      await deleteFormSubmissionTool.handler({ formId: 42, submissionId: 99 });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/submissions/99', {
+        method: 'DELETE',
+      });
+    });
+  });
+
+  describe('delete_all_form_submissions', () => {
+    it('DELETEs the submissions collection', async () => {
+      mockFetchFormsAPI.mockResolvedValue(undefined);
+      const { deleteAllFormSubmissionsTool } = await import('../tools/apps/forms.js');
+      const result = await deleteAllFormSubmissionsTool.handler({ formId: 42 });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/submissions', {
+        method: 'DELETE',
+      });
+      expect(result.content[0].text).toContain('All submissions deleted');
+    });
+  });
+
+  describe('export_form_submissions', () => {
+    it('POSTs path and fileFormat', async () => {
+      mockFetchFormsAPI.mockResolvedValue({ fileName: '/Exports/form-42.csv' });
+      const { exportFormSubmissionsTool } = await import('../tools/apps/forms.js');
+      const result = await exportFormSubmissionsTool.handler({
+        formId: 42,
+        path: '/Exports',
+        fileFormat: 'csv',
+      });
+      expect(mockFetchFormsAPI).toHaveBeenCalledWith('/forms/42/submissions/export', {
+        method: 'POST',
+        body: { path: '/Exports', fileFormat: 'csv' },
+      });
+      expect(result.content[0].text).toContain('/Exports/form-42.csv');
+    });
+
+    it('handles a plain string response', async () => {
+      mockFetchFormsAPI.mockResolvedValue('/Exports/form-42.xlsx');
+      const { exportFormSubmissionsTool } = await import('../tools/apps/forms.js');
+      const result = await exportFormSubmissionsTool.handler({
+        formId: 42,
+        path: '/Exports',
+        fileFormat: 'xlsx',
+      });
+      expect(result.content[0].text).toContain('/Exports/form-42.xlsx');
+    });
+  });
+
+  describe('formsTools array', () => {
+    it('exports 25 tools with valid shape', async () => {
+      const { formsTools } = await import('../tools/apps/forms.js');
+      expect(formsTools).toHaveLength(25);
+      for (const tool of formsTools) {
+        expect(tool.name).toMatch(/^[a-z_]+$/);
+        expect(tool.description.length).toBeGreaterThan(0);
+        expect(tool.inputSchema).toBeDefined();
+        expect(typeof tool.handler).toBe('function');
+      }
+    });
+  });
+});

--- a/mcp-server/src/client/forms.ts
+++ b/mcp-server/src/client/forms.ts
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MIT
+
+import { getNextcloudConfig } from '../tools/types.js';
+import { logger } from '../logger.js';
+import { ApiError } from './aiquila.js';
+
+export type FormState = 0 | 1 | 2;
+
+export type FormPermission = 'edit' | 'results' | 'results_delete' | 'submit' | 'embed';
+
+export type QuestionType =
+  | 'short'
+  | 'long'
+  | 'multiple'
+  | 'multiple_unique'
+  | 'dropdown'
+  | 'date'
+  | 'datetime'
+  | 'time'
+  | 'file'
+  | 'linearscale'
+  | 'color';
+
+export type ShareType = 0 | 1 | 3;
+
+export interface FormAccess {
+  permitAllUsers: boolean;
+  showToAllUsers: boolean;
+}
+
+export interface FormOption {
+  id: number;
+  questionId: number;
+  order: number;
+  text: string;
+}
+
+export interface FormQuestionExtraSettings {
+  allowOtherAnswer?: boolean;
+  shuffleOptions?: boolean;
+  optionsLimitMax?: number;
+  optionsLimitMin?: number;
+  validationType?: string | null;
+  validationRegex?: string;
+  allowedFileTypes?: string[];
+  allowedFileExtensions?: string[];
+  maxAllowedFilesCount?: number;
+  maxFileSize?: number;
+  dateMax?: number;
+  dateMin?: number;
+  dateRange?: boolean;
+  timeMax?: string;
+  timeMin?: string;
+  timeRange?: boolean;
+  optionsLowest?: number;
+  optionsHighest?: number;
+  optionsLabelLowest?: string;
+  optionsLabelHighest?: string;
+}
+
+export interface FormQuestion {
+  id: number;
+  formId: number;
+  order: number;
+  type: QuestionType;
+  isRequired: boolean;
+  text: string;
+  name: string;
+  options: FormOption[];
+  extraSettings: FormQuestionExtraSettings;
+}
+
+export interface FormAnswer {
+  id: number;
+  submissionId: number;
+  questionId: number;
+  questionName?: string;
+  text: string;
+  fileId?: number;
+}
+
+export interface FormSubmission {
+  id: number;
+  formId: number;
+  userId: string;
+  userDisplayName: string;
+  timestamp: number;
+  answers: FormAnswer[];
+}
+
+export interface FormShare {
+  id: number;
+  formId: number;
+  shareType: ShareType;
+  shareWith: string;
+  displayName?: string;
+  permissions?: FormPermission[];
+}
+
+export interface Form {
+  id: number;
+  hash: string;
+  title: string;
+  description: string;
+  ownerId: string;
+  submissionMessage?: string;
+  created: number;
+  access: FormAccess;
+  expires: number;
+  isAnonymous: boolean;
+  state: FormState;
+  lockedBy?: string | null;
+  lockedUntil?: number | null;
+  submitMultiple: boolean;
+  allowEditSubmissions?: boolean;
+  showExpiration: boolean;
+  canSubmit: boolean;
+  permissions: FormPermission[];
+  questions?: FormQuestion[];
+  shares?: FormShare[];
+  submissions?: FormSubmission[];
+  submissionCount?: number;
+}
+
+interface OcsEnvelope<T> {
+  ocs: {
+    meta: {
+      status: string;
+      statuscode: number;
+      message: string;
+      totalitems?: string;
+      itemsperpage?: string;
+    };
+    data: T;
+  };
+}
+
+/**
+ * Make an authenticated request to the Nextcloud Forms REST API v3.
+ *
+ * Base path: /ocs/v2.php/apps/forms/api/v3
+ * Unwraps the OCS envelope and returns `ocs.data` directly.
+ * Throws {@link ApiError} on HTTP errors or non-success OCS status codes.
+ */
+export async function fetchFormsAPI<T = unknown>(
+  endpoint: string,
+  options: {
+    method?: string;
+    body?: unknown;
+    queryParams?: Record<string, string>;
+  } = {}
+): Promise<T> {
+  const config = getNextcloudConfig();
+  const auth = Buffer.from(`${config.user}:${config.password}`).toString('base64');
+
+  let url = `${config.url}/ocs/v2.php/apps/forms/api/v3${endpoint}`;
+  if (options.queryParams) {
+    const params = new URLSearchParams(options.queryParams);
+    url += `?${params.toString()}`;
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Basic ${auth}`,
+    'OCS-APIRequest': 'true',
+    Accept: 'application/json',
+  };
+
+  let body: string | undefined;
+  if (options.body !== undefined) {
+    body = JSON.stringify(options.body);
+    headers['Content-Type'] = 'application/json';
+  }
+
+  const method = options.method ?? 'GET';
+  const t0 = Date.now();
+  const response = await fetch(url, { method, headers, body });
+  logger.trace({ method, url, status: response.status, ms: Date.now() - t0 }, '[forms] HTTP');
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new ApiError(response.status, response.statusText, text);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    return undefined as T;
+  }
+
+  const json = (await response.json()) as OcsEnvelope<T>;
+  const code = json?.ocs?.meta?.statuscode;
+  if (code !== undefined && code !== 200 && code !== 100) {
+    throw new ApiError(code, json.ocs.meta.status ?? 'error', json.ocs.meta.message ?? '');
+  }
+  return json.ocs.data;
+}

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -38,6 +38,7 @@ import { trashTools } from './tools/apps/trash.js';
 import { versionsTools } from './tools/apps/versions.js';
 import { projectsTools } from './tools/apps/projects.js';
 import { pollsTools } from './tools/apps/polls.js';
+import { formsTools } from './tools/apps/forms.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ToolArray = Array<{
@@ -97,6 +98,7 @@ export const TOOL_REGISTRY: ToolSetEntry[] = [
   { category: 'circles', appIds: ['circles'], tools: circlesTools },
   { category: 'bookmarks', appIds: ['bookmarks'], tools: bookmarksTools },
   { category: 'polls', appIds: ['polls'], tools: pollsTools },
+  { category: 'forms', appIds: ['forms'], tools: formsTools },
   { category: 'assistant', appIds: ['assistant'], tools: assistantTools },
   { category: 'translate', appIds: ['text_translate', 'translate'], tools: translateTools },
   { category: 'user_status', appIds: ['user_status'], tools: userStatusTools },

--- a/mcp-server/src/tools/apps/forms.ts
+++ b/mcp-server/src/tools/apps/forms.ts
@@ -1,0 +1,888 @@
+// SPDX-License-Identifier: MIT
+
+import { z } from 'zod';
+import {
+  fetchFormsAPI,
+  type Form,
+  type FormPermission,
+  type FormQuestion,
+  type FormOption,
+  type FormShare,
+  type FormSubmission,
+  type QuestionType,
+  type ShareType,
+} from '../../client/forms.js';
+import { handleAppError } from '../error-utils.js';
+
+/**
+ * Nextcloud Forms App Tools
+ * Uses the Forms OCS API v3 (/ocs/v2.php/apps/forms/api/v3)
+ */
+
+const formsStatusMap: Record<number, string> = {
+  400: 'Bad request — check parameters, or the form/question/option may not exist.',
+  403: 'Access denied to this form.',
+  404: 'Form, question, option, share, or submission not found.',
+};
+
+const QUESTION_TYPES = [
+  'short',
+  'long',
+  'multiple',
+  'multiple_unique',
+  'dropdown',
+  'date',
+  'datetime',
+  'time',
+  'file',
+  'linearscale',
+  'color',
+] as const;
+
+const PERMISSIONS = ['edit', 'results', 'results_delete', 'submit', 'embed'] as const;
+
+const SHARE_TYPE_LABELS: Record<ShareType, string> = {
+  0: 'user',
+  1: 'group',
+  3: 'link',
+};
+
+const STATE_LABELS: Record<number, string> = {
+  0: 'active',
+  1: 'closed',
+  2: 'archived',
+};
+
+function formatForm(f: Form): string {
+  const state = STATE_LABELS[f.state] ?? `state=${f.state}`;
+  const expires = f.expires ? ` expires=${new Date(f.expires * 1000).toISOString()}` : '';
+  const counts = f.submissionCount !== undefined ? ` submissions=${f.submissionCount}` : '';
+  return `[${f.id}] ${f.title || '(untitled)'} — owner=${f.ownerId}, ${state}${expires}${counts}`;
+}
+
+function formatFormDetailed(f: Form): string {
+  const lines: string[] = [formatForm(f)];
+  if (f.description) lines.push(`Description: ${f.description}`);
+  if (f.hash) lines.push(`Hash: ${f.hash}`);
+  if (f.created) lines.push(`Created: ${new Date(f.created * 1000).toISOString()}`);
+  const flags = [
+    f.isAnonymous ? 'anonymous' : null,
+    f.submitMultiple ? 'submit-multiple' : null,
+    f.allowEditSubmissions ? 'edit-submissions' : null,
+    f.showExpiration ? 'show-expiration' : null,
+    f.access?.permitAllUsers ? 'all-users' : null,
+  ].filter(Boolean);
+  if (flags.length) lines.push(`Flags: ${flags.join(', ')}`);
+  if (f.permissions?.length) lines.push(`Permissions: ${f.permissions.join(', ')}`);
+  if (f.questions?.length) lines.push(`Questions: ${f.questions.length}`);
+  if (f.shares?.length) lines.push(`Shares: ${f.shares.length}`);
+  return lines.join('\n');
+}
+
+function formatQuestion(q: FormQuestion): string {
+  const req = q.isRequired ? ' *required*' : '';
+  const optCount = q.options?.length ? ` (${q.options.length} options)` : '';
+  return `[${q.id}] #${q.order} ${q.type}${req}: ${q.text || q.name || '(no text)'}${optCount}`;
+}
+
+function formatOption(o: FormOption): string {
+  return `[${o.id}] #${o.order} ${o.text}`;
+}
+
+function formatShare(s: FormShare): string {
+  const type = SHARE_TYPE_LABELS[s.shareType] ?? `type=${s.shareType}`;
+  const who = s.displayName ? `${s.displayName} (${s.shareWith})` : s.shareWith;
+  const perms = s.permissions?.length ? ` [${s.permissions.join(',')}]` : '';
+  return `[${s.id}] ${type}: ${who}${perms}`;
+}
+
+function formatAnswer(a: { questionName?: string; text: string; fileId?: number }): string {
+  const q = a.questionName ? `${a.questionName}: ` : '';
+  const file = a.fileId ? ` (fileId=${a.fileId})` : '';
+  return `${q}${a.text}${file}`;
+}
+
+function formatSubmission(s: FormSubmission): string {
+  const when = s.timestamp ? new Date(s.timestamp * 1000).toISOString() : '';
+  const who = s.userDisplayName || s.userId || 'anonymous';
+  const answers =
+    s.answers && s.answers.length ? '\n  ' + s.answers.map(formatAnswer).join('\n  ') : '';
+  return `[${s.id}] ${who}${when ? ` at ${when}` : ''}${answers}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Forms
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const listFormsTool = {
+  name: 'list_forms',
+  description:
+    'List forms. type="owned" (default) returns forms the current user owns; "shared" returns forms shared with them; "partial" returns forms the user has an unfinished draft on.',
+  inputSchema: z.object({
+    type: z.enum(['owned', 'shared', 'partial']).optional().describe('Form list scope'),
+  }),
+  handler: async (args: { type?: 'owned' | 'shared' | 'partial' } = {}) => {
+    try {
+      const queryParams = args.type ? { type: args.type } : undefined;
+      const forms = await fetchFormsAPI<Form[]>('/forms', { queryParams });
+      if (!forms || forms.length === 0) {
+        return { content: [{ type: 'text' as const, text: 'No forms found.' }] };
+      }
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Forms (${forms.length}):\n\n${forms.map(formatForm).join('\n')}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error listing forms', formsStatusMap);
+    }
+  },
+};
+
+export const getFormTool = {
+  name: 'get_form',
+  description:
+    'Get full details for a form by ID, including questions, options, shares, and metadata.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID (from list_forms)'),
+  }),
+  handler: async (args: { formId: number }) => {
+    try {
+      const form = await fetchFormsAPI<Form>(`/forms/${args.formId}`);
+      return {
+        content: [{ type: 'text' as const, text: formatFormDetailed(form) }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error getting form', formsStatusMap);
+    }
+  },
+};
+
+export const createFormTool = {
+  name: 'create_form',
+  description:
+    'Create a new empty form. Returns the new form ID. Use update_form to set title/description and create_form_question to add questions.',
+  inputSchema: z.object({}),
+  handler: async () => {
+    try {
+      const form = await fetchFormsAPI<Form>('/forms', { method: 'POST', body: {} });
+      return {
+        content: [{ type: 'text' as const, text: `Form created: ${formatForm(form)}` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error creating form', formsStatusMap);
+    }
+  },
+};
+
+export const cloneFormTool = {
+  name: 'clone_form',
+  description: 'Clone an existing form (its questions, options, and settings) into a new form.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID to clone'),
+  }),
+  handler: async (args: { formId: number }) => {
+    try {
+      const form = await fetchFormsAPI<Form>('/forms', {
+        method: 'POST',
+        body: {},
+        queryParams: { fromId: String(args.formId) },
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Form cloned: ${formatForm(form)}` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error cloning form', formsStatusMap);
+    }
+  },
+};
+
+export const updateFormTool = {
+  name: 'update_form',
+  description:
+    'Update form properties. Only provided fields are changed. state: 0=active, 1=closed, 2=archived. expires=0 disables expiration.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    title: z.string().optional(),
+    description: z.string().optional(),
+    submissionMessage: z.string().optional(),
+    expires: z.number().int().optional().describe('Unix timestamp; 0 = no expiration'),
+    isAnonymous: z.boolean().optional(),
+    submitMultiple: z.boolean().optional(),
+    allowEditSubmissions: z.boolean().optional(),
+    showExpiration: z.boolean().optional(),
+    state: z.union([z.literal(0), z.literal(1), z.literal(2)]).optional(),
+  }),
+  handler: async (args: {
+    formId: number;
+    title?: string;
+    description?: string;
+    submissionMessage?: string;
+    expires?: number;
+    isAnonymous?: boolean;
+    submitMultiple?: boolean;
+    allowEditSubmissions?: boolean;
+    showExpiration?: boolean;
+    state?: 0 | 1 | 2;
+  }) => {
+    try {
+      const { formId, ...rest } = args;
+      const body: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(rest)) {
+        if (v !== undefined) body[k] = v;
+      }
+      if (Object.keys(body).length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: 'No fields provided to update.' }],
+          isError: true,
+        };
+      }
+      const form = await fetchFormsAPI<Form>(`/forms/${formId}`, {
+        method: 'PATCH',
+        body,
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Form updated: ${formatForm(form)}` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error updating form', formsStatusMap);
+    }
+  },
+};
+
+export const transferFormOwnerTool = {
+  name: 'transfer_form_owner',
+  description:
+    'Transfer ownership of a form to another Nextcloud user. The new owner must have access to the Forms app.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    ownerId: z.string().describe('User ID of the new owner'),
+  }),
+  handler: async (args: { formId: number; ownerId: string }) => {
+    try {
+      const form = await fetchFormsAPI<Form>(`/forms/${args.formId}`, {
+        method: 'PATCH',
+        body: { ownerId: args.ownerId },
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Ownership transferred: ${formatForm(form)}` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error transferring form ownership', formsStatusMap);
+    }
+  },
+};
+
+export const deleteFormTool = {
+  name: 'delete_form',
+  description: 'Permanently delete a form and all of its submissions. This cannot be undone.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+  }),
+  handler: async (args: { formId: number }) => {
+    try {
+      await fetchFormsAPI(`/forms/${args.formId}`, { method: 'DELETE' });
+      return {
+        content: [{ type: 'text' as const, text: `Form ${args.formId} deleted.` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error deleting form', formsStatusMap);
+    }
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Questions
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const listFormQuestionsTool = {
+  name: 'list_form_questions',
+  description: 'List all questions for a form, in display order.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+  }),
+  handler: async (args: { formId: number }) => {
+    try {
+      const questions = await fetchFormsAPI<FormQuestion[]>(`/forms/${args.formId}/questions`);
+      if (!questions || questions.length === 0) {
+        return { content: [{ type: 'text' as const, text: 'No questions for this form.' }] };
+      }
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Questions (${questions.length}):\n\n${questions.map(formatQuestion).join('\n')}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error listing questions', formsStatusMap);
+    }
+  },
+};
+
+export const createFormQuestionTool = {
+  name: 'create_form_question',
+  description:
+    'Add a question to a form. For choice questions use type "multiple" (checkbox), "multiple_unique" (radio), or "dropdown" — then call create_form_options.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    type: z.enum(QUESTION_TYPES).describe('Question type'),
+    text: z.string().optional().describe('Question text (optional at creation)'),
+  }),
+  handler: async (args: { formId: number; type: QuestionType; text?: string }) => {
+    try {
+      const body: Record<string, unknown> = { type: args.type };
+      if (args.text !== undefined) body.text = args.text;
+      const question = await fetchFormsAPI<FormQuestion>(`/forms/${args.formId}/questions`, {
+        method: 'POST',
+        body,
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Question created: ${formatQuestion(question)}` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error creating question', formsStatusMap);
+    }
+  },
+};
+
+export const updateFormQuestionTool = {
+  name: 'update_form_question',
+  description:
+    'Update question properties (text, requirement, type, etc.). Only provided fields are changed.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    questionId: z.number().int().describe('Question ID'),
+    text: z.string().optional(),
+    name: z.string().optional().describe('Internal name / shortcode'),
+    isRequired: z.boolean().optional(),
+    type: z.enum(QUESTION_TYPES).optional(),
+    extraSettings: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe('Question-type-specific settings (e.g. validationRegex, allowedFileTypes)'),
+  }),
+  handler: async (args: {
+    formId: number;
+    questionId: number;
+    text?: string;
+    name?: string;
+    isRequired?: boolean;
+    type?: QuestionType;
+    extraSettings?: Record<string, unknown>;
+  }) => {
+    try {
+      const { formId, questionId, ...rest } = args;
+      const body: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(rest)) {
+        if (v !== undefined) body[k] = v;
+      }
+      if (Object.keys(body).length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: 'No fields provided to update.' }],
+          isError: true,
+        };
+      }
+      const question = await fetchFormsAPI<FormQuestion>(
+        `/forms/${formId}/questions/${questionId}`,
+        { method: 'PATCH', body }
+      );
+      return {
+        content: [{ type: 'text' as const, text: `Question updated: ${formatQuestion(question)}` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error updating question', formsStatusMap);
+    }
+  },
+};
+
+export const reorderFormQuestionsTool = {
+  name: 'reorder_form_questions',
+  description:
+    'Reorder all questions in a form. Pass the full list of question IDs in the desired order.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    newOrder: z
+      .array(z.number().int())
+      .min(1)
+      .describe('Full list of question IDs in desired order'),
+  }),
+  handler: async (args: { formId: number; newOrder: number[] }) => {
+    try {
+      await fetchFormsAPI(`/forms/${args.formId}/questions`, {
+        method: 'PATCH',
+        body: { newOrder: args.newOrder },
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Reordered ${args.newOrder.length} questions.` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error reordering questions', formsStatusMap);
+    }
+  },
+};
+
+export const deleteFormQuestionTool = {
+  name: 'delete_form_question',
+  description: 'Delete a question from a form.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    questionId: z.number().int().describe('Question ID'),
+  }),
+  handler: async (args: { formId: number; questionId: number }) => {
+    try {
+      await fetchFormsAPI(`/forms/${args.formId}/questions/${args.questionId}`, {
+        method: 'DELETE',
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Question ${args.questionId} deleted.` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error deleting question', formsStatusMap);
+    }
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Options
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const createFormOptionsTool = {
+  name: 'create_form_options',
+  description:
+    'Add one or more options to a choice question (multiple/multiple_unique/dropdown). Pass an array of option texts.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    questionId: z.number().int().describe('Question ID'),
+    optionTexts: z.array(z.string().min(1)).min(1).describe('One or more option texts to create'),
+  }),
+  handler: async (args: { formId: number; questionId: number; optionTexts: string[] }) => {
+    try {
+      const options = await fetchFormsAPI<FormOption[]>(
+        `/forms/${args.formId}/questions/${args.questionId}/options`,
+        { method: 'POST', body: { optionTexts: args.optionTexts } }
+      );
+      const list = options && options.length ? options.map(formatOption).join('\n') : '(none)';
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Options created (${options?.length ?? 0}):\n${list}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error creating options', formsStatusMap);
+    }
+  },
+};
+
+export const updateFormOptionTool = {
+  name: 'update_form_option',
+  description: "Update a choice option's text (and optionally its order).",
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    questionId: z.number().int().describe('Question ID'),
+    optionId: z.number().int().describe('Option ID'),
+    text: z.string().optional(),
+    order: z.number().int().optional(),
+  }),
+  handler: async (args: {
+    formId: number;
+    questionId: number;
+    optionId: number;
+    text?: string;
+    order?: number;
+  }) => {
+    try {
+      const { formId, questionId, optionId, ...rest } = args;
+      const body: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(rest)) {
+        if (v !== undefined) body[k] = v;
+      }
+      if (Object.keys(body).length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: 'No fields provided to update.' }],
+          isError: true,
+        };
+      }
+      const option = await fetchFormsAPI<FormOption>(
+        `/forms/${formId}/questions/${questionId}/options/${optionId}`,
+        { method: 'PATCH', body }
+      );
+      return {
+        content: [{ type: 'text' as const, text: `Option updated: ${formatOption(option)}` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error updating option', formsStatusMap);
+    }
+  },
+};
+
+export const reorderFormOptionsTool = {
+  name: 'reorder_form_options',
+  description:
+    'Reorder all options for a choice question. Pass the full list of option IDs in the desired order.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    questionId: z.number().int().describe('Question ID'),
+    newOrder: z.array(z.number().int()).min(1).describe('Full list of option IDs in desired order'),
+  }),
+  handler: async (args: { formId: number; questionId: number; newOrder: number[] }) => {
+    try {
+      await fetchFormsAPI(`/forms/${args.formId}/questions/${args.questionId}/options/reorder`, {
+        method: 'PATCH',
+        body: { newOrder: args.newOrder },
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Reordered ${args.newOrder.length} options.` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error reordering options', formsStatusMap);
+    }
+  },
+};
+
+export const deleteFormOptionTool = {
+  name: 'delete_form_option',
+  description: 'Delete an option from a choice question.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    questionId: z.number().int().describe('Question ID'),
+    optionId: z.number().int().describe('Option ID'),
+  }),
+  handler: async (args: { formId: number; questionId: number; optionId: number }) => {
+    try {
+      await fetchFormsAPI(
+        `/forms/${args.formId}/questions/${args.questionId}/options/${args.optionId}`,
+        { method: 'DELETE' }
+      );
+      return {
+        content: [{ type: 'text' as const, text: `Option ${args.optionId} deleted.` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error deleting option', formsStatusMap);
+    }
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shares
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const createFormShareTool = {
+  name: 'create_form_share',
+  description:
+    'Share a form. type="user" shares with a Nextcloud user (shareWith=userId), "group" with a group (shareWith=groupId), "link" creates a public link (shareWith is the generated hash, omit it at creation).',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    type: z.enum(['user', 'group', 'link']).describe('Share type'),
+    shareWith: z
+      .string()
+      .optional()
+      .describe('User ID (type=user) or group ID (type=group). Omit for type=link.'),
+    permissions: z
+      .array(z.enum(PERMISSIONS))
+      .optional()
+      .describe('Permissions to grant. Defaults to ["submit"] if omitted.'),
+  }),
+  handler: async (args: {
+    formId: number;
+    type: 'user' | 'group' | 'link';
+    shareWith?: string;
+    permissions?: FormPermission[];
+  }) => {
+    try {
+      const shareTypeMap: Record<'user' | 'group' | 'link', ShareType> = {
+        user: 0,
+        group: 1,
+        link: 3,
+      };
+      const shareTypeValue = shareTypeMap[args.type];
+      if ((args.type === 'user' || args.type === 'group') && !args.shareWith) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `shareWith is required for type="${args.type}".`,
+            },
+          ],
+          isError: true,
+        };
+      }
+      const body: Record<string, unknown> = {
+        shareType: String(shareTypeValue),
+        shareWith: args.shareWith ?? '',
+        permissions: args.permissions ?? ['submit'],
+      };
+      const share = await fetchFormsAPI<FormShare>(`/forms/${args.formId}/shares`, {
+        method: 'POST',
+        body,
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Share created: ${formatShare(share)}` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error creating share', formsStatusMap);
+    }
+  },
+};
+
+export const updateFormShareTool = {
+  name: 'update_form_share',
+  description: 'Update the permissions on an existing form share.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    shareId: z.number().int().describe('Share ID (from get_form)'),
+    permissions: z.array(z.enum(PERMISSIONS)).min(1).describe('New permission set'),
+  }),
+  handler: async (args: { formId: number; shareId: number; permissions: FormPermission[] }) => {
+    try {
+      const share = await fetchFormsAPI<FormShare>(`/forms/${args.formId}/shares/${args.shareId}`, {
+        method: 'PATCH',
+        body: { permissions: args.permissions },
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Share updated: ${formatShare(share)}` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error updating share', formsStatusMap);
+    }
+  },
+};
+
+export const deleteFormShareTool = {
+  name: 'delete_form_share',
+  description: 'Revoke a form share.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    shareId: z.number().int().describe('Share ID'),
+  }),
+  handler: async (args: { formId: number; shareId: number }) => {
+    try {
+      await fetchFormsAPI(`/forms/${args.formId}/shares/${args.shareId}`, {
+        method: 'DELETE',
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Share ${args.shareId} deleted.` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error deleting share', formsStatusMap);
+    }
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Submissions
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const listFormSubmissionsTool = {
+  name: 'list_form_submissions',
+  description:
+    'List submissions for a form. Supports free-text search (query) and pagination (limit/offset). Only form owners/admins see all submissions.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    query: z.string().optional().describe('Free-text search across answer values'),
+    limit: z.number().int().min(1).max(500).optional().describe('Max submissions to return'),
+    offset: z.number().int().min(0).optional().describe('Offset for pagination'),
+  }),
+  handler: async (args: { formId: number; query?: string; limit?: number; offset?: number }) => {
+    try {
+      const queryParams: Record<string, string> = {};
+      if (args.query) queryParams.query = args.query;
+      if (args.limit !== undefined) queryParams.limit = String(args.limit);
+      if (args.offset !== undefined) queryParams.offset = String(args.offset);
+      const data = await fetchFormsAPI<{
+        submissions: FormSubmission[];
+        questions?: FormQuestion[];
+      }>(`/forms/${args.formId}/submissions`, {
+        queryParams: Object.keys(queryParams).length ? queryParams : undefined,
+      });
+      const subs = data?.submissions ?? [];
+      if (!subs.length) {
+        return { content: [{ type: 'text' as const, text: 'No submissions for this form.' }] };
+      }
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Submissions (${subs.length}):\n\n${subs.map(formatSubmission).join('\n\n')}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error listing submissions', formsStatusMap);
+    }
+  },
+};
+
+export const getFormSubmissionTool = {
+  name: 'get_form_submission',
+  description: 'Get a single submission with all of its answers.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    submissionId: z.number().int().describe('Submission ID'),
+  }),
+  handler: async (args: { formId: number; submissionId: number }) => {
+    try {
+      const submission = await fetchFormsAPI<FormSubmission>(
+        `/forms/${args.formId}/submissions/${args.submissionId}`
+      );
+      return {
+        content: [{ type: 'text' as const, text: formatSubmission(submission) }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error getting submission', formsStatusMap);
+    }
+  },
+};
+
+export const createFormSubmissionTool = {
+  name: 'create_form_submission',
+  description:
+    'Submit answers to a form. `answers` is an object keyed by question ID; values are always arrays. For text questions: ["My answer"]. For choice questions: [optionId1, optionId2] (numeric IDs). Public links require `shareHash`.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    answers: z
+      .record(z.string(), z.array(z.union([z.string(), z.number()])))
+      .describe('Object keyed by question ID; each value is an array of strings or option IDs'),
+    shareHash: z
+      .string()
+      .optional()
+      .describe('Share hash — required when submitting via a public link'),
+  }),
+  handler: async (args: {
+    formId: number;
+    answers: Record<string, (string | number)[]>;
+    shareHash?: string;
+  }) => {
+    try {
+      const body: Record<string, unknown> = { answers: args.answers };
+      if (args.shareHash) body.shareHash = args.shareHash;
+      await fetchFormsAPI(`/forms/${args.formId}/submissions`, {
+        method: 'POST',
+        body,
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Submission recorded for form ${args.formId}.` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error creating submission', formsStatusMap);
+    }
+  },
+};
+
+export const deleteFormSubmissionTool = {
+  name: 'delete_form_submission',
+  description: 'Delete a single submission by ID.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    submissionId: z.number().int().describe('Submission ID'),
+  }),
+  handler: async (args: { formId: number; submissionId: number }) => {
+    try {
+      await fetchFormsAPI(`/forms/${args.formId}/submissions/${args.submissionId}`, {
+        method: 'DELETE',
+      });
+      return {
+        content: [{ type: 'text' as const, text: `Submission ${args.submissionId} deleted.` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error deleting submission', formsStatusMap);
+    }
+  },
+};
+
+export const deleteAllFormSubmissionsTool = {
+  name: 'delete_all_form_submissions',
+  description:
+    'Delete every submission for a form. The form itself is kept. This cannot be undone.',
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+  }),
+  handler: async (args: { formId: number }) => {
+    try {
+      await fetchFormsAPI(`/forms/${args.formId}/submissions`, { method: 'DELETE' });
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `All submissions deleted for form ${args.formId}.`,
+          },
+        ],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error deleting submissions', formsStatusMap);
+    }
+  },
+};
+
+export const exportFormSubmissionsTool = {
+  name: 'export_form_submissions',
+  description:
+    "Export a form's submissions as a spreadsheet into the user's Nextcloud storage. Returns the destination path. Use read_file / get_file_info afterwards to work with the export.",
+  inputSchema: z.object({
+    formId: z.number().int().describe('Form ID'),
+    path: z.string().describe('Target folder path inside the user\'s Nextcloud (e.g. "/Exports")'),
+    fileFormat: z.enum(['csv', 'ods', 'xlsx']).describe('Export file format'),
+  }),
+  handler: async (args: { formId: number; path: string; fileFormat: 'csv' | 'ods' | 'xlsx' }) => {
+    try {
+      const result = await fetchFormsAPI<string | { fileName?: string; path?: string }>(
+        `/forms/${args.formId}/submissions/export`,
+        {
+          method: 'POST',
+          body: { path: args.path, fileFormat: args.fileFormat },
+        }
+      );
+      const where =
+        typeof result === 'string'
+          ? result
+          : (result?.path ??
+            result?.fileName ??
+            `${args.path}/form-${args.formId}.${args.fileFormat}`);
+      return {
+        content: [{ type: 'text' as const, text: `Submissions exported to ${where}.` }],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error exporting submissions', formsStatusMap);
+    }
+  },
+};
+
+export const formsTools = [
+  // Forms
+  listFormsTool,
+  getFormTool,
+  createFormTool,
+  cloneFormTool,
+  updateFormTool,
+  transferFormOwnerTool,
+  deleteFormTool,
+  // Questions
+  listFormQuestionsTool,
+  createFormQuestionTool,
+  updateFormQuestionTool,
+  reorderFormQuestionsTool,
+  deleteFormQuestionTool,
+  // Options
+  createFormOptionsTool,
+  updateFormOptionTool,
+  reorderFormOptionsTool,
+  deleteFormOptionTool,
+  // Shares
+  createFormShareTool,
+  updateFormShareTool,
+  deleteFormShareTool,
+  // Submissions
+  listFormSubmissionsTool,
+  getFormSubmissionTool,
+  createFormSubmissionTool,
+  deleteFormSubmissionTool,
+  deleteAllFormSubmissionsTool,
+  exportFormSubmissionsTool,
+];

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.4</version>
+    <version>0.3.5</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
## Summary
- Add Nextcloud Forms app integration via the v3 OCS API (`/ocs/v2.php/apps/forms/api/v3`)
- 25 new MCP tools across forms, questions, options, shares, and submissions
- Auto-registered when the Forms app is enabled (appId `forms`)

## What's included
- `mcp-server/src/client/forms.ts` — thin OCS v3 client that unwraps `ocs.data` and throws `ApiError` on non-2xx / non-100 status
- `mcp-server/src/tools/apps/forms.ts` — 25 tools:
  - **Forms (7):** `list_forms`, `get_form`, `create_form`, `clone_form`, `update_form`, `transfer_form_owner`, `delete_form`
  - **Questions (5):** `list_form_questions`, `create_form_question`, `update_form_question`, `reorder_form_questions`, `delete_form_question`
  - **Options (4):** `create_form_options`, `update_form_option`, `reorder_form_options`, `delete_form_option`
  - **Shares (3):** `create_form_share`, `update_form_share`, `delete_form_share`
  - **Submissions (6):** `list_form_submissions`, `get_form_submission`, `create_form_submission`, `delete_form_submission`, `delete_all_form_submissions`, `export_form_submissions`
- Registry entry, docs (`docs/mcp/tools/apps/forms.md` + `docs/mcp/README.md` + `mcp-server/README.md`), version bump to 0.3.5
- 40 new vitest tests (covers every tool: happy path + empty/error/validation branches)

## Out of scope
- Binary export download (`GET /submissions?fileFormat=…`) — use `export_form_submissions` + existing file tools instead
- File-upload answers (multipart; can add later if users ask)

## Type of change
- [x] New feature
- [x] Patch version bump (0.3.4 → 0.3.5)

## Component
- [x] MCP Server

## Related Issues
Closes #118

## Test plan
- [x] `npm test` — 694 tests pass (40 new)
- [x] `npx prettier --check src/` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — clean, `server.json` synced to 0.3.5
- [ ] Manual smoke against standalone stack with Forms installed:
  - `list_forms` / `create_form` / `update_form` / `delete_form` round-trip
  - `create_form_question` + `create_form_options` + `list_form_questions`
  - `create_form_submission` via public link (`shareHash`) + `list_form_submissions`
  - `export_form_submissions` → verify file appears in NC storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)