### PR TITLE
chore: bump GitHub Actions to Node.js 24 runtimes

### DIFF
--- a/.github/workflows/hetzner-integration-test.yml
+++ b/.github/workflows/hetzner-integration-test.yml
@@ -64,7 +64,7 @@ jobs:
       RUN_INFRA_TEST: ${{ inputs.run_infra_test }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Mask sensitive inputs
         run: |
@@ -73,12 +73,12 @@ jobs:
           echo "::add-mask::${{ inputs.dns_zone }}"
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: hetzner/go.mod
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 

--- a/.github/workflows/hetzner-release.yml
+++ b/.github/workflows/hetzner-release.yml
@@ -17,7 +17,7 @@ jobs:
       previous-version: ${{ steps.check.outputs.previous }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -47,12 +47,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: hetzner/go.mod
 
@@ -177,7 +177,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: hetzner-v${{ needs.check-version.outputs.version }}
           name: aiquila-hetzner v${{ needs.check-version.outputs.version }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,10 @@ jobs:
         working-directory: mcp-server
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -18,7 +18,7 @@ jobs:
       previous-version: ${{ steps.check.outputs.previous }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -56,12 +56,12 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 
@@ -174,7 +174,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: mcp-v${{ needs.check-version.outputs.version }}
           name: MCP Server v${{ needs.check-version.outputs.version }}
@@ -194,8 +194,8 @@ jobs:
       contents: read
       id-token: write          # required for npm Trusted Publishing (OIDC)
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -221,8 +221,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
       - name: Install dependencies
@@ -252,7 +252,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/nc-release.yml
+++ b/.github/workflows/nc-release.yml
@@ -18,7 +18,7 @@ jobs:
       previous-version: ${{ steps.check.outputs.previous }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -56,7 +56,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -67,7 +67,7 @@ jobs:
           tools: composer
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 
@@ -231,7 +231,7 @@ jobs:
           sed -i 's/^          //' /tmp/release-body.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: nc-v${{ needs.check-version.outputs.version }}
           name: Nextcloud App v${{ needs.check-version.outputs.version }}
@@ -313,7 +313,7 @@ jobs:
           APPSTORE_TOKEN: ${{ secrets.NEXTCLOUD_APPSTORE_TOKEN }}
 
       - name: Download release artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: aiquila.tar.gz
         continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
         working-directory: mcp-server
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'npm'
@@ -39,7 +39,7 @@ jobs:
         working-directory: nextcloud-app
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Summary

Resolves the **Node.js 20 actions are deprecated** warnings surfaced in CI (e.g. the `check-version` and `build-and-release` jobs). GitHub forces the Node.js 24 default on June 16th 2026 and removes Node.js 20 from runners on September 16th 2026, so these actions are bumped to the major versions that ship a Node.js 24 runtime.

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v5 |
| `actions/setup-node` | v4 | v5 |
| `actions/setup-go` | v5 | v6 |
| `actions/download-artifact` | v4 | v5 |
| `softprops/action-gh-release` | v1 | v2 |

`docker/*` actions already run on Node 24 and were left unchanged.

## Notes

- All `setup-node` steps pin `node-version`, so the v4→v5 default-Node change is a no-op here.
- Bumps are drop-in for the inputs in use; no workflow logic changed.

## Verification

- `grep` confirms no `@v4`/`@v1` remain for the bumped actions across `.github/workflows/`.
- `lint` and `test` workflows should run green on this PR with the deprecation annotations gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)