### PR TITLE
fix(nextcloud): NC33 compatibility and Postgres is_enabled binding

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "AIquila - MCP server for Nextcloud integration",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,13 +18,13 @@
       ]
     }
   ],
-  "version": "0.3.8",
+  "version": "0.3.9",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -52,7 +52,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.8",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.9",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.8</version>
+    <version>0.3.9</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/lib/Db/McpServer.php
+++ b/nextcloud-app/lib/Db/McpServer.php
@@ -16,8 +16,6 @@ use OCP\AppFramework\Db\Entity;
  * @method void setAuthType(string $authType)
  * @method string|null getAuthToken()
  * @method void setAuthToken(?string $authToken)
- * @method bool getIsEnabled()
- * @method void setIsEnabled(bool $isEnabled)
  * @method string|null getLastStatus()
  * @method void setLastStatus(?string $lastStatus)
  * @method string|null getLastError()
@@ -50,7 +48,7 @@ class McpServer extends Entity {
     protected string $url = '';
     protected string $authType = 'none';
     protected ?string $authToken = null;
-    protected bool $isEnabled = true;
+    protected int $isEnabled = 1;
     protected ?string $lastStatus = null;
     protected ?string $lastError = null;
     protected ?int $toolCount = null;
@@ -70,7 +68,7 @@ class McpServer extends Entity {
         $this->addType('url', 'string');
         $this->addType('authType', 'string');
         $this->addType('authToken', 'string');
-        $this->addType('isEnabled', 'boolean');
+        $this->addType('isEnabled', 'integer');
         $this->addType('lastStatus', 'string');
         $this->addType('lastError', 'string');
         $this->addType('toolCount', 'integer');
@@ -84,5 +82,17 @@ class McpServer extends Entity {
         $this->addType('oauthCodeVerifier', 'string');
         $this->addType('oauthState', 'string');
         $this->addType('oauthMetadata', 'string');
+    }
+
+    public function getIsEnabled(): bool {
+        return (int)$this->isEnabled === 1;
+    }
+
+    public function setIsEnabled(bool $isEnabled): void {
+        $intValue = $isEnabled ? 1 : 0;
+        if ($this->isEnabled !== $intValue) {
+            $this->isEnabled = $intValue;
+            $this->markFieldUpdated('isEnabled');
+        }
     }
 }

--- a/nextcloud-app/lib/Db/McpServerMapper.php
+++ b/nextcloud-app/lib/Db/McpServerMapper.php
@@ -49,7 +49,7 @@ class McpServerMapper extends QBMapper {
         $qb = $this->db->getQueryBuilder();
         $qb->select('*')
             ->from($this->getTableName())
-            ->where($qb->expr()->eq('is_enabled', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
+            ->where($qb->expr()->eq('is_enabled', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)))
             ->orderBy('display_name', 'ASC');
 
         return $this->findEntities($qb);

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",

--- a/nextcloud-app/templates/main.php
+++ b/nextcloud-app/templates/main.php
@@ -4,7 +4,7 @@ $appId = OCA\AIquila\AppInfo\Application::APP_ID;
 // Load the Vite entry as an ES module so its emitted chunk imports work.
 // `Util::addScript` emits a classic <script> tag and cannot load modules.
 $scriptUrl = \OC::$server->getURLGenerator()->linkTo($appId, 'js/aiquila-main.js')
-    . '?v=' . \OCP\App::getAppVersion($appId);
+    . '?v=' . \OCP\Server::get(\OCP\App\IAppManager::class)->getAppVersion($appId);
 \OCP\Util::addHeader('script', [
     'type' => 'module',
     'src' => $scriptUrl,


### PR DESCRIPTION
## Summary
- Replace removed `OCP\App::getAppVersion()` in `templates/main.php` with `IAppManager::getAppVersion()` — fixes 500 on `/apps/aiquila/` on Nextcloud 32+ (observed on NC 33.0.3.2).
- Align `McpServer` entity with the actual `SMALLINT` column for `is_enabled`: store as `int`, register `addType('integer')`, expose `bool` API via explicit getter/setter. Avoids `PARAM_BOOL` bindings that Postgres rejects (`SQLSTATE[22P02] invalid input syntax for type smallint: "t"`).
- `McpServerMapper::findAllEnabled()` binds the comparison value as `PARAM_INT` (1).

No DB migration required — the entity is now in sync with the existing schema, so existing deployments are unaffected.

## Test plan
- [ ] Load `/apps/aiquila/` on NC 33 — page renders, no 500.
- [ ] `GET /apps/aiquila/api/admin/native-mcp/status` on Postgres returns 200.
- [ ] Create / toggle an MCP server entry via `McpServerController` on Postgres.
- [ ] `php occ aiquila:mcp:add` still works (MySQL + Postgres).
- [ ] Existing PHPUnit suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)