### PR TITLE
chore: bump to 0.3.17 + enrich MCP registry metadata

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.16",
+      "version": "0.3.17",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.16",
-  "description": "AIquila - MCP server for Nextcloud integration",
+  "version": "0.3.17",
+  "description": "Nextcloud MCP server — files, calendar, contacts, mail, maps, notes, tasks & 120+ more tools",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
@@ -21,10 +21,15 @@
   },
   "keywords": [
     "mcp",
+    "model-context-protocol",
     "nextcloud",
     "claude",
     "ai",
-    "aiquila"
+    "aiquila",
+    "webdav",
+    "caldav",
+    "carddav",
+    "self-hosted"
   ],
   "author": "sirgorro",
   "license": "MIT",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,13 +18,25 @@
       ]
     }
   ],
-  "version": "0.3.16",
+  "version": "0.3.17",
   "websiteUrl": "https://github.com/elgorro/aiquila",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://{hostname}/mcp",
+      "variables": {
+        "hostname": {
+          "description": "Hostname of your self-hosted AIquila MCP server (e.g. mcp.example.com). Authenticates via OAuth 2.0 (PKCE); clients discover the flow via the server's protected-resource metadata.",
+          "isRequired": true
+        }
+      }
+    }
+  ],
   "packages": [
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.16",
+      "version": "0.3.17",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -52,7 +64,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.16",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.17",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.16</version>
+    <version>0.3.17</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
## Why

The original idea — PR our server into `modelcontextprotocol/servers` — is a dead end: that repo dropped its community list and now redirects all listings to the **MCP Registry**. This change improves the metadata the registry actually surfaces, so AIquila is more discoverable.

## Changes

- **`server.json`**: add a `remotes` (streamable-http) entry using `{hostname}` URL templating to model self-hosted instances; OAuth 2.0 / PKCE discovered via protected-resource metadata (no headers).
- **`package.json`**: richer npm description (matches `server.json`) + expanded keywords (`model-context-protocol`, `webdav`, `caldav`, `carddav`, `self-hosted`).
- Bump all four version locations to **0.3.17**; sync lockfile + OCI tag.

## Notes

- Sync script (`scripts/sync-server-json.mjs`) only rewrites `version`/package identifiers — `remotes` is preserved. Verified.
- Prettier clean, lint passes (warnings only).
- Publishing to npm + `mcp-publisher publish` is a manual follow-up (requires auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)