### PR TITLE
feat(mcp): add mail_get_attachment tool (#347)

### DIFF
--- a/docker/mcp-server/Dockerfile
+++ b/docker/mcp-server/Dockerfile
@@ -11,6 +11,8 @@ FROM node:24-alpine AS runner
 LABEL io.modelcontextprotocol.server.name="io.github.elgorro/aiquila-mcp"
 WORKDIR /app
 ENV NODE_ENV=production
+# poppler-utils provides pdftotext, used by mail_get_attachment for PDF text extraction
+RUN apk add --no-cache poppler-utils
 COPY package*.json ./
 RUN npm ci --omit=dev
 COPY --from=builder /app/dist ./dist

--- a/docker/mcp-server/Dockerfile.dev
+++ b/docker/mcp-server/Dockerfile.dev
@@ -1,9 +1,11 @@
 FROM node:24-alpine
 
 # Install development dependencies
+# poppler-utils provides pdftotext, used by mail_get_attachment for PDF text extraction
 RUN apk add --no-cache \
     git \
-    curl
+    curl \
+    poppler-utils
 
 WORKDIR /app
 

--- a/docs/mcp/tools/apps/mail.md
+++ b/docs/mcp/tools/apps/mail.md
@@ -15,6 +15,7 @@ Integration with Nextcloud Mail app. Manage email accounts, mailboxes, and messa
 | `list_mailboxes` | List mailboxes/folders for an account |
 | `list_messages` | List messages in a mailbox |
 | `read_message` | Read full message content |
+| `mail_get_attachment` | Download an attachment inline (text/image/PDF) |
 | `send_message` | Send an email |
 | `delete_message` | Delete a message |
 | `move_message` | Move a message to another mailbox |
@@ -94,6 +95,34 @@ Headers, body text, and attachment list.
 ```
 Ask Claude: "Read message 1234"
 Ask Claude: "Show me the full email from John"
+```
+
+---
+
+### mail_get_attachment
+
+Download an email attachment by message ID and attachment ID and return its content
+inline. Attachment IDs are listed in `read_message` output (shown as `[id: …]`).
+
+**Parameters:**
+- `messageId` (number, required): The message ID (from `read_message`)
+- `attachmentId` (string, required): The attachment ID shown in `read_message` (e.g. `"2"`)
+
+**Returns (depends on the attachment's content type):**
+- **Text / ICS / JSON** — the raw text
+- **Images** — a base64 image block, usable directly by vision-capable models
+- **PDFs** — plain text extracted with `pdftotext`, wrapped in
+  `[UNTRUSTED EXTERNAL CONTENT]` markers
+- **Other binary** — a short note with the MIME type and size (cannot be read inline)
+
+**Dependency:** PDF text extraction requires `pdftotext` from `poppler-utils`. It is
+included in the official Docker image. If it is unavailable, the tool degrades gracefully
+and returns the type + size fallback instead of failing.
+
+**Example Usage:**
+```
+Ask Claude: "Read message 1234, then open the PDF attachment"
+Ask Claude: "Show me the image attached to message 1234"
 ```
 
 ---

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.12",
+      "version": "0.3.13",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "AIquila - MCP server for Nextcloud integration",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,13 +18,13 @@
       ]
     }
   ],
-  "version": "0.3.12",
+  "version": "0.3.13",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.12",
+      "version": "0.3.13",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -52,7 +52,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.12",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.13",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/__tests__/tools-mail.test.ts
+++ b/mcp-server/src/__tests__/tools-mail.test.ts
@@ -297,7 +297,7 @@ describe('Mail Tools', () => {
             to: [{ label: 'Bob', email: 'bob@example.com' }],
             cc: [{ label: 'Carol', email: 'carol@example.com' }],
             dateInt: 1700000000,
-            attachments: [{ fileName: 'report.pdf', size: 12345 }],
+            attachments: [{ id: '2', fileName: 'report.pdf', size: 12345 }],
             body: '<p>Hello <b>World</b></p><br>Nice to meet you.',
           }),
       });
@@ -317,6 +317,7 @@ describe('Mail Tools', () => {
       expect(result.content[0].text).toContain('Nice to meet you');
       expect(result.content[0].text).toContain('report.pdf');
       expect(result.content[0].text).toContain('12345 bytes');
+      expect(result.content[0].text).toContain('[id: 2]');
       expect(result.content[0].text).toContain('Message ID: 100');
     });
 
@@ -353,6 +354,95 @@ describe('Mail Tools', () => {
       const { mailTools } = await import('../tools/apps/mail.js');
       const tool = mailTools.find((t) => t.name === 'mail_read_message')!;
       const result = await tool.handler({ messageId: 999 });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('404');
+    });
+  });
+
+  describe('mail_get_attachment', () => {
+    it('should return text content for text attachments', async () => {
+      mockFetchMailAPI.mockResolvedValue({
+        ok: true,
+        headers: { get: () => 'text/plain; charset=utf-8' },
+        text: () => Promise.resolve('hello attachment'),
+      });
+
+      const { mailTools } = await import('../tools/apps/mail.js');
+      const tool = mailTools.find((t) => t.name === 'mail_get_attachment')!;
+      const result = await tool.handler({ messageId: 100, attachmentId: '2' });
+
+      expect(mockFetchMailAPI).toHaveBeenCalledWith('/messages/100/attachment/2');
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toBe('hello attachment');
+    });
+
+    it('should return an image block for image attachments', async () => {
+      const bytes = Buffer.from('fakepng');
+      mockFetchMailAPI.mockResolvedValue({
+        ok: true,
+        headers: { get: () => 'image/png' },
+        arrayBuffer: () => Promise.resolve(bytes.buffer.slice(0, bytes.length)),
+      });
+
+      const { mailTools } = await import('../tools/apps/mail.js');
+      const tool = mailTools.find((t) => t.name === 'mail_get_attachment')!;
+      const result = await tool.handler({ messageId: 100, attachmentId: '3' });
+
+      expect(result.content[0].type).toBe('image');
+      expect(result.content[0]).toHaveProperty('mimeType', 'image/png');
+      expect(result.content[0]).toHaveProperty('data');
+      expect((result.content[0] as { data: string }).data.length).toBeGreaterThan(0);
+    });
+
+    it('should fall back gracefully for PDFs when pdftotext yields no text', async () => {
+      const bytes = Buffer.from('%PDF-1.4 not-real');
+      mockFetchMailAPI.mockResolvedValue({
+        ok: true,
+        headers: { get: () => 'application/pdf' },
+        arrayBuffer: () => Promise.resolve(bytes.buffer.slice(0, bytes.length)),
+      });
+
+      const { mailTools } = await import('../tools/apps/mail.js');
+      const tool = mailTools.find((t) => t.name === 'mail_get_attachment')!;
+      const result = await tool.handler({ messageId: 100, attachmentId: '4' });
+
+      // Either extracted text (UNTRUSTED marker) or graceful fallback — never an error.
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].type).toBe('text');
+      const text = result.content[0].text;
+      expect(text.includes('UNTRUSTED EXTERNAL CONTENT') || text.includes('application/pdf')).toBe(
+        true
+      );
+    });
+
+    it('should return type + size for other binary attachments', async () => {
+      const bytes = Buffer.alloc(2048);
+      mockFetchMailAPI.mockResolvedValue({
+        ok: true,
+        headers: { get: () => 'application/octet-stream' },
+        arrayBuffer: () => Promise.resolve(bytes.buffer.slice(0, bytes.length)),
+      });
+
+      const { mailTools } = await import('../tools/apps/mail.js');
+      const tool = mailTools.find((t) => t.name === 'mail_get_attachment')!;
+      const result = await tool.handler({ messageId: 100, attachmentId: '5' });
+
+      expect(result.content[0].text).toContain('application/octet-stream');
+      expect(result.content[0].text).toContain('2.0 KB');
+      expect(result.content[0].text).toContain('Cannot be read inline');
+    });
+
+    it('should handle errors', async () => {
+      mockFetchMailAPI.mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve('Not found'),
+      });
+
+      const { mailTools } = await import('../tools/apps/mail.js');
+      const tool = mailTools.find((t) => t.name === 'mail_get_attachment')!;
+      const result = await tool.handler({ messageId: 999, attachmentId: '1' });
 
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('404');

--- a/mcp-server/src/tools/apps/mail.ts
+++ b/mcp-server/src/tools/apps/mail.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, unlinkSync } from 'node:fs';
 import { z } from 'zod';
 import { fetchMailAPI } from '../../client/mail.js';
 import { fetchOCS } from '../../client/ocs.js';
@@ -298,12 +300,16 @@ const readMessageTool = {
       text += `\nDate: ${date}`;
       text += `\n${'─'.repeat(60)}\n${bodyText}`;
 
-      const attachments = data.attachments as Array<{ fileName: string; size: number }> | undefined;
+      const attachments = data.attachments as
+        | Array<{ id?: string | number; fileName: string; size: number }>
+        | undefined;
       if (attachments && attachments.length > 0) {
         text += `\n${'─'.repeat(60)}\nAttachments:`;
         for (const att of attachments) {
-          text += `\n  • ${att.fileName} (${att.size} bytes)`;
+          const idPart = att.id !== undefined ? `[id: ${att.id}] ` : '';
+          text += `\n  • ${idPart}${att.fileName} (${att.size} bytes)`;
         }
+        text += `\n(Use mail_get_attachment with the message ID and an attachment id to read one.)`;
       }
 
       text += `\n\nMessage ID: ${args.messageId}`;
@@ -315,6 +321,105 @@ const readMessageTool = {
           {
             type: 'text' as const,
             text: `Error reading message: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+const getAttachmentTool = {
+  name: 'mail_get_attachment',
+  description:
+    'Download an email attachment by message ID and attachment ID. ' +
+    'Returns text for text files and calendar invites (ICS), image data for images, ' +
+    'extracted text for PDFs (requires pdftotext). ' +
+    'Attachment IDs are shown in mail_read_message output.',
+  inputSchema: z.object({
+    messageId: z.number().describe('Message ID (from mail_read_message)'),
+    attachmentId: z.string().describe('Attachment ID shown in mail_read_message (e.g. "2")'),
+  }),
+  handler: async (args: { messageId: number; attachmentId: string }) => {
+    try {
+      const response = await fetchMailAPI(
+        `/messages/${args.messageId}/attachment/${args.attachmentId}`
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+      }
+
+      const contentType = response.headers.get('content-type') ?? 'application/octet-stream';
+      const mimeType = contentType.split(';')[0].trim();
+
+      if (
+        mimeType.startsWith('text/') ||
+        mimeType === 'application/json' ||
+        mimeType === 'application/ics'
+      ) {
+        const text = await response.text();
+        return { content: [{ type: 'text' as const, text }] };
+      }
+
+      if (mimeType.startsWith('image/')) {
+        const buffer = await response.arrayBuffer();
+        const base64 = Buffer.from(buffer).toString('base64');
+        return { content: [{ type: 'image' as const, data: base64, mimeType }] };
+      }
+
+      if (mimeType === 'application/pdf') {
+        const buffer = await response.arrayBuffer();
+        const safeId =
+          String(args.messageId).replace(/[^a-zA-Z0-9_-]/g, '') +
+          '_' +
+          String(args.attachmentId).replace(/[^a-zA-Z0-9_-]/g, '');
+        const tmpFile = `/tmp/mcp_att_${safeId}.pdf`;
+        try {
+          writeFileSync(tmpFile, Buffer.from(buffer));
+          const result = spawnSync('pdftotext', [tmpFile, '-'], { encoding: 'utf8' });
+          unlinkSync(tmpFile);
+          if (result.status === 0 && result.stdout.trim().length > 0) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `[UNTRUSTED EXTERNAL CONTENT - PDF ATTACHMENT]\n${result.stdout}\n[END EXTERNAL CONTENT]`,
+                },
+              ],
+            };
+          }
+        } catch {
+          try {
+            unlinkSync(tmpFile);
+          } catch {
+            /* ignore */
+          }
+        }
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Attachment: ${mimeType}, ${(buffer.byteLength / 1024).toFixed(1)} KB. Could not extract text (pdftotext unavailable or empty).`,
+            },
+          ],
+        };
+      }
+
+      const buffer = await response.arrayBuffer();
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Attachment: ${mimeType}, ${(buffer.byteLength / 1024).toFixed(1)} KB. Cannot be read inline.`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error downloading attachment: ${error instanceof Error ? error.message : String(error)}`,
           },
         ],
         isError: true,
@@ -606,6 +711,7 @@ export const mailTools = [
   listMailboxesTool,
   listMessagesTool,
   readMessageTool,
+  getAttachmentTool,
   searchMessagesTool,
   sendMessageTool,
   deleteMessageTool,

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.12</version>
+    <version>0.3.13</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
Closes #347.

## Summary

Adds a `mail_get_attachment` MCP tool that downloads a Nextcloud Mail attachment by message ID + attachment ID and returns it inline, branching on the response `Content-Type`:

- **text / ICS / JSON** → raw text
- **images** → base64 `image` content block (usable by vision-capable models)
- **PDFs** → plain text extracted via `pdftotext` (poppler-utils), wrapped in `[UNTRUSTED EXTERNAL CONTENT]` markers; degrades gracefully to a type+size note if `pdftotext` is unavailable or yields no text
- **other binary** → MIME type + size note

## Notable extras beyond the issue

- **Expose attachment IDs in `mail_read_message`.** The issue assumed IDs were already shown, but the tool only printed `fileName` + `size`. They're now rendered as `[id: …]` with a hint, so the get-attachment workflow is actually usable.
- **`poppler-utils` added to the Docker images** (`docker/mcp-server/Dockerfile` + `Dockerfile.dev`) so PDF extraction works in all deployed stacks out of the box, instead of requiring an out-of-tree Dockerfile extension.

## Security notes

- Temp-file IDs sanitized with `/[^a-zA-Z0-9_-]/g` to prevent path traversal
- `spawnSync` invoked without `shell: true` — no shell injection
- Extracted PDF text wrapped in untrusted-content markers as a prompt-injection hint

## Version

Patch bump `0.3.12 → 0.3.13` across `package.json`, `server.json` (+ ghcr image tag), `info.xml`, nextcloud `package.json`, and `package-lock.json`.

## Docs

New `mail_get_attachment` section in `docs/mcp/tools/apps/mail.md`.

## Testing

- `npm run build`, `npm run lint` (0 errors), `npx prettier --check src/` — all pass
- `npm test` — **735 passed**, including 5 new `mail_get_attachment` cases (text, image, PDF graceful-fallback, binary fallback, HTTP error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)