### PR TITLE
feat(mcp): support multiple event reminders via alarms[] (#346)

### DIFF
--- a/docs/mcp/tools/apps/calendar.md
+++ b/docs/mcp/tools/apps/calendar.md
@@ -96,7 +96,8 @@ Create a new calendar event with date/time, location, description, attendees, an
 - `attendees` (object[], optional): Attendees with email, display name, role, RSVP
 - `rrule` (string, optional): Recurrence rule (e.g. `FREQ=WEEKLY;BYDAY=MO,WE,FR`)
 - `accessClass` (enum, optional): `PUBLIC`, `PRIVATE`, `CONFIDENTIAL`
-- `alarm` (number, optional): Reminder in minutes before the event
+- `alarm` (number, optional): Single reminder in minutes before the event
+- `alarms` (number[], optional): Multiple reminders in minutes before the event (e.g. `[1440, 60]` for 1 day and 1 hour before). Combined with `alarm` if both are set.
 
 **Returns:**
 Confirmation with event UID.
@@ -143,6 +144,8 @@ Update an existing calendar event's fields by UID. Uses CalDAV ETag-based optimi
 - `categories` (string[], optional): Replace all tags
 - `accessClass` (enum, optional): New classification
 - `rrule` (string|null, optional): New recurrence rule, or `null` to remove
+- `alarm` (number|null, optional): Single reminder in minutes before the event, or `null` to remove all existing alarms
+- `alarms` (number[], optional): Multiple reminders in minutes before the event (e.g. `[1440, 60]`). Replaces existing alarms; combined with `alarm` if both are set.
 
 **Returns:**
 Confirmation message.

--- a/mcp-server/src/__tests__/tools-calendar.test.ts
+++ b/mcp-server/src/__tests__/tools-calendar.test.ts
@@ -419,6 +419,33 @@ END:VCALENDAR</c:calendar-data>
       expect(putCall[1].body).toContain('END:VALARM');
     });
 
+    it('should create event with multiple alarms via alarms[] (and merge with alarm)', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(propfindVeventOk)
+        .mockResolvedValueOnce({ ok: true, status: 201, text: () => Promise.resolve('') })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 207,
+          text: () => Promise.resolve(verifyResponse),
+        });
+
+      const { createEventTool } = await import('../tools/apps/calendar.js');
+      await createEventTool.handler({
+        summary: 'Release',
+        calendarName: 'personal',
+        dtstart: '20240315T100000Z',
+        alarm: 15,
+        alarms: [1440, 60],
+      });
+
+      const putBody = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[1][1].body;
+      // One VALARM block per reminder: alarms[] first, then alarm
+      expect(putBody.match(/BEGIN:VALARM/g)).toHaveLength(3);
+      expect(putBody).toContain('TRIGGER:-PT24H'); // 1440 min = 1 day
+      expect(putBody).toContain('TRIGGER:-PT1H'); // 60 min
+      expect(putBody).toContain('TRIGGER:-PT15M'); // 15 min
+    });
+
     it('should create event with recurrence rule', async () => {
       (global.fetch as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce(propfindVeventOk)
@@ -724,6 +751,25 @@ END:VCALENDAR</C:calendar-data>
       expect(putBody).toContain('TRIGGER:-PT15M');
       expect(putBody).toContain('ACTION:DISPLAY');
       expect(putBody).toContain('END:VALARM');
+    });
+
+    it('should set multiple alarms via alarms[]', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(resolveResponse) })
+        .mockResolvedValueOnce({ ok: true, status: 204, text: () => Promise.resolve('') });
+
+      const { updateEventTool } = await import('../tools/apps/calendar.js');
+      const result = await updateEventTool.handler({
+        uid: 'event-1',
+        calendarName: 'personal',
+        alarms: [1440, 60],
+      });
+
+      expect(result.content[0].text).toContain('updated successfully');
+      const putBody = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[1][1].body;
+      expect(putBody.match(/BEGIN:VALARM/g)).toHaveLength(2);
+      expect(putBody).toContain('TRIGGER:-PT24H');
+      expect(putBody).toContain('TRIGGER:-PT1H');
     });
 
     it('should remove alarm when set to null', async () => {

--- a/mcp-server/src/tools/apps/calendar.ts
+++ b/mcp-server/src/tools/apps/calendar.ts
@@ -263,6 +263,29 @@ function ensureVTimezone(icalData: string, tzid: string): string {
   return icalData.replace(/BEGIN:VEVENT/, `${vtz}\r\nBEGIN:VEVENT`);
 }
 
+/**
+ * Build a DISPLAY VALARM block firing `minutes` before the event. Returns an
+ * empty string for non-positive values (those are skipped, not emitted).
+ */
+function buildVAlarm(minutes: number): string {
+  if (minutes <= 0) return '';
+  const totalSeconds = minutes * 60;
+  const hours = Math.floor(totalSeconds / 3600);
+  const mins = Math.floor((totalSeconds % 3600) / 60);
+  const durationStr = `-PT${hours > 0 ? hours + 'H' : ''}${mins > 0 ? mins + 'M' : ''}`;
+  return `BEGIN:VALARM\r\nACTION:DISPLAY\r\nDESCRIPTION:Reminder\r\nTRIGGER:${durationStr}\r\nEND:VALARM`;
+}
+
+/**
+ * Merge the single `alarm` and the `alarms` array into one list of reminder
+ * minutes. `alarms` entries come first, then `alarm` (if a positive number).
+ * The MCP-client-friendly split exists because a union type's anyOf JSON Schema
+ * is not reliably honored, so a dedicated array parameter is needed.
+ */
+function collectAlarmMinutes(alarm: number | null | undefined, alarms?: number[]): number[] {
+  return [...(alarms ?? []), ...(alarm !== undefined && alarm !== null ? [alarm] : [])];
+}
+
 // ---------------------------------------------------------------------------
 // Parsing
 // ---------------------------------------------------------------------------
@@ -1051,7 +1074,15 @@ export const createEventTool = {
     alarm: z
       .number()
       .optional()
-      .describe('Reminder in minutes before the event (e.g. 15 for 15 min before)'),
+      .describe(
+        'Single reminder in minutes before the event (e.g. 15 for 15 min before). For multiple reminders use alarms[].'
+      ),
+    alarms: z
+      .array(z.number())
+      .optional()
+      .describe(
+        'Multiple reminders in minutes before the event (e.g. [1440, 60] for 1 day and 1 hour before). Combined with alarm if both are set.'
+      ),
     tzid: z
       .string()
       .optional()
@@ -1078,6 +1109,7 @@ export const createEventTool = {
     rrule?: string;
     accessClass?: string;
     alarm?: number;
+    alarms?: number[];
     tzid?: string;
   }) => {
     try {
@@ -1195,14 +1227,10 @@ export const createEventTool = {
         }
       }
 
-      // Add alarm
-      if (args.alarm !== undefined && args.alarm > 0) {
-        const sign = '-';
-        const totalSeconds = args.alarm * 60;
-        const hours = Math.floor(totalSeconds / 3600);
-        const minutes = Math.floor((totalSeconds % 3600) / 60);
-        const durationStr = `${sign}PT${hours > 0 ? hours + 'H' : ''}${minutes > 0 ? minutes + 'M' : ''}`;
-        vevent += `\r\nBEGIN:VALARM\r\nACTION:DISPLAY\r\nDESCRIPTION:Reminder\r\nTRIGGER:${durationStr}\r\nEND:VALARM`;
+      // Add alarms — one VALARM block per reminder (alarm + alarms merged)
+      for (const mins of collectAlarmMinutes(args.alarm, args.alarms)) {
+        const valarm = buildVAlarm(mins);
+        if (valarm) vevent += `\r\n${valarm}`;
       }
 
       vevent += `\r\nEND:VEVENT\r\nEND:VCALENDAR`;
@@ -1289,7 +1317,15 @@ export const updateEventTool = {
       .number()
       .nullable()
       .optional()
-      .describe('Reminder in minutes before the event, or null to remove existing alarm'),
+      .describe(
+        'Single reminder in minutes before the event, or null to remove all existing alarms. For multiple reminders use alarms[].'
+      ),
+    alarms: z
+      .array(z.number())
+      .optional()
+      .describe(
+        'Multiple reminders in minutes before the event (e.g. [1440, 60]). Replaces existing alarms; combined with alarm if both are set.'
+      ),
     attendees: z
       .array(
         z.object({
@@ -1326,6 +1362,7 @@ export const updateEventTool = {
     accessClass?: string;
     rrule?: string | null;
     alarm?: number | null;
+    alarms?: number[];
     attendees?: Array<{
       email: string;
       cn?: string;
@@ -1392,20 +1429,17 @@ export const updateEventTool = {
         }
       }
 
-      // Handle alarm (VALARM)
-      if (args.alarm !== undefined) {
-        // Remove existing VALARM block
+      // Handle alarms (VALARM). Any alarm/alarms input replaces all existing
+      // VALARM blocks; alarm:null clears them without adding new ones.
+      if (args.alarm !== undefined || args.alarms !== undefined) {
         modified = modified.replace(/BEGIN:VALARM[\s\S]*?END:VALARM\r?\n?/g, '');
-        if (args.alarm !== null && args.alarm > 0) {
-          const sign = '-';
-          const totalSeconds = args.alarm * 60;
-          const hours = Math.floor(totalSeconds / 3600);
-          const minutes = Math.floor((totalSeconds % 3600) / 60);
-          const durationStr = `${sign}PT${hours > 0 ? hours + 'H' : ''}${minutes > 0 ? minutes + 'M' : ''}`;
-          modified = modified.replace(
-            /END:VEVENT/,
-            `BEGIN:VALARM\r\nACTION:DISPLAY\r\nDESCRIPTION:Reminder\r\nTRIGGER:${durationStr}\r\nEND:VALARM\r\nEND:VEVENT`
-          );
+        if (args.alarm !== null) {
+          for (const mins of collectAlarmMinutes(args.alarm, args.alarms)) {
+            const valarm = buildVAlarm(mins);
+            if (valarm) {
+              modified = modified.replace(/END:VEVENT/, `${valarm}\r\nEND:VEVENT`);
+            }
+          }
         }
       }
 


### PR DESCRIPTION
Closes #346.

## Problem

`create_event` / `update_event` only accepted a single `alarm` (minutes before the event), so it was impossible to set multiple reminders (e.g. 1 day **and** 1 hour before) — standard in calendar apps and fully supported by CalDAV via multiple `VALARM` blocks.

## Approach

Add a separate `alarms: number[]` parameter alongside the existing `alarm`. The handler merges both and emits one `VALARM` block per entry. A `z.union([number, number[]])` was deliberately avoided — the generated `anyOf` JSON Schema is not reliably honored by MCP clients (Claude only ever passed a single number).

- New helpers `buildVAlarm()` / `collectAlarmMinutes()` de-duplicate the VALARM/duration logic that was previously inlined in both tools.
- Fully backwards compatible: `alarm: 15` works unchanged; `alarm: null` on update still clears all alarms.

## Usage

```jsonc
// Single reminder (unchanged)
{ "alarm": 15 }
// Multiple reminders
{ "alarms": [1440, 60] }   // 1 day + 1 hour before
// Combined
{ "alarm": 15, "alarms": [1440, 60] }
```

## Tests & docs

- Added create + update test cases asserting the correct number of `VALARM` blocks and `TRIGGER:-PT24H` / `-PT1H` / `-PT15M` values.
- Documented `alarms` on both tools in `docs/mcp/tools/apps/calendar.md` (also filled in the previously-missing `alarm` entry on `update_event`).

## Verification

- `npm run build` ✅ · `npm run lint` ✅ (0 errors) · `npx prettier --check src/` ✅
- `npm test` ✅ — 730 passed (38 calendar tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)