### PR TITLE
fix(mcp): stop crash loop on unwritable state dir — degrade gracefully (#342)

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "AIquila - MCP server for Nextcloud integration",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,13 +18,13 @@
       ]
     }
   ],
-  "version": "0.3.11",
+  "version": "0.3.12",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -52,7 +52,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.11",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.12",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/__tests__/auth/state-persistence.test.ts
+++ b/mcp-server/src/__tests__/auth/state-persistence.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+//
+// End-to-end persistence tests that exercise the *real* filesystem (no fs mock),
+// proving OAuth state survives a process restart and that an unwritable state
+// directory degrades gracefully instead of crashing (discussion #342).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+vi.mock('../../logger.js', () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { logger } from '../../logger.js';
+import { ClientsStore, RefreshStore } from '../../auth/store.js';
+
+describe('state persistence (real filesystem)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dir = mkdtempSync(join(tmpdir(), 'aiquila-persist-'));
+  });
+
+  afterEach(() => {
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      /* ignore */
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('RefreshStore persists a token to disk and a new instance reloads it', () => {
+    const file = join(dir, 'refresh-tokens.json');
+
+    const first = new RefreshStore(file);
+    const token = first.store({ userId: 'alice', clientId: 'c1', scopes: ['read'] });
+
+    // Simulate a restart: a brand-new store reading the same file.
+    const second = new RefreshStore(file);
+    const entry = second.get(token);
+    expect(entry?.userId).toBe('alice');
+    expect(entry?.clientId).toBe('c1');
+    expect(entry?.scopes).toEqual(['read']);
+  });
+
+  it('RefreshStore reflects a deletion on disk across instances', () => {
+    const file = join(dir, 'refresh-tokens.json');
+
+    const first = new RefreshStore(file);
+    const token = first.store({ userId: 'bob', clientId: 'c2', scopes: [] });
+    first.delete(token);
+
+    const second = new RefreshStore(file);
+    expect(second.get(token)).toBeUndefined();
+  });
+
+  it('ClientsStore persists a registered client and a new instance reloads it', () => {
+    const file = join(dir, 'clients.json');
+
+    const first = new ClientsStore({ enableDynamicRegistration: true, stateFile: file });
+    const client = first.registerClient!({
+      redirect_uris: [new URL('https://example.com/cb')],
+      client_name: 'Round Trip App',
+    });
+
+    const second = new ClientsStore({ enableDynamicRegistration: true, stateFile: file });
+    expect(second.getClient(client.client_id)).toMatchObject({
+      client_id: client.client_id,
+      client_name: 'Round Trip App',
+    });
+  });
+
+  it('degrades gracefully when the state dir is read-only — no throw, in-memory still works, warns with #342', () => {
+    if (process.getuid?.() === 0) {
+      // root bypasses permission checks — skip
+      return;
+    }
+    const file = join(dir, 'refresh-tokens.json');
+    chmodSync(dir, 0o500); // read + execute, no write
+
+    const store = new RefreshStore(file);
+    let token = '';
+    expect(() => {
+      token = store.store({ userId: 'alice', clientId: 'c1', scopes: ['read'] });
+    }).not.toThrow();
+
+    // The token is unusable across a restart, but works in-memory for this process.
+    expect(store.get(token)?.userId).toBe('alice');
+
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.objectContaining({ code: expect.stringMatching(/EACCES|EPERM|EROFS/) }),
+      expect.stringContaining('discussions/342')
+    );
+  });
+});

--- a/mcp-server/src/__tests__/auth/store.test.ts
+++ b/mcp-server/src/__tests__/auth/store.test.ts
@@ -488,17 +488,26 @@ describe('RefreshStore — persistence', () => {
     expect(mockWriteFileSync).not.toHaveBeenCalled();
   });
 
-  it('writeFileSync error propagates so the token endpoint can return 500', () => {
+  it('writeFileSync error degrades gracefully — does not throw, warns with #342 guidance', () => {
     const stateFile = `${TEST_STATE_DIR}/refresh-tokens.json`;
+    const err = new Error('permission denied') as NodeJS.ErrnoException;
+    err.code = 'EACCES';
     mockWriteFileSync.mockImplementation(() => {
-      throw new Error('disk full');
+      throw err;
     });
 
     const store = new RefreshStore(stateFile);
-    expect(() => store.store({ userId: 'alice', clientId: 'c1', scopes: [] })).toThrow('disk full');
+    const token = store.store({ userId: 'alice', clientId: 'c1', scopes: [] });
+
+    // Token still works in-memory even though it couldn't be persisted.
+    expect(store.get(token)?.userId).toBe('alice');
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.objectContaining({ dir: TEST_STATE_DIR, code: 'EACCES' }),
+      expect.stringContaining('discussions/342')
+    );
   });
 
-  it('renameSync error propagates and cleans up the .tmp file', () => {
+  it('renameSync error degrades gracefully — does not throw and cleans up the .tmp file', () => {
     const stateFile = `${TEST_STATE_DIR}/refresh-tokens.json`;
     mockRenameSync.mockImplementation(() => {
       throw new Error('cross-device link');
@@ -506,9 +515,7 @@ describe('RefreshStore — persistence', () => {
     mockUnlinkSync.mockReturnValue(undefined);
 
     const store = new RefreshStore(stateFile);
-    expect(() => store.store({ userId: 'alice', clientId: 'c1', scopes: [] })).toThrow(
-      'cross-device link'
-    );
+    expect(() => store.store({ userId: 'alice', clientId: 'c1', scopes: [] })).not.toThrow();
     expect(mockUnlinkSync).toHaveBeenCalledWith(stateFile + '.tmp');
   });
 

--- a/mcp-server/src/auth/store.ts
+++ b/mcp-server/src/auth/store.ts
@@ -2,7 +2,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { readFileSync, writeFileSync, mkdirSync, renameSync, unlinkSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import type { OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
 import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
 import { logger } from '../logger.js';
@@ -31,6 +31,45 @@ const DEFAULT_STATE_DIR = '/app/state';
 
 function stateDir(): string {
   return (process.env.MCP_AUTH_STATE_DIR ?? DEFAULT_STATE_DIR).replace(/\/+$/, '');
+}
+
+// True once we've emitted the loud "state dir not writable" warning, so the
+// startup probe and the first failed persist warn at most once between them —
+// subsequent persist failures drop to debug to avoid flooding the logs.
+let warnedUnwritable = false;
+
+/**
+ * Operator-facing remediation for an unwritable state directory. The fix is to
+ * recreate the (root-owned) Docker named volume so a fresh one inherits the
+ * image's node ownership — `docker compose exec ... chown` cannot be used here
+ * because the container would otherwise be in a crash loop. See discussion #342.
+ */
+export function stateUnwritableMessage(dir: string, code?: string): string {
+  return (
+    `State directory ${dir} is not writable${code ? ` (${code})` : ''} — ` +
+    `OAuth tokens will NOT persist; clients must re-authenticate after every restart. ` +
+    `To restore persistence, recreate the state volume (this clears existing tokens; ` +
+    `clients re-authenticate once):\n` +
+    `  docker compose down mcp && docker volume rm <project>_mcp_state && docker compose up -d mcp\n` +
+    `See https://github.com/elgorro/aiquila/discussions/342`
+  );
+}
+
+/**
+ * Marks the unwritable-state warning as already emitted (called by the startup
+ * probe in the HTTP transport) so the first failed persist does not warn twice.
+ */
+export function markStateUnwritableWarned(): void {
+  warnedUnwritable = true;
+}
+
+function warnPersistFailed(dir: string, code: string | undefined, err: unknown): void {
+  if (warnedUnwritable) {
+    logger.debug({ dir, code, err }, '[state] persist failed — state dir not writable');
+    return;
+  }
+  warnedUnwritable = true;
+  logger.warn({ dir, code }, stateUnwritableMessage(dir, code));
 }
 
 function ensureDir(dir: string): void {
@@ -70,7 +109,10 @@ function saveJson(filePath: string, data: unknown): void {
     } catch {
       // ignore cleanup failure
     }
-    throw err;
+    // Graceful degradation: a persist failure must never crash a request or the
+    // process. The server keeps running with in-memory state (tokens just won't
+    // survive a restart) and warns the operator how to fix it. See discussion #342.
+    warnPersistFailed(dirname(filePath), (err as NodeJS.ErrnoException).code, err);
   }
 }
 

--- a/mcp-server/src/transports/http.ts
+++ b/mcp-server/src/transports/http.ts
@@ -8,7 +8,12 @@ import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js';
 import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
 import { createServer, SERVER_VERSION } from '../server.js';
 import { NextcloudOAuthProvider } from '../auth/provider.js';
-import { probeStateDir, StateDirNotWritableError } from '../auth/store.js';
+import {
+  probeStateDir,
+  StateDirNotWritableError,
+  stateUnwritableMessage,
+  markStateUnwritableWarned,
+} from '../auth/store.js';
 import { loginHandler } from '../auth/login.js';
 import { logger } from '../logger.js';
 import { fetchStatus } from '../client/ocs.js';
@@ -212,14 +217,18 @@ export async function startHttp(): Promise<void> {
       probeStateDir();
     } catch (err) {
       if (err instanceof StateDirNotWritableError) {
-        logger.fatal(
+        // Degrade gracefully rather than crash-loop: the server still serves
+        // requests, it just can't persist OAuth tokens until the operator fixes
+        // the volume. Crashing here was un-fixable under `restart: unless-stopped`
+        // because `docker compose exec` needs a running container (discussion #342).
+        logger.warn(
           { dir: err.dir, code: err.cause.code },
-          `[startup] State directory is not writable — refresh tokens cannot be persisted. ` +
-            `Fix volume ownership and restart:\n  docker compose exec -u 0 mcp chown -R node:node ${err.dir}\n  docker compose restart mcp`
+          stateUnwritableMessage(err.dir, err.cause.code)
         );
-        process.exit(1);
+        markStateUnwritableWarned();
+      } else {
+        throw err;
       }
-      throw err;
     }
 
     const provider = new NextcloudOAuthProvider();

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.11</version>
+    <version>0.3.12</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
## Problem

PR #341 added a startup probe that called `process.exit(1)` when `/app/state` was not writable. Under `restart: unless-stopped` this turned into an **un-fixable crash loop**: the container exits in ~1s, so the remediation it printed (`docker compose exec -u 0 mcp chown …`) can't run — there's no running container to exec into. This is what users hit in production (discussion #342).

The root cause is unchanged: the `mcp_state` Docker **named volume** is root-owned (created by an older image that ran as root), while the server runs as the unprivileged `node` user. Docker only copies the image's ownership onto an *empty* volume on first mount, so pre-existing volumes stay root-owned across upgrades. Fresh installs are fine.

Investigation note: the OAuth state dir is the **only** thing the server writes to disk (`refresh-tokens.json` + `clients.json`). The only data at risk is OAuth tokens, which a one-time client re-auth fully recovers — so a hard crash is disproportionate.

## Fix — graceful degradation

- **`auth/store.ts`**: `saveJson()` now catches persist failures, cleans up the `.tmp` file, and warns instead of throwing. Added a shared `stateUnwritableMessage()` (points operators to the recreate-volume command + discussion #342) and a warn-once guard so logs don't flood.
- **`transports/http.ts`**: the probe failure now logs a single `warn` and **continues startup** instead of `process.exit(1)`. The server serves normally; OAuth tokens just don't persist until the volume is fixed.

## Tests

- Updated the two `store.test.ts` cases that asserted error *propagation* → now assert graceful degradation (no throw, in-memory token still works, warns with the #342 link, `.tmp` cleaned up).
- Added **`state-persistence.test.ts`** (real filesystem, no fs mock): RefreshStore/ClientsStore disk round-trips across simulated restarts, deletion propagation, and a read-only-dir case proving no-crash + warning.
- Full suite: 728 passing.

## Operator remediation (now documented in #342)

Recreate the state volume so a fresh one inherits the image's `node` ownership (clients re-auth once):

\`\`\`bash
docker compose down mcp
docker volume rm <project>_mcp_state   # e.g. aiq-full_mcp_state
docker compose up -d mcp
\`\`\`

Or fix ownership in place from a throwaway root container (works even during the old crash loop):

\`\`\`bash
docker run --rm -u 0 -v <project>_mcp_state:/app/state alpine chown -R 1000:1000 /app/state
\`\`\`

## Version

Patch bump `0.3.11 → 0.3.12` across all release locations (mcp `package.json`/`server.json` incl. ghcr image tag, nextcloud `info.xml`/`package.json`, lock synced) so the fix ships in the published image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)