### PR TITLE
fix(mcp): emit VTIMEZONE/TZID in create_event for iOS & Thunderbird sync

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "AIquila - MCP server for Nextcloud integration",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,13 +18,13 @@
       ]
     }
   ],
-  "version": "0.3.6",
+  "version": "0.3.7",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -52,7 +52,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.6",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.7",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/__tests__/tools-calendar.test.ts
+++ b/mcp-server/src/__tests__/tools-calendar.test.ts
@@ -441,6 +441,120 @@ END:VCALENDAR</c:calendar-data>
       expect(putCall[1].body).toContain('RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR');
     });
 
+    it('should emit VTIMEZONE and TZID when tzid is provided (DST zone)', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(propfindVeventOk)
+        .mockResolvedValueOnce({ ok: true, status: 201, text: () => Promise.resolve('') })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 207,
+          text: () => Promise.resolve(verifyResponse),
+        });
+
+      const { createEventTool } = await import('../tools/apps/calendar.js');
+      await createEventTool.handler({
+        summary: 'Testeintrag',
+        calendarName: 'personal',
+        dtstart: '20260512T130000Z',
+        dtend: '20260512T133000Z',
+        tzid: 'Europe/Berlin',
+      });
+
+      const putCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      const body: string = putCall[1].body;
+      // VTIMEZONE block with both STANDARD and DAYLIGHT
+      expect(body).toContain('BEGIN:VTIMEZONE');
+      expect(body).toContain('TZID:Europe/Berlin');
+      expect(body).toContain('BEGIN:STANDARD');
+      expect(body).toContain('BEGIN:DAYLIGHT');
+      expect(body).toContain('TZOFFSETFROM:+0100');
+      expect(body).toContain('TZOFFSETTO:+0200');
+      expect(body).toContain('END:VTIMEZONE');
+      // 13:00Z in May is 15:00 Europe/Berlin (CEST)
+      expect(body).toContain('DTSTART;TZID=Europe/Berlin:20260512T150000');
+      expect(body).toContain('DTEND;TZID=Europe/Berlin:20260512T153000');
+      // No trailing Z on the TZID'd properties
+      expect(body).not.toMatch(/DTSTART;TZID=Europe\/Berlin:[^\r\n]*Z/);
+    });
+
+    it('should emit single STANDARD block for fixed-offset zone', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(propfindVeventOk)
+        .mockResolvedValueOnce({ ok: true, status: 201, text: () => Promise.resolve('') })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 207,
+          text: () => Promise.resolve(verifyResponse),
+        });
+
+      const { createEventTool } = await import('../tools/apps/calendar.js');
+      await createEventTool.handler({
+        summary: 'Tokyo meeting',
+        calendarName: 'personal',
+        dtstart: '20260512T010000Z',
+        tzid: 'Asia/Tokyo',
+      });
+
+      const putCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      const body: string = putCall[1].body;
+      expect(body).toContain('BEGIN:VTIMEZONE');
+      expect(body).toContain('TZID:Asia/Tokyo');
+      expect(body).toContain('TZOFFSETTO:+0900');
+      expect(body).not.toContain('BEGIN:DAYLIGHT');
+      // 01:00 UTC -> 10:00 JST same day; default dtend = +1h -> 11:00 JST
+      expect(body).toContain('DTSTART;TZID=Asia/Tokyo:20260512T100000');
+      expect(body).toContain('DTEND;TZID=Asia/Tokyo:20260512T110000');
+    });
+
+    it('should accept floating local dtstart when tzid is set', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(propfindVeventOk)
+        .mockResolvedValueOnce({ ok: true, status: 201, text: () => Promise.resolve('') })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 207,
+          text: () => Promise.resolve(verifyResponse),
+        });
+
+      const { createEventTool } = await import('../tools/apps/calendar.js');
+      await createEventTool.handler({
+        summary: 'Local lunch',
+        calendarName: 'personal',
+        dtstart: '20260512T150000',
+        tzid: 'Europe/Berlin',
+      });
+
+      const putCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      const body: string = putCall[1].body;
+      expect(body).toContain('DTSTART;TZID=Europe/Berlin:20260512T150000');
+      expect(body).toContain('DTEND;TZID=Europe/Berlin:20260512T160000');
+    });
+
+    it('should ignore tzid for all-day events', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(propfindVeventOk)
+        .mockResolvedValueOnce({ ok: true, status: 201, text: () => Promise.resolve('') })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 207,
+          text: () => Promise.resolve(verifyResponse),
+        });
+
+      const { createEventTool } = await import('../tools/apps/calendar.js');
+      await createEventTool.handler({
+        summary: 'Holiday',
+        calendarName: 'personal',
+        dtstart: '20260401',
+        tzid: 'Europe/Berlin',
+      });
+
+      const putCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      const body: string = putCall[1].body;
+      expect(body).toContain('DTSTART;VALUE=DATE:20260401');
+      expect(body).not.toContain('BEGIN:VTIMEZONE');
+      expect(body).not.toContain('TZID=');
+    });
+
     it('should handle create failure', async () => {
       (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
         ok: false,

--- a/mcp-server/src/tools/apps/calendar.ts
+++ b/mcp-server/src/tools/apps/calendar.ts
@@ -115,16 +115,152 @@ function setICalProperty(icalData: string, propName: string, value: string | nul
   return icalData.replace(/END:VEVENT/, `${propName}:${value}\r\nEND:VEVENT`);
 }
 
-function setICalDateProperty(icalData: string, propName: string, value: string | null): string {
+function setICalDateProperty(
+  icalData: string,
+  propName: string,
+  value: string | null,
+  tzid?: string
+): string {
   const regex = new RegExp(`^${propName}(;[^:]*)?:.*$`, 'm');
   if (value === null) {
     return icalData.replace(regex, '').replace(/(\r?\n){2,}/g, '\r\n');
   }
-  const formatted = value.length === 8 ? `${propName};VALUE=DATE:${value}` : `${propName}:${value}`;
+  let formatted: string;
+  if (value.length === 8) {
+    formatted = `${propName};VALUE=DATE:${value}`;
+  } else if (tzid) {
+    formatted = `${propName};TZID=${tzid}:${normalizeLocalICal(value, tzid)}`;
+  } else {
+    formatted = `${propName}:${value}`;
+  }
   if (regex.test(icalData)) {
     return icalData.replace(regex, formatted);
   }
   return icalData.replace(/END:VEVENT/, `${formatted}\r\nEND:VEVENT`);
+}
+
+/**
+ * Format the UTC offset for a given IANA zone at a specific instant.
+ * Returns "+HHMM" or "-HHMM" (e.g. "+0200", "-0500", "+0000").
+ */
+function getTimezoneOffset(tzid: string, date: Date): string {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: tzid,
+    timeZoneName: 'longOffset',
+  });
+  const tzPart = fmt.formatToParts(date).find((p) => p.type === 'timeZoneName')?.value || 'GMT';
+  // tzPart is "GMT", "GMT+02:00", "GMT-05:30", or "GMT+5:45" depending on engine
+  const m = tzPart.match(/GMT([+-])(\d{1,2})(?::(\d{2}))?/);
+  if (!m) return '+0000';
+  const sign = m[1];
+  const hh = m[2].padStart(2, '0');
+  const mm = m[3] ?? '00';
+  return `${sign}${hh}${mm}`;
+}
+
+/**
+ * Build a minimal but RFC 5545-conformant VTIMEZONE component for the given
+ * IANA zone. Uses two reference instants in the current year to detect DST.
+ * No external tzdata required — sufficient for iOS / Thunderbird to accept
+ * the event and apply the TZID correctly to upcoming occurrences.
+ */
+export function buildVTimezone(tzid: string): string {
+  const year = new Date().getUTCFullYear();
+  const janOffset = getTimezoneOffset(tzid, new Date(Date.UTC(year, 0, 15)));
+  const julOffset = getTimezoneOffset(tzid, new Date(Date.UTC(year, 6, 15)));
+  const lines: string[] = ['BEGIN:VTIMEZONE', `TZID:${tzid}`];
+  if (janOffset === julOffset) {
+    lines.push(
+      'BEGIN:STANDARD',
+      'DTSTART:19700101T000000',
+      `TZOFFSETFROM:${janOffset}`,
+      `TZOFFSETTO:${janOffset}`,
+      `TZNAME:${tzid}`,
+      'END:STANDARD'
+    );
+  } else {
+    // Higher numeric offset = daylight, lower = standard (works for both hemispheres)
+    const standardOffset = janOffset < julOffset ? janOffset : julOffset;
+    const daylightOffset = janOffset < julOffset ? julOffset : janOffset;
+    lines.push(
+      'BEGIN:STANDARD',
+      'DTSTART:19701101T000000',
+      `TZOFFSETFROM:${daylightOffset}`,
+      `TZOFFSETTO:${standardOffset}`,
+      `TZNAME:${tzid}`,
+      'END:STANDARD',
+      'BEGIN:DAYLIGHT',
+      'DTSTART:19700301T000000',
+      `TZOFFSETFROM:${standardOffset}`,
+      `TZOFFSETTO:${daylightOffset}`,
+      `TZNAME:${tzid}`,
+      'END:DAYLIGHT'
+    );
+  }
+  lines.push('END:VTIMEZONE');
+  return lines.join('\r\n');
+}
+
+/**
+ * Convert a UTC iCal datetime ("YYYYMMDDTHHmmssZ") to wall-clock time in the
+ * given IANA zone, returning "YYYYMMDDTHHmmss" (no Z).
+ */
+function convertUtcICalToLocalICal(utcICal: string, tzid: string): string {
+  const m = utcICal.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/);
+  if (!m) return utcICal.replace(/Z$/, '');
+  const [, y, mo, d, h, mi, s] = m;
+  const instant = new Date(Date.UTC(+y, +mo - 1, +d, +h, +mi, +s));
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: tzid,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+  const parts = fmt.formatToParts(instant);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? '00';
+  let hour = get('hour');
+  if (hour === '24') hour = '00';
+  return `${get('year')}${get('month')}${get('day')}T${hour}${get('minute')}${get('second')}`;
+}
+
+/**
+ * If `value` ends in Z, convert it to wall-clock time in `tzid`. Otherwise
+ * assume it is already a floating local datetime in that zone.
+ */
+function normalizeLocalICal(value: string, tzid: string): string {
+  if (/Z$/.test(value)) return convertUtcICalToLocalICal(value, tzid);
+  return value;
+}
+
+/**
+ * Add `hours` to a floating "YYYYMMDDTHHmmss" string, returning the same form.
+ */
+function addHoursToLocalICal(local: string, hours: number): string {
+  const m = local.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})$/);
+  if (!m) return local;
+  const [, y, mo, d, h, mi, s] = m;
+  const dt = new Date(Date.UTC(+y, +mo - 1, +d, +h + hours, +mi, +s));
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${dt.getUTCFullYear()}${pad(dt.getUTCMonth() + 1)}${pad(dt.getUTCDate())}` +
+    `T${pad(dt.getUTCHours())}${pad(dt.getUTCMinutes())}${pad(dt.getUTCSeconds())}`
+  );
+}
+
+/**
+ * Ensure the VCALENDAR contains a VTIMEZONE with the requested TZID. Insert
+ * one before the first VEVENT if not already present.
+ */
+function ensureVTimezone(icalData: string, tzid: string): string {
+  const escaped = tzid.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const existing = new RegExp(`BEGIN:VTIMEZONE[\\s\\S]*?TZID:${escaped}[\\s\\S]*?END:VTIMEZONE`);
+  if (existing.test(icalData)) return icalData;
+  const vtz = buildVTimezone(tzid);
+  return icalData.replace(/BEGIN:VEVENT/, `${vtz}\r\nBEGIN:VEVENT`);
 }
 
 // ---------------------------------------------------------------------------
@@ -851,6 +987,12 @@ export const createEventTool = {
       .number()
       .optional()
       .describe('Reminder in minutes before the event (e.g. 15 for 15 min before)'),
+    tzid: z
+      .string()
+      .optional()
+      .describe(
+        'IANA time zone (e.g. "Europe/Berlin"). When set, a VTIMEZONE block is emitted and dtstart/dtend use TZID instead of UTC. Required for reliable iOS Calendar and Thunderbird CalDAV sync of timed events. UTC inputs (trailing Z) are converted to wall-clock time in this zone.'
+      ),
   }),
   handler: async (args: {
     summary: string;
@@ -871,6 +1013,7 @@ export const createEventTool = {
     rrule?: string;
     accessClass?: string;
     alarm?: number;
+    tzid?: string;
   }) => {
     try {
       const config = getNextcloudConfig();
@@ -883,6 +1026,9 @@ export const createEventTool = {
       const now = icalNow();
       const isAllDay = args.dtstart.length === 8;
 
+      const tzid = !isAllDay ? args.tzid : undefined;
+      const localDtstart = tzid ? normalizeLocalICal(args.dtstart, tzid) : args.dtstart;
+
       // Calculate default end
       let dtend = args.dtend;
       if (!dtend) {
@@ -894,8 +1040,11 @@ export const createEventTool = {
             parseInt(args.dtstart.slice(6, 8)) + 1
           );
           dtend = `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`;
+        } else if (tzid) {
+          // Timed with TZID: 1 hour after local wall time
+          dtend = addHoursToLocalICal(localDtstart, 1);
         } else {
-          // Timed: 1 hour later
+          // Timed: 1 hour later (UTC)
           const startDate = new Date(
             parseInt(args.dtstart.slice(0, 4)),
             parseInt(args.dtstart.slice(4, 6)) - 1,
@@ -908,13 +1057,23 @@ export const createEventTool = {
           dtend = startDate.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
         }
       }
+      const localDtend = tzid ? normalizeLocalICal(dtend, tzid) : dtend;
 
-      const dtstartProp = isAllDay
-        ? `DTSTART;VALUE=DATE:${args.dtstart}`
-        : `DTSTART:${args.dtstart}`;
-      const dtendProp = isAllDay ? `DTEND;VALUE=DATE:${dtend}` : `DTEND:${dtend}`;
+      let dtstartProp: string;
+      let dtendProp: string;
+      if (isAllDay) {
+        dtstartProp = `DTSTART;VALUE=DATE:${args.dtstart}`;
+        dtendProp = `DTEND;VALUE=DATE:${dtend}`;
+      } else if (tzid) {
+        dtstartProp = `DTSTART;TZID=${tzid}:${localDtstart}`;
+        dtendProp = `DTEND;TZID=${tzid}:${localDtend}`;
+      } else {
+        dtstartProp = `DTSTART:${args.dtstart}`;
+        dtendProp = `DTEND:${dtend}`;
+      }
 
-      let vevent = `BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//AIquila//MCP Server//EN\r\nBEGIN:VEVENT\r\nUID:${eventUid}\r\nDTSTAMP:${now}\r\nCREATED:${now}\r\nLAST-MODIFIED:${now}\r\n${dtstartProp}\r\n${dtendProp}\r\nSUMMARY:${escapeICalValue(args.summary)}`;
+      const vtimezoneBlock = tzid ? `${buildVTimezone(tzid)}\r\n` : '';
+      let vevent = `BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//AIquila//MCP Server//EN\r\n${vtimezoneBlock}BEGIN:VEVENT\r\nUID:${eventUid}\r\nDTSTAMP:${now}\r\nCREATED:${now}\r\nLAST-MODIFIED:${now}\r\n${dtstartProp}\r\n${dtendProp}\r\nSUMMARY:${escapeICalValue(args.summary)}`;
 
       if (args.location) {
         vevent += `\r\nLOCATION:${escapeICalValue(args.location)}`;
@@ -1064,6 +1223,12 @@ export const updateEventTool = {
       .nullable()
       .optional()
       .describe('Replace attendees list, or null to remove all attendees'),
+    tzid: z
+      .string()
+      .optional()
+      .describe(
+        'IANA time zone (e.g. "Europe/Berlin") for the updated dtstart/dtend. When set, a VTIMEZONE block is added (if missing) and DTSTART/DTEND use TZID instead of UTC. Required for iOS/Thunderbird CalDAV sync.'
+      ),
   }),
   handler: async (args: {
     uid: string;
@@ -1085,6 +1250,7 @@ export const updateEventTool = {
       role?: string;
       rsvp?: boolean;
     }> | null;
+    tzid?: string;
   }) => {
     try {
       const config = getNextcloudConfig();
@@ -1095,11 +1261,18 @@ export const updateEventTool = {
       if (args.summary !== undefined) {
         modified = setICalProperty(modified, 'SUMMARY', escapeICalValue(args.summary));
       }
+      // Only timed datetimes carry a TZID; all-day (length 8) values are dates.
+      const dtstartTz =
+        args.tzid && args.dtstart && args.dtstart.length > 8 ? args.tzid : undefined;
+      const dtendTz = args.tzid && args.dtend && args.dtend.length > 8 ? args.tzid : undefined;
       if (args.dtstart !== undefined) {
-        modified = setICalDateProperty(modified, 'DTSTART', args.dtstart);
+        modified = setICalDateProperty(modified, 'DTSTART', args.dtstart, dtstartTz);
       }
       if (args.dtend !== undefined) {
-        modified = setICalDateProperty(modified, 'DTEND', args.dtend);
+        modified = setICalDateProperty(modified, 'DTEND', args.dtend, dtendTz);
+      }
+      if (args.tzid && (dtstartTz || dtendTz)) {
+        modified = ensureVTimezone(modified, args.tzid);
       }
       if (args.location !== undefined) {
         modified = setICalProperty(

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.6</version>
+    <version>0.3.7</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
## Summary
- Fixes #325 — `create_event` emitted bare UTC `DTSTART` with no `VTIMEZONE`, so events did not sync to iOS Calendar or Thunderbird (only the Nextcloud web UI).
- Adds optional `tzid` (IANA zone) parameter to `create_event` and `update_event`. When set, a dependency-free RFC 5545 §3.6.5 `VTIMEZONE` block is emitted and `DTSTART`/`DTEND` use `;TZID=…:local` instead of bare UTC.
- Backwards compatible — omitting `tzid` keeps today's UTC output byte-identical.
- Bumps both components to **0.3.7**.

## Implementation notes
- `VTIMEZONE` is generated from `Intl.DateTimeFormat` with `timeZoneName: 'longOffset'` at Jan 15 / Jul 15 of the current year — no tzdata dependency.
- Fixed-offset zones (e.g. `Asia/Tokyo`) get a single `STANDARD` sub-component; DST zones get both `STANDARD` and `DAYLIGHT`.
- UTC-suffixed inputs (`…Z`) are converted to wall-clock time in the target zone; floating local inputs (`YYYYMMDDTHHmmss`) are taken as-is.
- All-day events ignore `tzid`.

## Test plan
- [x] `npm test` — 710 tests pass (4 new VTIMEZONE cases: DST zone, fixed-offset zone, floating local input, all-day ignores tzid).
- [x] `npm run lint` clean (no new warnings/errors).
- [x] `npx prettier --check src/` clean.
- [ ] Manual: `cd docker/standalone && make up && make test-tools` — confirm UTC default path still works.
- [ ] Manual: call `create_event` with `tzid: "Europe/Berlin"` via an MCP client; inspect the resulting `.ics`; subscribe the calendar from iOS Calendar and Thunderbird and confirm the event appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)