### PR TITLE
fix(mcp): Mail 5.x compatibility + calendar display-name resolution (#339)

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "AIquila - MCP server for Nextcloud integration",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,13 +18,13 @@
       ]
     }
   ],
-  "version": "0.3.10",
+  "version": "0.3.11",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -52,7 +52,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.10",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.11",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/__tests__/tools-calendar.test.ts
+++ b/mcp-server/src/__tests__/tools-calendar.test.ts
@@ -897,4 +897,186 @@ END:VCALENDAR</c:calendar-data>
       expect(result.content[0].text).toContain('ETag mismatch');
     });
   });
+
+  describe('calendar display-name resolution (issue #339)', () => {
+    // Calendar list PROPFIND response mapping displayName "Persönlich" → slug "personal"
+    const calendarListXml = `<?xml version="1.0" encoding="UTF-8"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/remote.php/dav/calendars/admin/personal/</d:href>
+    <d:propstat><d:prop>
+      <d:resourcetype><d:collection/><cal:calendar xmlns:cal="urn:ietf:params:xml:ns:caldav"/></d:resourcetype>
+      <d:displayname>Persönlich</d:displayname>
+    </d:prop></d:propstat>
+  </d:response>
+</d:multistatus>`;
+
+    const eventReportXml = `<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/remote.php/dav/calendars/admin/personal/event-1.ics</d:href>
+    <d:propstat><d:prop>
+      <d:getetag>"etag-ev1"</d:getetag>
+      <c:calendar-data>BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:event-1
+SUMMARY:Meeting
+DTSTART:20240315T090000Z
+DTEND:20240315T093000Z
+END:VEVENT
+END:VCALENDAR</c:calendar-data>
+    </d:prop></d:propstat>
+  </d:response>
+</d:multistatus>`;
+
+    it('list_events: first attempt uses input, retry uses resolved slug', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ ok: false, status: 404, text: () => Promise.resolve('') })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 207,
+          text: () => Promise.resolve(calendarListXml),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 207,
+          text: () => Promise.resolve(eventReportXml),
+        });
+
+      const { listEventsTool } = await import('../tools/apps/calendar.js');
+      await listEventsTool.handler({ calendarName: 'Persönlich' });
+
+      const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      // 1st: REPORT against display name (404)
+      expect(calls[0][1].method).toBe('REPORT');
+      expect(decodeURI(calls[0][0])).toContain('/Persönlich/');
+      // 2nd: PROPFIND for calendar list
+      expect(calls[1][1].method).toBe('PROPFIND');
+      // 3rd: REPORT against resolved slug
+      expect(calls[2][1].method).toBe('REPORT');
+      expect(calls[2][0]).toContain('/personal/');
+    });
+
+    it('list_events: matches display name case-insensitively', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ ok: false, status: 404, text: () => Promise.resolve('') })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 207,
+          text: () => Promise.resolve(calendarListXml),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 207,
+          text: () => Promise.resolve(eventReportXml),
+        });
+
+      const { listEventsTool } = await import('../tools/apps/calendar.js');
+      const result = await listEventsTool.handler({ calendarName: 'PERSÖNLICH' });
+
+      expect(result.isError).toBeUndefined();
+      const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      expect(calls[2][0]).toContain('/personal/');
+    });
+
+    it('list_events: when no match found, surfaces original 404', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ ok: false, status: 404, text: () => Promise.resolve('Not found') })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 207,
+          text: () => Promise.resolve(calendarListXml),
+        });
+
+      const { listEventsTool } = await import('../tools/apps/calendar.js');
+      const result = await listEventsTool.handler({ calendarName: 'Unknown' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('404');
+    });
+
+    it('get_event: resolves display name and retries REPORT', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ ok: false, status: 404, text: () => Promise.resolve('') })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 207,
+          text: () => Promise.resolve(calendarListXml),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 207,
+          text: () => Promise.resolve(eventReportXml),
+        });
+
+      const { getEventTool } = await import('../tools/apps/calendar.js');
+      const result = await getEventTool.handler({ uid: 'event-1', calendarName: 'Persönlich' });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Meeting');
+
+      const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      expect(calls[2][0]).toContain('/personal/');
+    });
+
+    it('create_event: resolves display name when assertCalendarSupportsEvents 404s', async () => {
+      const propfindVeventOk = {
+        ok: true,
+        status: 207,
+        text: () =>
+          Promise.resolve(
+            '<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">' +
+              '<d:response><d:propstat><d:prop>' +
+              '<c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set>' +
+              '</d:prop></d:propstat></d:response></d:multistatus>'
+          ),
+      };
+      const verifyXml = `<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/remote.php/dav/calendars/admin/personal/event.ics</d:href>
+    <d:propstat><d:prop>
+      <d:getetag>"x"</d:getetag>
+      <c:calendar-data>BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:any
+SUMMARY:Test
+DTSTART:20240315T120000Z
+END:VEVENT
+END:VCALENDAR</c:calendar-data>
+    </d:prop></d:propstat>
+  </d:response>
+</d:multistatus>`;
+
+      (global.fetch as ReturnType<typeof vi.fn>)
+        // 1st PROPFIND: assertCalendarSupportsEvents on display name → 404
+        .mockResolvedValueOnce({ ok: false, status: 404, text: () => Promise.resolve('') })
+        // 2nd PROPFIND: calendar list for slug resolution
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 207,
+          text: () => Promise.resolve(calendarListXml),
+        })
+        // 3rd PROPFIND: assertCalendarSupportsEvents on resolved slug → ok
+        .mockResolvedValueOnce(propfindVeventOk)
+        // 4th: PUT
+        .mockResolvedValueOnce({ ok: true, status: 201, text: () => Promise.resolve('') })
+        // 5th: verification REPORT
+        .mockResolvedValueOnce({ ok: true, status: 207, text: () => Promise.resolve(verifyXml) });
+
+      const { createEventTool } = await import('../tools/apps/calendar.js');
+      const result = await createEventTool.handler({
+        summary: 'Test',
+        calendarName: 'Persönlich',
+        dtstart: '20240315T120000Z',
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('created successfully');
+
+      const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      // PUT URL must use resolved slug, not display name
+      const putCall = calls.find((c) => c[1].method === 'PUT');
+      expect(putCall![0]).toContain('/personal/');
+      expect(putCall![0]).not.toContain('Persönlich');
+    });
+  });
 });

--- a/mcp-server/src/__tests__/tools-mail.test.ts
+++ b/mcp-server/src/__tests__/tools-mail.test.ts
@@ -81,7 +81,7 @@ describe('Mail Tools', () => {
   });
 
   describe('list_mailboxes', () => {
-    it('should return formatted mailbox list', async () => {
+    it('should return formatted mailbox list (legacy array shape)', async () => {
       mockFetchMailAPI.mockResolvedValue({
         ok: true,
         json: () =>
@@ -96,11 +96,41 @@ describe('Mail Tools', () => {
       const tool = mailTools.find((t) => t.name === 'list_mailboxes')!;
       const result = await tool.handler({ accountId: 1 });
 
+      expect(mockFetchMailAPI).toHaveBeenCalledWith('/mailboxes?accountId=1');
       expect(result.content[0].text).toContain('INBOX');
       expect(result.content[0].text).toContain('5 unread');
       expect(result.content[0].text).toContain('ID: 10');
       expect(result.content[0].text).toContain('Sent');
       expect(result.content[0].text).toContain('Drafts');
+    });
+
+    it('should handle Mail 5.x wrapped shape with displayName/databaseId', async () => {
+      mockFetchMailAPI.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            mailboxes: [
+              {
+                id: 10,
+                databaseId: 42,
+                accountId: 1,
+                name: 'INBOX',
+                displayName: 'Inbox',
+                unread: 3,
+                total: 99,
+                delimiter: '/',
+              },
+            ],
+          }),
+      });
+
+      const { mailTools } = await import('../tools/apps/mail.js');
+      const tool = mailTools.find((t) => t.name === 'list_mailboxes')!;
+      const result = await tool.handler({ accountId: 1 });
+
+      expect(result.content[0].text).toContain('Inbox');
+      expect(result.content[0].text).toContain('ID: 42');
+      expect(result.content[0].text).not.toContain('ID: 10');
     });
 
     it('should handle errors', async () => {
@@ -120,11 +150,11 @@ describe('Mail Tools', () => {
   });
 
   describe('mail_list_messages', () => {
-    it('should return formatted message summaries', async () => {
-      mockFetchOCS.mockResolvedValue({
-        ocs: {
-          meta: { status: 'ok', statuscode: 200, message: 'OK' },
-          data: [
+    it('should return formatted message summaries (legacy shape)', async () => {
+      mockFetchMailAPI.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve([
             {
               id: 100,
               uid: 1,
@@ -165,14 +195,15 @@ describe('Mail Tools', () => {
               },
               hasAttachments: false,
             },
-          ],
-        },
+          ]),
       });
 
       const { mailTools } = await import('../tools/apps/mail.js');
       const tool = mailTools.find((t) => t.name === 'mail_list_messages')!;
       const result = await tool.handler({ mailboxId: 10 });
 
+      expect(mockFetchOCS).not.toHaveBeenCalled();
+      expect(mockFetchMailAPI).toHaveBeenCalledWith('/messages?mailboxId=10');
       expect(result.content[0].text).toContain('Hello World');
       expect(result.content[0].text).toContain('UNREAD');
       expect(result.content[0].text).toContain('starred');
@@ -184,12 +215,52 @@ describe('Mail Tools', () => {
       expect(result.content[0].text).toContain('Messages (2)');
     });
 
+    it('should pick up databaseId and flags.hasAttachments (Mail 5.x shape)', async () => {
+      mockFetchMailAPI.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            messages: [
+              {
+                id: 1,
+                databaseId: 555,
+                uid: 1,
+                mailboxId: 10,
+                subject: 'New shape',
+                from: [{ label: '', email: 'x@example.com' }],
+                to: [],
+                cc: [],
+                dateInt: 1700000000,
+                flags: {
+                  seen: true,
+                  flagged: false,
+                  answered: false,
+                  deleted: false,
+                  draft: false,
+                  important: false,
+                  junk: false,
+                  hasAttachments: true,
+                },
+              },
+            ],
+          }),
+      });
+
+      const { mailTools } = await import('../tools/apps/mail.js');
+      const tool = mailTools.find((t) => t.name === 'mail_list_messages')!;
+      const result = await tool.handler({ mailboxId: 10, limit: 5, cursor: 99, filter: 'unread' });
+
+      expect(mockFetchMailAPI).toHaveBeenCalledWith(
+        '/messages?mailboxId=10&limit=5&cursor=99&filter=unread'
+      );
+      expect(result.content[0].text).toContain('ID: 555');
+      expect(result.content[0].text).toContain('attachment');
+    });
+
     it('should handle empty results', async () => {
-      mockFetchOCS.mockResolvedValue({
-        ocs: {
-          meta: { status: 'ok', statuscode: 200, message: 'OK' },
-          data: [],
-        },
+      mockFetchMailAPI.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
       });
 
       const { mailTools } = await import('../tools/apps/mail.js');
@@ -200,7 +271,11 @@ describe('Mail Tools', () => {
     });
 
     it('should handle errors', async () => {
-      mockFetchOCS.mockRejectedValue(new Error('OCS API error: 404 Not Found'));
+      mockFetchMailAPI.mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve('Not found'),
+      });
 
       const { mailTools } = await import('../tools/apps/mail.js');
       const tool = mailTools.find((t) => t.name === 'mail_list_messages')!;
@@ -212,31 +287,28 @@ describe('Mail Tools', () => {
   });
 
   describe('mail_read_message', () => {
-    it('should return full message content', async () => {
-      mockFetchOCS.mockResolvedValue({
-        ocs: {
-          meta: { status: 'ok', statuscode: 200, message: 'OK' },
-          data: {
-            id: 100,
+    it('should return full message content from single /body call', async () => {
+      mockFetchMailAPI.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
             subject: 'Test Subject',
             from: [{ label: 'Alice', email: 'alice@example.com' }],
             to: [{ label: 'Bob', email: 'bob@example.com' }],
             cc: [{ label: 'Carol', email: 'carol@example.com' }],
             dateInt: 1700000000,
             attachments: [{ fileName: 'report.pdf', size: 12345 }],
-          },
-        },
-      });
-
-      mockFetchMailAPI.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ body: '<p>Hello <b>World</b></p><br>Nice to meet you.' }),
+            body: '<p>Hello <b>World</b></p><br>Nice to meet you.',
+          }),
       });
 
       const { mailTools } = await import('../tools/apps/mail.js');
       const tool = mailTools.find((t) => t.name === 'mail_read_message')!;
       const result = await tool.handler({ messageId: 100 });
 
+      expect(mockFetchOCS).not.toHaveBeenCalled();
+      expect(mockFetchMailAPI).toHaveBeenCalledTimes(1);
+      expect(mockFetchMailAPI).toHaveBeenCalledWith('/messages/100/body');
       expect(result.content[0].text).toContain('Subject: Test Subject');
       expect(result.content[0].text).toContain('Alice <alice@example.com>');
       expect(result.content[0].text).toContain('Bob <bob@example.com>');
@@ -248,15 +320,113 @@ describe('Mail Tools', () => {
       expect(result.content[0].text).toContain('Message ID: 100');
     });
 
+    it('should extract <img alt=...> and strip invisible chars', async () => {
+      mockFetchMailAPI.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            subject: 'Newsletter',
+            from: [{ label: 'News', email: 'n@example.com' }],
+            to: [],
+            dateInt: 1700000000,
+            // U+200B padding + alt-only image + table cells
+            body: '​​<table><tr><td>Left</td><td>Right</td></tr></table><img alt="Big Headline" src="x.png">',
+          }),
+      });
+
+      const { mailTools } = await import('../tools/apps/mail.js');
+      const tool = mailTools.find((t) => t.name === 'mail_read_message')!;
+      const result = await tool.handler({ messageId: 7 });
+
+      expect(result.content[0].text).toContain('Big Headline');
+      expect(result.content[0].text).toContain('Left Right');
+      expect(result.content[0].text).not.toContain('​');
+    });
+
     it('should handle errors', async () => {
-      mockFetchOCS.mockRejectedValue(new Error('Message not found'));
+      mockFetchMailAPI.mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve('Message not found'),
+      });
 
       const { mailTools } = await import('../tools/apps/mail.js');
       const tool = mailTools.find((t) => t.name === 'mail_read_message')!;
       const result = await tool.handler({ messageId: 999 });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Message not found');
+      expect(result.content[0].text).toContain('404');
+    });
+  });
+
+  describe('mail_search_messages', () => {
+    it('should return IDs and resolve multi-message threads', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: {
+            entries: [
+              {
+                title: 'Re: Project',
+                subline: 'alice@example.com',
+                resourceUrl: '/apps/mail/box/3/thread/42',
+              },
+              {
+                title: 'Single message',
+                subline: 'bob@example.com',
+                resourceUrl: '/apps/mail/box/3/thread/77',
+              },
+            ],
+            isPaginated: false,
+          },
+        },
+      });
+
+      mockFetchMailAPI.mockImplementation((url: string) => {
+        if (url === '/messages/42/thread') {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve([
+                { databaseId: 42, dateInt: 1700000200 },
+                { databaseId: 41, dateInt: 1700000100 },
+              ]),
+          });
+        }
+        if (url === '/messages/77/thread') {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve([{ databaseId: 77, dateInt: 1700000300 }]),
+          });
+        }
+        return Promise.resolve({ ok: false, status: 404, text: () => Promise.resolve('') });
+      });
+
+      const { mailTools } = await import('../tools/apps/mail.js');
+      const tool = mailTools.find((t) => t.name === 'mail_search_messages')!;
+      const result = await tool.handler({ query: 'project' });
+
+      expect(result.content[0].text).toContain('Re: Project');
+      // Multi-message thread: sorted ascending by dateInt → 41, 42
+      expect(result.content[0].text).toContain('Thread (2 messages) IDs: 41, 42');
+      // Single-message thread
+      expect(result.content[0].text).toContain('Single message');
+      expect(result.content[0].text).toContain('ID: 77');
+    });
+
+    it('should report no results', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: { entries: [], isPaginated: false },
+        },
+      });
+
+      const { mailTools } = await import('../tools/apps/mail.js');
+      const tool = mailTools.find((t) => t.name === 'mail_search_messages')!;
+      const result = await tool.handler({ query: 'nothing' });
+
+      expect(result.content[0].text).toContain('No messages found');
     });
   });
 

--- a/mcp-server/src/__tests__/tools-search.test.ts
+++ b/mcp-server/src/__tests__/tools-search.test.ts
@@ -130,6 +130,114 @@ describe('Search Tools', () => {
       expect(parsed[0].provider).toBe('files');
     });
 
+    it('should always include priority providers (files/mail/calendar/notes) regardless of order', async () => {
+      // Providers list: low-order non-priority ones come "first" by order,
+      // but mail (order 20) and calendar (order 30) must still be queried.
+      mockFetchOCS.mockResolvedValueOnce({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: [
+            {
+              id: 'files',
+              appId: 'files',
+              name: 'Files',
+              icon: '',
+              order: 5,
+              triggers: [],
+              filters: {},
+            },
+            {
+              id: 'comments',
+              appId: 'comments',
+              name: 'Comments',
+              icon: '',
+              order: 1,
+              triggers: [],
+              filters: {},
+            },
+            {
+              id: 'deck',
+              appId: 'deck',
+              name: 'Deck',
+              icon: '',
+              order: 2,
+              triggers: [],
+              filters: {},
+            },
+            {
+              id: 'talk',
+              appId: 'talk',
+              name: 'Talk',
+              icon: '',
+              order: 3,
+              triggers: [],
+              filters: {},
+            },
+            {
+              id: 'contacts',
+              appId: 'contacts',
+              name: 'Contacts',
+              icon: '',
+              order: 4,
+              triggers: [],
+              filters: {},
+            },
+            {
+              id: 'mail',
+              appId: 'mail',
+              name: 'Mail',
+              icon: '',
+              order: 20,
+              triggers: [],
+              filters: {},
+            },
+            {
+              id: 'calendar',
+              appId: 'calendar',
+              name: 'Calendar',
+              icon: '',
+              order: 30,
+              triggers: [],
+              filters: {},
+            },
+            {
+              id: 'notes',
+              appId: 'notes',
+              name: 'Notes',
+              icon: '',
+              order: 40,
+              triggers: [],
+              filters: {},
+            },
+          ],
+        },
+      });
+      // Stub every subsequent search call with an empty result.
+      mockFetchOCS.mockResolvedValue({
+        ocs: {
+          meta: { status: 'ok', statuscode: 200, message: 'OK' },
+          data: { name: '', isPaginated: false, entries: [], cursor: null },
+        },
+      });
+
+      const { unifiedSearchTool } = await import('../tools/system/search.js');
+      await unifiedSearchTool.handler({ query: 'x', limit: 5 });
+
+      const searchedIds = mockFetchOCS.mock.calls
+        .slice(1)
+        .map((call) => call[0] as string)
+        .filter((url) => url.startsWith('/ocs/v2.php/search/providers/'))
+        .map((url) => decodeURIComponent(url.split('/')[5]));
+
+      // Priority providers must all appear.
+      expect(searchedIds).toContain('files');
+      expect(searchedIds).toContain('mail');
+      expect(searchedIds).toContain('calendar');
+      expect(searchedIds).toContain('notes');
+      // Total capped at 6.
+      expect(searchedIds.length).toBeLessThanOrEqual(6);
+    });
+
     it('should return message when no results found', async () => {
       mockFetchOCS.mockResolvedValueOnce({
         ocs: {

--- a/mcp-server/src/tools/apps/calendar.ts
+++ b/mcp-server/src/tools/apps/calendar.ts
@@ -579,6 +579,43 @@ function formatCalendar(cal: ParsedCalendar): string {
 // ---------------------------------------------------------------------------
 
 /**
+ * Resolve a calendar identifier (display name or URL slug) to its URL slug.
+ * Falls back to the input unchanged when no match is found or PROPFIND fails,
+ * so existing slug-based callers keep working.
+ */
+async function resolveCalendarSlug(nameOrSlug: string): Promise<string> {
+  const config = getNextcloudConfig();
+  const calDavUrl = `${config.url}/remote.php/dav/calendars/${config.user}/`;
+  const propfindBody = `<?xml version="1.0" encoding="UTF-8"?>
+<d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:prop><d:resourcetype /><d:displayname /></d:prop>
+</d:propfind>`;
+  try {
+    const response = await fetchCalDAV(calDavUrl, {
+      method: 'PROPFIND',
+      body: propfindBody,
+      headers: { Depth: '1' },
+    });
+    if (!response.ok) return nameOrSlug;
+    const text = await response.text();
+    const calendars = parseCalendars(text);
+    for (const cal of calendars) {
+      const slug = cal.url.split('/').filter(Boolean).pop() ?? '';
+      if (slug === nameOrSlug) return nameOrSlug;
+    }
+    const lower = nameOrSlug.toLowerCase();
+    for (const cal of calendars) {
+      if (cal.displayName.toLowerCase() === lower) {
+        return cal.url.split('/').filter(Boolean).pop() ?? nameOrSlug;
+      }
+    }
+  } catch {
+    /* fall through — keep original input */
+  }
+  return nameOrSlug;
+}
+
+/**
  * Assert that a calendar supports VEVENT. Throws a descriptive error if not,
  * so create_event fails early with a useful message instead of a 403 from the server.
  */
@@ -600,9 +637,11 @@ async function assertCalendarSupportsEvents(
   });
 
   if (response.status === 404) {
-    throw new Error(
+    const err = new Error(
       `Calendar "${calendarName}" not found. Use list_calendars to find available calendar names.`
-    );
+    ) as Error & { code?: string };
+    err.code = 'CALENDAR_NOT_FOUND';
+    throw err;
   }
   if (!response.ok) return; // Can't check — let the server reject if needed
 
@@ -630,7 +669,8 @@ async function resolveEventByUid(
   uid: string
 ): Promise<{ href: string; etag: string; icalData: string }> {
   const config = getNextcloudConfig();
-  const calDavUrl = `${config.url}/remote.php/dav/calendars/${config.user}/${calendarName}/`;
+  let slug = calendarName;
+  const buildUrl = () => `${config.url}/remote.php/dav/calendars/${config.user}/${slug}/`;
 
   const reportBody = `<?xml version="1.0" encoding="UTF-8"?>
 <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
@@ -649,11 +689,23 @@ async function resolveEventByUid(
   </c:filter>
 </c:calendar-query>`;
 
-  const response = await fetchCalDAV(calDavUrl, {
+  let response = await fetchCalDAV(buildUrl(), {
     method: 'REPORT',
     body: reportBody,
     headers: { Depth: '1' },
   });
+
+  if (response.status === 404) {
+    const resolved = await resolveCalendarSlug(calendarName);
+    if (resolved !== calendarName) {
+      slug = resolved;
+      response = await fetchCalDAV(buildUrl(), {
+        method: 'REPORT',
+        body: reportBody,
+        headers: { Depth: '1' },
+      });
+    }
+  }
 
   if (!response.ok) {
     const errorText = await response.text();
@@ -788,7 +840,8 @@ export const listEventsTool = {
   handler: async (args: { calendarName: string; from?: string; to?: string; limit?: number }) => {
     try {
       const config = getNextcloudConfig();
-      const calDavUrl = `${config.url}/remote.php/dav/calendars/${config.user}/${args.calendarName}/`;
+      let slug = args.calendarName;
+      const buildUrl = () => `${config.url}/remote.php/dav/calendars/${config.user}/${slug}/`;
       const limit = args.limit || 50;
 
       // Default time range: today to 30 days from now
@@ -816,11 +869,23 @@ export const listEventsTool = {
   </c:filter>
 </c:calendar-query>`;
 
-      const response = await fetchCalDAV(calDavUrl, {
+      let response = await fetchCalDAV(buildUrl(), {
         method: 'REPORT',
         body: reportBody,
         headers: { Depth: '1' },
       });
+
+      if (response.status === 404) {
+        const resolved = await resolveCalendarSlug(args.calendarName);
+        if (resolved !== args.calendarName) {
+          slug = resolved;
+          response = await fetchCalDAV(buildUrl(), {
+            method: 'REPORT',
+            body: reportBody,
+            headers: { Depth: '1' },
+          });
+        }
+      }
 
       if (!response.ok) {
         const errorText = await response.text();
@@ -1018,11 +1083,28 @@ export const createEventTool = {
     try {
       const config = getNextcloudConfig();
       const eventUid = `${Date.now()}-${Math.random().toString(36).substring(7)}`;
-      const calendarBaseUrl = `${config.url}/remote.php/dav/calendars/${config.user}/${args.calendarName}/`;
-      const calDavUrl = `${calendarBaseUrl}${eventUid}.ics`;
+      let slug = args.calendarName;
+      const baseUrl = () => `${config.url}/remote.php/dav/calendars/${config.user}/${slug}/`;
 
-      // Validate the calendar supports VEVENT before building and sending the iCal payload
-      await assertCalendarSupportsEvents(calendarBaseUrl, args.calendarName);
+      // Validate the calendar supports VEVENT before building and sending the iCal payload.
+      // If the original name is a display name (not a slug), retry once after resolving.
+      try {
+        await assertCalendarSupportsEvents(baseUrl(), args.calendarName);
+      } catch (err) {
+        if ((err as { code?: string }).code === 'CALENDAR_NOT_FOUND') {
+          const resolved = await resolveCalendarSlug(args.calendarName);
+          if (resolved !== args.calendarName) {
+            slug = resolved;
+            await assertCalendarSupportsEvents(baseUrl(), args.calendarName);
+          } else {
+            throw err;
+          }
+        } else {
+          throw err;
+        }
+      }
+      const calendarBaseUrl = baseUrl();
+      const calDavUrl = `${calendarBaseUrl}${eventUid}.ics`;
       const now = icalNow();
       const isAllDay = args.dtstart.length === 8;
 
@@ -1144,7 +1226,7 @@ export const createEventTool = {
 
       // Verify the event was actually persisted
       try {
-        await resolveEventByUid(args.calendarName, eventUid);
+        await resolveEventByUid(slug, eventUid);
       } catch {
         throw new Error(
           `Event creation appeared to succeed (HTTP ${response.status}) but the event ` +

--- a/mcp-server/src/tools/apps/mail.ts
+++ b/mcp-server/src/tools/apps/mail.ts
@@ -4,6 +4,10 @@ import { z } from 'zod';
 import { fetchMailAPI } from '../../client/mail.js';
 import { fetchOCS } from '../../client/ocs.js';
 
+// Invisible padding characters used in newsletter preheaders
+// (U+034F, U+00AD, U+200B–U+200D, U+FEFF)
+const INVISIBLE_CHARS_RE = /[\u034F\u00AD\u200B-\u200D\uFEFF]/g;
+
 // ── Types ────────────────────────────────────────────────────────────
 
 interface MailAccount {
@@ -14,8 +18,10 @@ interface MailAccount {
 
 interface Mailbox {
   id: number;
+  databaseId?: number;
   accountId: number;
   name: string;
+  displayName?: string;
   specialUse: string[];
   unread: number;
   total: number;
@@ -29,6 +35,7 @@ interface MailRecipient {
 
 interface MailMessageSummary {
   id: number;
+  databaseId?: number;
   uid: number;
   mailboxId: number;
   subject: string;
@@ -44,8 +51,9 @@ interface MailMessageSummary {
     draft: boolean;
     important: boolean;
     junk: boolean;
+    hasAttachments?: boolean;
   };
-  hasAttachments: boolean;
+  hasAttachments?: boolean;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -55,7 +63,15 @@ function stripHtml(html: string): string {
   // Remove style and script blocks
   text = text.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '');
   text = text.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '');
-  // Convert line-break tags to newlines
+  // Image-based newsletters carry content in alt attributes
+  text = text.replace(/<img[^>]+alt="([^"]{2,})"[^>]*\/?>/gi, (_, alt) => `\n${alt.trim()}\n`);
+  text = text.replace(/<img[^>]+alt='([^']{2,})'[^>]*\/?>/gi, (_, alt) => `\n${alt.trim()}\n`);
+  text = text.replace(/<img[^>]*\/?>/gi, '');
+  // Block-level structure
+  text = text.replace(/<\/h[1-6]>/gi, '\n\n');
+  text = text.replace(/<\/tr>/gi, '\n');
+  text = text.replace(/<td[^>]*>/gi, ' ');
+  text = text.replace(/<th[^>]*>/gi, ' ');
   text = text.replace(/<br\s*\/?>/gi, '\n');
   text = text.replace(/<\/p>/gi, '\n\n');
   text = text.replace(/<\/div>/gi, '\n');
@@ -70,7 +86,15 @@ function stripHtml(html: string): string {
   text = text.replace(/&quot;/g, '"');
   text = text.replace(/&#39;/g, "'");
   text = text.replace(/&nbsp;/g, ' ');
-  // Collapse multiple blank lines
+  text = text.replace(/&#\d+;/g, '');
+  // Strip invisible preheader padding
+  text = text.replace(INVISIBLE_CHARS_RE, '');
+  // Trim per-line and drop blanks before collapsing
+  text = text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .join('\n');
   text = text.replace(/\n{3,}/g, '\n\n');
   return text.trim();
 }
@@ -134,19 +158,22 @@ const listMailboxesTool = {
   }),
   handler: async (args: { accountId: number }) => {
     try {
-      const response = await fetchMailAPI(`/accounts/${args.accountId}/mailboxes`);
+      const response = await fetchMailAPI(`/mailboxes?accountId=${args.accountId}`);
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${await response.text()}`);
       }
-      const mailboxes = (await response.json()) as Mailbox[];
+      const data = (await response.json()) as Mailbox[] | { mailboxes?: Mailbox[] };
+      const mailboxes = Array.isArray(data) ? data : (data.mailboxes ?? []);
 
       if (mailboxes.length === 0) {
         return { content: [{ type: 'text' as const, text: 'No mailboxes found.' }] };
       }
 
       const lines = mailboxes.map((m) => {
+        const id = m.databaseId ?? m.id;
+        const name = m.displayName ?? m.name;
         const unread = m.unread > 0 ? ` (${m.unread} unread)` : '';
-        return `• ${m.name}${unread} — ID: ${m.id}`;
+        return `• ${name}${unread} — ID: ${id}`;
       });
       return {
         content: [{ type: 'text' as const, text: `Mailboxes:\n${lines.join('\n')}` }],
@@ -190,35 +217,40 @@ const listMessagesTool = {
     filter?: string;
   }) => {
     try {
-      const queryParams: Record<string, string> = {};
-      if (args.limit) queryParams.limit = String(args.limit);
-      if (args.cursor) queryParams.cursor = String(args.cursor);
-      if (args.filter && args.filter !== 'all') queryParams.filter = args.filter;
+      const queryParts = [`mailboxId=${args.mailboxId}`];
+      if (args.limit) queryParts.push(`limit=${args.limit}`);
+      if (args.cursor) queryParts.push(`cursor=${args.cursor}`);
+      if (args.filter && args.filter !== 'all') queryParts.push(`filter=${args.filter}`);
 
-      const response = await fetchOCS<MailMessageSummary[]>(
-        `/ocs/v2.php/apps/mail/api/v1/mailboxes/${args.mailboxId}/messages`,
-        { queryParams }
-      );
+      const response = await fetchMailAPI(`/messages?${queryParts.join('&')}`);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+      }
+      const data = (await response.json()) as
+        | MailMessageSummary[]
+        | { messages?: MailMessageSummary[]; data?: MailMessageSummary[] };
+      const messages = Array.isArray(data) ? data : (data.messages ?? data.data ?? []);
 
-      const messages = response.ocs.data;
       if (!messages || messages.length === 0) {
         return { content: [{ type: 'text' as const, text: 'No messages found.' }] };
       }
 
       const lines = messages.map((msg) => {
+        const id = msg.databaseId ?? msg.id;
         const flags: string[] = [];
         if (!msg.flags.seen) flags.push('UNREAD');
         if (msg.flags.flagged) flags.push('starred');
         if (msg.flags.answered) flags.push('replied');
-        if (msg.hasAttachments) flags.push('attachment');
+        if (msg.flags?.hasAttachments ?? msg.hasAttachments) flags.push('attachment');
         const flagStr = flags.length > 0 ? ` [${flags.join(', ')}]` : '';
         const from = formatRecipients(msg.from);
-        return `• ${msg.subject}${flagStr}\n  From: ${from} | ${formatDate(msg.dateInt)} | ID: ${msg.id}`;
+        return `• ${msg.subject}${flagStr}\n  From: ${from} | ${formatDate(msg.dateInt)} | ID: ${id}`;
       });
 
       let text = `Messages (${messages.length}):\n${lines.join('\n')}`;
       if (messages.length >= (args.limit || 20)) {
-        const lastId = messages[messages.length - 1].id;
+        const last = messages[messages.length - 1];
+        const lastId = last.databaseId ?? last.id;
         text += `\n\nMore messages available. Use cursor: ${lastId} to load next page.`;
       }
 
@@ -246,34 +278,27 @@ const readMessageTool = {
   }),
   handler: async (args: { messageId: number }) => {
     try {
-      // Fetch metadata via OCS
-      const metaResponse = await fetchOCS<Record<string, unknown>>(
-        `/ocs/v2.php/apps/mail/api/v1/message/${args.messageId}`
-      );
-      const meta = metaResponse.ocs.data;
-
-      // Fetch body via Mail REST API
+      // Mail 5.x: /messages/{id}/body returns both metadata and body in one call.
       const bodyResponse = await fetchMailAPI(`/messages/${args.messageId}/body`);
-      let bodyText = '';
-      if (bodyResponse.ok) {
-        const bodyData = (await bodyResponse.json()) as Record<string, unknown>;
-        const rawBody = (bodyData.body as string) || (bodyData.data as string) || '';
-        bodyText = stripHtml(rawBody);
+      if (!bodyResponse.ok) {
+        throw new Error(`HTTP ${bodyResponse.status}: ${await bodyResponse.text()}`);
       }
+      const data = (await bodyResponse.json()) as Record<string, unknown>;
+      const rawBody = (data.body as string) || '';
+      const bodyText = rawBody ? stripHtml(rawBody) : '(no body)';
 
-      // Format output
-      const from = formatRecipients(meta.from as MailRecipient[]);
-      const to = formatRecipients(meta.to as MailRecipient[]);
-      const cc = formatRecipients((meta.cc as MailRecipient[]) || []);
-      const date = meta.dateInt ? formatDate(meta.dateInt as number) : 'Unknown';
-      const subject = (meta.subject as string) || '(No subject)';
+      const from = formatRecipients(data.from as MailRecipient[]);
+      const to = formatRecipients(data.to as MailRecipient[]);
+      const cc = formatRecipients((data.cc as MailRecipient[]) || []);
+      const date = data.dateInt ? formatDate(data.dateInt as number) : 'Unknown';
+      const subject = (data.subject as string) || '(No subject)';
 
       let text = `Subject: ${subject}\nFrom: ${from}\nTo: ${to}`;
       if (cc) text += `\nCc: ${cc}`;
       text += `\nDate: ${date}`;
       text += `\n${'─'.repeat(60)}\n${bodyText}`;
 
-      const attachments = meta.attachments as Array<{ fileName: string; size: number }> | undefined;
+      const attachments = data.attachments as Array<{ fileName: string; size: number }> | undefined;
       if (attachments && attachments.length > 0) {
         text += `\n${'─'.repeat(60)}\nAttachments:`;
         for (const att of attachments) {
@@ -290,6 +315,83 @@ const readMessageTool = {
           {
             type: 'text' as const,
             text: `Error reading message: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+const searchMessagesTool = {
+  name: 'mail_search_messages',
+  description:
+    'Search email messages across all mailboxes by subject or sender. ' +
+    'Returns matches with message IDs usable in mail_read_message. ' +
+    'For threaded conversations all message IDs in the thread are returned.',
+  inputSchema: z.object({
+    query: z.string().describe('Search query (matches subject and sender name)'),
+    limit: z.number().min(1).max(20).optional().describe('Max results (default: 10)'),
+  }),
+  handler: async (args: { query: string; limit?: number }) => {
+    try {
+      const response = await fetchOCS<{
+        entries: Array<{ title: string; subline: string; resourceUrl?: string }>;
+        isPaginated: boolean;
+        cursor?: string;
+      }>('/ocs/v2.php/search/providers/mail/search', {
+        queryParams: {
+          term: args.query,
+          limit: String(args.limit ?? 10),
+          format: 'json',
+        },
+      });
+      const results = response.ocs.data;
+      if (!results.entries?.length) {
+        return {
+          content: [{ type: 'text' as const, text: `No messages found for "${args.query}".` }],
+        };
+      }
+
+      const lines = await Promise.all(
+        results.entries.map(async (entry) => {
+          const match = entry.resourceUrl?.match(/\/box\/(\d+)\/thread\/(\d+)/);
+          if (!match) return `• ${entry.title}\n  ${entry.subline}`;
+          const msgId = parseInt(match[2], 10);
+          try {
+            const threadResp = await fetchMailAPI(`/messages/${msgId}/thread`);
+            if (!threadResp.ok) throw new Error('thread fetch failed');
+            const threadData = (await threadResp.json()) as unknown;
+            const msgs = (
+              Array.isArray(threadData)
+                ? threadData
+                : ((threadData as Record<string, unknown>).messages ?? [])
+            ) as Array<Record<string, unknown>>;
+            const sorted = msgs.sort(
+              (a, b) => ((a.dateInt as number) ?? 0) - ((b.dateInt as number) ?? 0)
+            );
+            if (sorted.length <= 1) {
+              return `• ${entry.title}\n  ${entry.subline} | ID: ${msgId}`;
+            }
+            const idList = sorted.map((m) => (m.databaseId ?? m.id) as number).join(', ');
+            return `• ${entry.title}\n  ${entry.subline} | Thread (${sorted.length} messages) IDs: ${idList}`;
+          } catch {
+            return `• ${entry.title}\n  ${entry.subline} | ID: ${msgId}`;
+          }
+        })
+      );
+
+      let text = `Search results for "${args.query}" (${results.entries.length}):\n${lines.join('\n')}`;
+      if (results.isPaginated && results.cursor) {
+        text += `\n\nMore results available.`;
+      }
+      return { content: [{ type: 'text' as const, text }] };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error searching messages: ${error instanceof Error ? error.message : String(error)}`,
           },
         ],
         isError: true,
@@ -504,6 +606,7 @@ export const mailTools = [
   listMailboxesTool,
   listMessagesTool,
   readMessageTool,
+  searchMessagesTool,
   sendMessageTool,
   deleteMessageTool,
   moveMessageTool,

--- a/mcp-server/src/tools/system/search.ts
+++ b/mcp-server/src/tools/system/search.ts
@@ -122,8 +122,17 @@ export const unifiedSearchTool = {
         };
       }
 
-      // Sort by order and take top providers (max 5 to avoid flooding)
-      const topProviders = [...providers].sort((a, b) => a.order - b.order).slice(0, 5);
+      // Always include the most useful providers; fill remaining slots by order.
+      // Without this, mail (order 20) and calendar (order 30) fall outside the
+      // top 5 on a typical install and are silently never searched.
+      const PRIORITY_IDS = ['files', 'mail', 'calendar', 'notes'];
+      const prioritized = PRIORITY_IDS.map((id) => providers.find((p) => p.id === id)).filter(
+        (p): p is SearchProvider => p !== undefined
+      );
+      const rest = providers
+        .filter((p) => !PRIORITY_IDS.includes(p.id))
+        .sort((a, b) => a.order - b.order);
+      const topProviders = [...prioritized, ...rest].slice(0, 6);
 
       const searches = await Promise.allSettled(
         topProviders.map((p) => searchProvider(p.id, args.query, args.limit))

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.10</version>
+    <version>0.3.11</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/composer.lock
+++ b/nextcloud-app/composer.lock
@@ -607,22 +607,23 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v8.0.13",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "c7f40f9103233630167c25c9a4570acf805fdade"
+                "reference": "68a48e4c31f63fcd1bdff997a85a09e55efe8cdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/c7f40f9103233630167c25c9a4570acf805fdade",
-                "reference": "c7f40f9103233630167c25c9a4570acf805fdade",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/68a48e4c31f63fcd1bdff997a85a09e55efe8cdb",
+                "reference": "68a48e4c31f63fcd1bdff997a85a09e55efe8cdb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "psr/log": "^1|^2|^3",
-                "symfony/http-client-contracts": "~3.4.4|^3.5.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/http-client-contracts": "^3.7",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
@@ -638,7 +639,7 @@
             "require-dev": {
                 "amphp/http-client": "^5.3.2",
                 "amphp/http-tunnel": "^2.0",
-                "guzzlehttp/promises": "^1.4|^2.0",
+                "guzzlehttp/guzzle": "^7.10",
                 "nyholm/psr7": "^1.0",
                 "php-http/httplug": "^1.0|^2.0",
                 "psr/http-client": "^1.0",
@@ -679,7 +680,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v8.0.13"
+                "source": "https://github.com/symfony/http-client/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -699,7 +700,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-24T09:58:02+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/http-client-contracts",

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
## Summary

Patch release **0.3.11** bundling two MCP fixes:

- **Nextcloud Mail 5.x compatibility (#338)** (be7cd17) — Mail 5.x removed the OCS API and renamed REST fields, breaking `list_mailboxes`, `mail_list_messages` and `mail_read_message` on any NC running Mail ≥ 5.0. Also adds `mail_search_messages`.
- **Calendar display-name resolution (#339)** — `list_events`, `get_event`, `create_event`, `update_event` and `delete_event` previously 404'd when given the display name shown by `list_calendars` (e.g. `Persönlich` vs the slug `personal`). They now lazily resolve display names to slugs on 404 with a single PROPFIND retry; existing slug callers see zero extra round trips.

Version bumped to 0.3.11 across `mcp-server` and `nextcloud-app`.

## Test plan

- [x] `npm test` — 724 tests pass (36 calendar tests including 5 new display-name cases)
- [x] `npm run build` — server.json synced to 0.3.11
- [x] `npx prettier --check src/` clean
- [ ] Manual: call `list_calendars` against an NC with a non-ASCII display name, then call `list_events` with the display name — expect events, not a 404
- [ ] Manual: NC + Mail 5.x → `list_mailboxes`, `mail_list_messages`, `mail_read_message`, `mail_search_messages`

Closes #338.
Closes #339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)