### PR TITLE
fix(nextcloud): migrate deprecated claude-sonnet-4 and claude-opus-4 to active models

### DIFF
--- a/nextcloud-app/lib/Service/ClaudeModels.php
+++ b/nextcloud-app/lib/Service/ClaudeModels.php
@@ -32,11 +32,27 @@ class ClaudeModels {
     /** Opus 4.5 */
     public const OPUS_4_5   = 'claude-opus-4-5-20251101';
 
-    /** Sonnet 4 — deprecated by Anthropic (SDK 0.15.0 dropped from typed Model enum). Constant kept so existing user_model preferences continue to resolve. */
+    /** Sonnet 4 — retired June 15 2026; resolveModel() transparently maps this to SONNET_4_6. */
     public const SONNET_4   = 'claude-sonnet-4-20250514';
 
-    /** Opus 4 — deprecated by Anthropic (SDK 0.15.0 dropped from typed Model enum). Constant kept so existing user_model preferences continue to resolve. */
+    /** Opus 4 — retired June 15 2026; resolveModel() transparently maps this to OPUS_4_7. */
     public const OPUS_4     = 'claude-opus-4-20250514';
+
+    // ── Deprecated-model migration map ────────────────────────────────────
+
+    private const DEPRECATED_MAP = [
+        self::SONNET_4 => self::SONNET_4_6,
+        self::OPUS_4   => self::OPUS_4_7,
+    ];
+
+    /**
+     * Return the active replacement for a deprecated model ID, or the model
+     * itself if it is already active. Call this whenever a model ID is read
+     * from stored user/admin config before it is used in an API request.
+     */
+    public static function resolveModel(string $model): string {
+        return self::DEPRECATED_MAP[$model] ?? $model;
+    }
 
     // ── Application defaults ───────────────────────────────────────────────
 

--- a/nextcloud-app/lib/Service/ClaudeSDKService.php
+++ b/nextcloud-app/lib/Service/ClaudeSDKService.php
@@ -66,9 +66,11 @@ class ClaudeSDKService {
     public function getModel(?string $userId = null): string {
         if ($userId) {
             $userModel = $this->config->getUserValue($userId, $this->appName, 'user_model', '');
-            if ($userModel) return $userModel;
+            if ($userModel) return ClaudeModels::resolveModel($userModel);
         }
-        return $this->config->getAppValue($this->appName, 'model', ClaudeModels::DEFAULT_MODEL);
+        return ClaudeModels::resolveModel(
+            $this->config->getAppValue($this->appName, 'model', ClaudeModels::DEFAULT_MODEL)
+        );
     }
 
     /**

--- a/nextcloud-app/tests/Unit/AIquilaCapabilityTest.php
+++ b/nextcloud-app/tests/Unit/AIquilaCapabilityTest.php
@@ -58,14 +58,14 @@ class AIquilaCapabilityTest extends TestCase {
         $this->appManager->method('getAppVersion')->willReturn('1.0.0');
         $this->config->method('getAppValue')
             ->willReturnMap([
-                ['aiquila', 'model', ClaudeModels::DEFAULT_MODEL, 'claude-opus-4-20250514'],
+                ['aiquila', 'model', ClaudeModels::DEFAULT_MODEL, ClaudeModels::OPUS_4_7],
                 ['aiquila', 'search_enabled', '1', '1'],
             ]);
         $this->credentialService->method('getApiKey')->willReturn('');
 
         $result = $this->capability->getCapabilities();
 
-        $this->assertEquals('claude-opus-4-20250514', $result['aiquila']['model']);
+        $this->assertEquals(ClaudeModels::OPUS_4_7, $result['aiquila']['model']);
     }
 
     public function testApiConfiguredTrueWhenKeyExists(): void {

--- a/nextcloud-app/tests/Unit/SetupCheck/AnthropicApiReachableTest.php
+++ b/nextcloud-app/tests/Unit/SetupCheck/AnthropicApiReachableTest.php
@@ -40,7 +40,7 @@ class AnthropicApiReachableTest extends TestCase {
 
     public function testSuccessWhenApiReachable(): void {
         $this->credentials->method('hasApiKey')->with(null)->willReturn(true);
-        $this->sdk->method('listModels')->with(null)->willReturn(['claude-sonnet-4-20250514']);
+        $this->sdk->method('listModels')->with(null)->willReturn(['claude-sonnet-4-6']);
         $result = $this->check->run();
         $this->assertSame('success', $result->getSeverity());
     }


### PR DESCRIPTION
claude-sonnet-4-20250514 and claude-opus-4-20250514 are deprecated and retire
June 15 2026. Add ClaudeModels::resolveModel() with a DEPRECATED_MAP and call it
in ClaudeSDKService::getModel() so any stored user/admin preference using a retired
model ID is transparently upgraded to its active replacement at read time, with no
database migration required. Update the two unit tests that still hardcoded the
deprecated IDs.

https://claude.ai/code/session_01YYAo1jRzrfDNQqxMjzqGRw