### PR TITLE
feat(mcp): News integration (RSS feeds)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ Complete documentation for the AIquila Nextcloud app and MCP server.
 | Bookmarks, folders, tags | 13 | [Bookmarks](mcp/tools/apps/bookmarks.md) |
 | Maps, GPS, tracks, photos | 26 | [Maps](mcp/tools/apps/maps.md) |
 | Notes | 5 | [Notes](mcp/tools/apps/notes.md) |
+| News (RSS feeds) | 17 | [News](mcp/tools/apps/news.md) |
 | Recipes | 6 | [Cookbook](mcp/tools/apps/cookbook.md) |
 | NC AI tasks & image gen | 4 | [Assistant](mcp/tools/apps/assistant.md) |
 | File shares | 4 | [Shares](mcp/tools/apps/shares.md) |

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -35,6 +35,7 @@ Nextcloud apps and administration:
 - **Bookmarks** — Bookmark CRUD, folder hierarchy, and tag management
 - **Maps** — Favorites, GPS devices/tracks, photo geotagging, custom maps, import/export
 - **Notes** — Markdown notes with categories and search
+- **News** — RSS/Atom feed subscriptions, folders, and article reading/triage
 - **Polls** — Create text/date polls, vote, comment, and share
 - **Forms** — Build surveys, collect responses, and export results
 - **Cookbook** — Recipe management with schema.org format
@@ -198,6 +199,27 @@ Nextcloud apps and administration:
 | `create_note` | Create a note | [Notes](tools/apps/notes.md#create_note) |
 | `update_note` | Update a note | [Notes](tools/apps/notes.md#update_note) |
 | `delete_note` | Delete a note | [Notes](tools/apps/notes.md#delete_note) |
+
+#### News (17 tools)
+| Tool | Description | Documentation |
+|------|-------------|---------------|
+| `list_feeds` | List subscribed RSS feeds | [News](tools/apps/news.md#list_feeds) |
+| `add_feed` | Subscribe to a feed | [News](tools/apps/news.md#add_feed) |
+| `delete_feed` | Delete a feed | [News](tools/apps/news.md#delete_feed) |
+| `move_feed` | Move a feed to a folder | [News](tools/apps/news.md#move_feed) |
+| `rename_feed` | Rename a feed | [News](tools/apps/news.md#rename_feed) |
+| `mark_feed_read` | Mark a feed's items read | [News](tools/apps/news.md#mark_feed_read) |
+| `list_news_folders` | List feed folders | [News](tools/apps/news.md#list_news_folders) |
+| `create_news_folder` | Create a folder | [News](tools/apps/news.md#create_news_folder) |
+| `rename_news_folder` | Rename a folder | [News](tools/apps/news.md#rename_news_folder) |
+| `delete_news_folder` | Delete a folder | [News](tools/apps/news.md#delete_news_folder) |
+| `mark_news_folder_read` | Mark a folder's items read | [News](tools/apps/news.md#mark_news_folder_read) |
+| `list_news_items` | List/filter articles | [News](tools/apps/news.md#list_news_items) |
+| `mark_item_read` | Mark an article read | [News](tools/apps/news.md#mark_item_read) |
+| `mark_item_unread` | Mark an article unread | [News](tools/apps/news.md#mark_item_unread) |
+| `star_item` | Star an article | [News](tools/apps/news.md#star_item) |
+| `unstar_item` | Unstar an article | [News](tools/apps/news.md#unstar_item) |
+| `mark_items_read` | Mark multiple articles read | [News](tools/apps/news.md#mark_items_read) |
 
 #### Polls (21 tools)
 | Tool | Description | Documentation |

--- a/docs/mcp/tools/apps/news.md
+++ b/docs/mcp/tools/apps/news.md
@@ -1,0 +1,137 @@
+# Nextcloud News Tools
+
+Integration with the Nextcloud News app. Manage RSS/Atom feeds, organize them into folders, and read and triage articles through Claude.
+
+## Prerequisites
+
+- Nextcloud News app must be installed and enabled
+- Uses the News REST API v1-3
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_feeds` | List all subscribed feeds with unread counts |
+| `add_feed` | Subscribe to a new feed by URL |
+| `delete_feed` | Delete (unsubscribe from) a feed |
+| `move_feed` | Move a feed into a folder |
+| `rename_feed` | Rename a feed |
+| `mark_feed_read` | Mark all items in a feed as read |
+| `list_news_folders` | List feed folders |
+| `create_news_folder` | Create a folder |
+| `rename_news_folder` | Rename a folder |
+| `delete_news_folder` | Delete a folder and its feeds |
+| `mark_news_folder_read` | Mark all items in a folder as read |
+| `list_news_items` | List/filter articles (feed, folder, starred, all) |
+| `mark_item_read` | Mark an article read |
+| `mark_item_unread` | Mark an article unread |
+| `star_item` | Star an article |
+| `unstar_item` | Unstar an article |
+| `mark_items_read` | Mark multiple articles read in one call |
+
+---
+
+## Feed Tools
+
+### list_feeds
+List all RSS feeds subscribed in the Nextcloud News app, with unread counts. No parameters.
+
+### add_feed
+Subscribe to a new RSS feed by URL, optionally placing it in a folder.
+
+**Parameters:**
+- `url` (string, required): The RSS/Atom feed URL
+- `folderId` (number, optional): Folder ID to place the feed in (omit for root)
+
+### delete_feed
+Delete (unsubscribe from) a feed and all its items.
+
+**Parameters:**
+- `feedId` (number, required): The feed ID
+
+### move_feed
+Move a feed into a different folder.
+
+**Parameters:**
+- `feedId` (number, required): The feed ID
+- `folderId` (number, required): Destination folder ID (0 for root)
+
+### rename_feed
+Rename a feed.
+
+**Parameters:**
+- `feedId` (number, required): The feed ID
+- `feedTitle` (string, required): The new feed title
+
+### mark_feed_read
+Mark all items in a feed as read up to (and including) the given newest item ID.
+
+**Parameters:**
+- `feedId` (number, required): The feed ID
+- `newestItemId` (number, required): Mark all items with ID ≤ this value as read
+
+---
+
+## Folder Tools
+
+### list_news_folders
+List all folders used to organize feeds. No parameters.
+
+### create_news_folder
+Create a new folder.
+
+**Parameters:**
+- `name` (string, required): The folder name
+
+### rename_news_folder
+Rename a folder.
+
+**Parameters:**
+- `folderId` (number, required): The folder ID
+- `name` (string, required): The new folder name
+
+### delete_news_folder
+Delete a folder and all feeds it contains.
+
+**Parameters:**
+- `folderId` (number, required): The folder ID
+
+### mark_news_folder_read
+Mark all items in a folder as read up to (and including) the given newest item ID.
+
+**Parameters:**
+- `folderId` (number, required): The folder ID
+- `newestItemId` (number, required): Mark all items with ID ≤ this value as read
+
+---
+
+## Item Tools
+
+### list_news_items
+List news articles. Filter by feed, folder, starred, or all; supports pagination and read/unread filtering.
+
+**Parameters:**
+- `type` (`feed` | `folder` | `starred` | `all`, optional): Scope (default `all`)
+- `id` (number, optional): Feed or folder ID when `type` is `feed` or `folder` (default 0)
+- `batchSize` (number, optional): Max items to return (default 20, -1 for all)
+- `offset` (number, optional): Return items older than this item ID (pagination)
+- `getRead` (boolean, optional): Include already-read items (default false)
+- `oldestFirst` (boolean, optional): Return oldest items first (default newest first)
+
+### mark_item_read / mark_item_unread
+Mark a single article read or unread.
+
+**Parameters:**
+- `itemId` (number, required): The item ID
+
+### star_item / unstar_item
+Star or unstar a single article.
+
+**Parameters:**
+- `itemId` (number, required): The item ID
+
+### mark_items_read
+Mark multiple articles as read in one call.
+
+**Parameters:**
+- `itemIds` (number[], required): The item IDs to mark as read

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.17",
+      "version": "0.3.18",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Nextcloud MCP server — files, calendar, contacts, mail, maps, notes, tasks & 120+ more tools",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,7 +18,7 @@
       ]
     }
   ],
-  "version": "0.3.17",
+  "version": "0.3.18",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "remotes": [
     {
@@ -36,7 +36,7 @@
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.17",
+      "version": "0.3.18",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -64,7 +64,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.17",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.18",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/__tests__/tools-news.test.ts
+++ b/mcp-server/src/__tests__/tools-news.test.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the News API client module
+const mockFetchNewsAPI = vi.fn();
+
+vi.mock('../client/news.js', () => ({
+  fetchNewsAPI: (...args: unknown[]) => mockFetchNewsAPI(...args),
+}));
+
+describe('News Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXTCLOUD_URL = 'https://cloud.example.com';
+    process.env.NEXTCLOUD_USER = 'testuser';
+    process.env.NEXTCLOUD_PASSWORD = 'testpass';
+  });
+
+  describe('list_feeds', () => {
+    it('should return formatted feed list', async () => {
+      mockFetchNewsAPI.mockResolvedValue({
+        feeds: [
+          {
+            id: 4,
+            url: 'https://blog.example.com/feed',
+            title: 'Example Blog',
+            faviconLink: null,
+            added: 1700000000,
+            folderId: 2,
+            unreadCount: 7,
+            ordering: 0,
+            link: 'https://blog.example.com',
+            pinned: false,
+            updateErrorCount: 0,
+            lastUpdateError: null,
+          },
+        ],
+      });
+
+      const { newsTools } = await import('../tools/apps/news.js');
+      const tool = newsTools.find((t) => t.name === 'list_feeds')!;
+      const result = await tool.handler({});
+
+      expect(result.content[0].text).toContain('Example Blog');
+      expect(result.content[0].text).toContain('https://blog.example.com/feed');
+      expect(result.content[0].text).toContain('Unread: 7');
+      expect(result.content[0].text).toContain('Feeds (1)');
+    });
+
+    it('should handle empty feed list', async () => {
+      mockFetchNewsAPI.mockResolvedValue({ feeds: [] });
+      const { newsTools } = await import('../tools/apps/news.js');
+      const tool = newsTools.find((t) => t.name === 'list_feeds')!;
+      const result = await tool.handler({});
+      expect(result.content[0].text).toContain('No feeds');
+    });
+  });
+
+  describe('add_feed', () => {
+    it('should POST url and folderId and report created feed', async () => {
+      mockFetchNewsAPI.mockResolvedValue({ feeds: [{ id: 9, title: 'New Feed' }] });
+      const { newsTools } = await import('../tools/apps/news.js');
+      const tool = newsTools.find((t) => t.name === 'add_feed')!;
+      const result = await tool.handler({ url: 'https://x.example/feed', folderId: 3 });
+
+      expect(mockFetchNewsAPI).toHaveBeenCalledWith('/feeds', {
+        method: 'POST',
+        body: { url: 'https://x.example/feed', folderId: 3 },
+      });
+      expect(result.content[0].text).toContain('New Feed');
+      expect(result.content[0].text).toContain('9');
+    });
+  });
+
+  describe('list_news_items', () => {
+    it('should map type/id and format items', async () => {
+      mockFetchNewsAPI.mockResolvedValue({
+        items: [
+          {
+            id: 100,
+            guid: 'g',
+            guidHash: 'gh',
+            url: 'https://x.example/article',
+            title: 'Big News',
+            author: 'Jane',
+            pubDate: 1700000000,
+            body: '<p>Hello <b>world</b></p>',
+            enclosureMime: null,
+            enclosureLink: null,
+            feedId: 4,
+            unread: true,
+            starred: false,
+            lastModified: 1700000001,
+            fingerprint: 'fp',
+          },
+        ],
+      });
+
+      const { newsTools } = await import('../tools/apps/news.js');
+      const tool = newsTools.find((t) => t.name === 'list_news_items')!;
+      const result = await tool.handler({ type: 'feed', id: 4, getRead: true });
+
+      expect(mockFetchNewsAPI).toHaveBeenCalledWith('/items', {
+        queryParams: { type: 0, id: 4, batchSize: 20, getRead: true, oldestFirst: false },
+      });
+      expect(result.content[0].text).toContain('Big News');
+      expect(result.content[0].text).toContain('Hello world');
+      expect(result.content[0].text).not.toContain('<b>');
+    });
+  });
+
+  describe('mark_item_read', () => {
+    it('should POST to the read endpoint', async () => {
+      mockFetchNewsAPI.mockResolvedValue(undefined);
+      const { newsTools } = await import('../tools/apps/news.js');
+      const tool = newsTools.find((t) => t.name === 'mark_item_read')!;
+      const result = await tool.handler({ itemId: 100 });
+
+      expect(mockFetchNewsAPI).toHaveBeenCalledWith('/items/100/read', { method: 'POST' });
+      expect(result.content[0].text).toContain('100');
+    });
+
+    it('should return an error result when the API throws', async () => {
+      mockFetchNewsAPI.mockRejectedValue(new Error('boom'));
+      const { newsTools } = await import('../tools/apps/news.js');
+      const tool = newsTools.find((t) => t.name === 'mark_item_read')!;
+      const result = await tool.handler({ itemId: 100 });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('boom');
+    });
+  });
+});

--- a/mcp-server/src/client/news.ts
+++ b/mcp-server/src/client/news.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+
+import { getNextcloudConfig } from '../tools/types.js';
+import { logger } from '../logger.js';
+import { ApiError } from './aiquila.js';
+
+export interface Feed {
+  id: number;
+  url: string;
+  title: string;
+  faviconLink: string | null;
+  added: number;
+  folderId: number;
+  unreadCount: number;
+  ordering: number;
+  link: string | null;
+  pinned: boolean;
+  updateErrorCount: number;
+  lastUpdateError: string | null;
+}
+
+export interface Folder {
+  id: number;
+  name: string;
+  opened: boolean;
+}
+
+export interface Item {
+  id: number;
+  guid: string;
+  guidHash: string;
+  url: string;
+  title: string;
+  author: string | null;
+  pubDate: number;
+  body: string;
+  enclosureMime: string | null;
+  enclosureLink: string | null;
+  feedId: number;
+  unread: boolean;
+  starred: boolean;
+  lastModified: number;
+  fingerprint: string;
+}
+
+/**
+ * Make an authenticated request to the Nextcloud News REST API v1-3.
+ *
+ * Base path: /index.php/apps/news/api/v1-3
+ *
+ * Returns plain JSON (no OCS envelope), like the Notes API.
+ */
+export async function fetchNewsAPI<T = unknown>(
+  endpoint: string,
+  options: {
+    method?: string;
+    body?: unknown;
+    queryParams?: Record<string, string | number | boolean | undefined>;
+  } = {}
+): Promise<T> {
+  const config = getNextcloudConfig();
+  const auth = Buffer.from(`${config.user}:${config.password}`).toString('base64');
+
+  let url = `${config.url}/index.php/apps/news/api/v1-3${endpoint}`;
+  if (options.queryParams) {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(options.queryParams)) {
+      if (value !== undefined) params.append(key, String(value));
+    }
+    const qs = params.toString();
+    if (qs) url += `?${qs}`;
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Basic ${auth}`,
+    'OCS-APIRequest': 'true',
+    Accept: 'application/json',
+  };
+
+  let body: string | undefined;
+  if (options.body !== undefined) {
+    body = JSON.stringify(options.body);
+    headers['Content-Type'] = 'application/json';
+  }
+
+  const method = options.method ?? 'GET';
+  const t0 = Date.now();
+  const response = await fetch(url, { method, headers, body });
+  logger.trace({ method, url, status: response.status, ms: Date.now() - t0 }, '[news] HTTP');
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new ApiError(response.status, response.statusText, text);
+  }
+
+  if (
+    response.status === 200 &&
+    response.headers.get('content-type')?.includes('application/json')
+  ) {
+    return (await response.json()) as T;
+  }
+
+  return undefined as T;
+}

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -18,6 +18,7 @@ import { calendarTools } from './tools/apps/calendar.js';
 import { cookbookTools } from './tools/apps/cookbook.js';
 import { deckTools } from './tools/apps/deck.js';
 import { notesTools } from './tools/apps/notes.js';
+import { newsTools } from './tools/apps/news.js';
 import { aiquilaTools } from './tools/apps/aiquila.js';
 import { usersTools } from './tools/apps/users.js';
 import { groupsTools } from './tools/apps/groups.js';
@@ -90,6 +91,7 @@ export const TOOL_REGISTRY: ToolSetEntry[] = [
   { category: 'tasks', appIds: ['tasks'], tools: tasksTools },
   { category: 'contacts', appIds: ['contacts'], tools: contactsTools },
   { category: 'notes', appIds: ['notes'], tools: notesTools },
+  { category: 'news', appIds: ['news'], tools: newsTools },
   { category: 'mail', appIds: ['mail'], tools: mailTools },
   { category: 'deck', appIds: ['deck'], tools: deckTools },
   { category: 'cookbook', appIds: ['cookbook'], tools: cookbookTools },

--- a/mcp-server/src/tools/apps/news.ts
+++ b/mcp-server/src/tools/apps/news.ts
@@ -1,0 +1,451 @@
+// SPDX-License-Identifier: MIT
+
+import { z } from 'zod';
+import { fetchNewsAPI, type Feed, type Folder, type Item } from '../../client/news.js';
+
+/**
+ * Nextcloud News App Tools
+ * Manages RSS feeds, folders, and articles via the News REST API v1-3.
+ */
+
+// ── Response shapes ─────────────────────────────────────────────────────────
+
+interface FeedsResponse {
+  feeds: Feed[];
+  starredCount?: number;
+  newestItemId?: number;
+}
+
+interface FoldersResponse {
+  folders: Folder[];
+}
+
+interface ItemsResponse {
+  items: Item[];
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function err(action: string, error: unknown) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: `Error ${action}: ${error instanceof Error ? error.message : String(error)}`,
+      },
+    ],
+    isError: true,
+  };
+}
+
+function text(body: string) {
+  return { content: [{ type: 'text' as const, text: body }] };
+}
+
+/** Strip HTML tags and collapse whitespace, then truncate. */
+function stripHtml(html: string, max = 280): string {
+  const plain = html
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return plain.length > max ? `${plain.slice(0, max)}…` : plain;
+}
+
+function formatFeed(f: Feed): string {
+  const parts = [`- **${f.title || '(untitled)'}** — ${f.url}`];
+  parts.push(`  ID: ${f.id} | Folder: ${f.folderId} | Unread: ${f.unreadCount}`);
+  if (f.lastUpdateError) parts.push(`  ⚠ Update error: ${f.lastUpdateError}`);
+  return parts.join('\n');
+}
+
+function formatItem(i: Item): string {
+  const flags = [i.unread ? 'unread' : 'read', i.starred ? 'starred' : null]
+    .filter(Boolean)
+    .join(', ');
+  const lines = [`- **${i.title || '(untitled)'}**  (ID: ${i.id}, feed: ${i.feedId}, ${flags})`];
+  lines.push(`  ${i.url}`);
+  if (i.author) lines.push(`  by ${i.author} — ${new Date(i.pubDate * 1000).toISOString()}`);
+  else lines.push(`  ${new Date(i.pubDate * 1000).toISOString()}`);
+  if (i.body) lines.push(`  ${stripHtml(i.body)}`);
+  return lines.join('\n');
+}
+
+// ── Feed tools ──────────────────────────────────────────────────────────────
+
+export const listFeedsTool = {
+  name: 'list_feeds',
+  description: 'List all RSS feeds subscribed in the Nextcloud News app, with unread counts.',
+  inputSchema: z.object({}),
+  handler: async () => {
+    try {
+      const result = await fetchNewsAPI<FeedsResponse>('/feeds');
+      if (!result.feeds || result.feeds.length === 0) {
+        return text('No feeds subscribed.');
+      }
+      const formatted = result.feeds.map(formatFeed).join('\n');
+      return text(`Feeds (${result.feeds.length}):\n\n${formatted}`);
+    } catch (error) {
+      return err('listing feeds', error);
+    }
+  },
+};
+
+export const addFeedTool = {
+  name: 'add_feed',
+  description: 'Subscribe to a new RSS feed by URL, optionally placing it in a folder.',
+  inputSchema: z.object({
+    url: z.string().describe('The RSS/Atom feed URL to subscribe to'),
+    folderId: z.number().optional().describe('Folder ID to place the feed in (omit for root)'),
+  }),
+  handler: async (args: { url: string; folderId?: number }) => {
+    try {
+      const body: Record<string, unknown> = { url: args.url };
+      if (args.folderId !== undefined) body.folderId = args.folderId;
+      const result = await fetchNewsAPI<FeedsResponse>('/feeds', { method: 'POST', body });
+      const feed = result.feeds?.[0];
+      return text(
+        feed
+          ? `Subscribed to feed "${feed.title}" (ID: ${feed.id}).`
+          : `Subscribed to feed: ${args.url}`
+      );
+    } catch (error) {
+      return err('adding feed', error);
+    }
+  },
+};
+
+export const deleteFeedTool = {
+  name: 'delete_feed',
+  description: 'Delete (unsubscribe from) a feed and all its items.',
+  inputSchema: z.object({
+    feedId: z.number().describe('The feed ID to delete'),
+  }),
+  handler: async (args: { feedId: number }) => {
+    try {
+      await fetchNewsAPI(`/feeds/${args.feedId}`, { method: 'DELETE' });
+      return text(`Deleted feed ${args.feedId}.`);
+    } catch (error) {
+      return err('deleting feed', error);
+    }
+  },
+};
+
+export const moveFeedTool = {
+  name: 'move_feed',
+  description: 'Move a feed into a different folder.',
+  inputSchema: z.object({
+    feedId: z.number().describe('The feed ID to move'),
+    folderId: z.number().describe('Destination folder ID (0 for root)'),
+  }),
+  handler: async (args: { feedId: number; folderId: number }) => {
+    try {
+      await fetchNewsAPI(`/feeds/${args.feedId}/move`, {
+        method: 'POST',
+        body: { folderId: args.folderId },
+      });
+      return text(`Moved feed ${args.feedId} to folder ${args.folderId}.`);
+    } catch (error) {
+      return err('moving feed', error);
+    }
+  },
+};
+
+export const renameFeedTool = {
+  name: 'rename_feed',
+  description: 'Rename a feed.',
+  inputSchema: z.object({
+    feedId: z.number().describe('The feed ID to rename'),
+    feedTitle: z.string().describe('The new feed title'),
+  }),
+  handler: async (args: { feedId: number; feedTitle: string }) => {
+    try {
+      await fetchNewsAPI(`/feeds/${args.feedId}/rename`, {
+        method: 'POST',
+        body: { feedTitle: args.feedTitle },
+      });
+      return text(`Renamed feed ${args.feedId} to "${args.feedTitle}".`);
+    } catch (error) {
+      return err('renaming feed', error);
+    }
+  },
+};
+
+export const markFeedReadTool = {
+  name: 'mark_feed_read',
+  description: 'Mark all items in a feed as read up to (and including) the given newest item ID.',
+  inputSchema: z.object({
+    feedId: z.number().describe('The feed ID'),
+    newestItemId: z.number().describe('Mark all items with ID <= this value as read'),
+  }),
+  handler: async (args: { feedId: number; newestItemId: number }) => {
+    try {
+      await fetchNewsAPI(`/feeds/${args.feedId}/read`, {
+        method: 'POST',
+        body: { newestItemId: args.newestItemId },
+      });
+      return text(`Marked feed ${args.feedId} read up to item ${args.newestItemId}.`);
+    } catch (error) {
+      return err('marking feed read', error);
+    }
+  },
+};
+
+// ── Folder tools ────────────────────────────────────────────────────────────
+
+export const listNewsFoldersTool = {
+  name: 'list_news_folders',
+  description: 'List all folders used to organize feeds in the Nextcloud News app.',
+  inputSchema: z.object({}),
+  handler: async () => {
+    try {
+      const result = await fetchNewsAPI<FoldersResponse>('/folders');
+      if (!result.folders || result.folders.length === 0) {
+        return text('No folders found.');
+      }
+      const formatted = result.folders.map((f) => `- **${f.name}** (ID: ${f.id})`).join('\n');
+      return text(`News folders (${result.folders.length}):\n\n${formatted}`);
+    } catch (error) {
+      return err('listing folders', error);
+    }
+  },
+};
+
+export const createNewsFolderTool = {
+  name: 'create_news_folder',
+  description: 'Create a new folder for organizing feeds in the News app.',
+  inputSchema: z.object({
+    name: z.string().describe('The folder name'),
+  }),
+  handler: async (args: { name: string }) => {
+    try {
+      const result = await fetchNewsAPI<FoldersResponse>('/folders', {
+        method: 'POST',
+        body: { name: args.name },
+      });
+      const folder = result.folders?.[0];
+      return text(
+        folder
+          ? `Created folder "${folder.name}" (ID: ${folder.id}).`
+          : `Created folder "${args.name}".`
+      );
+    } catch (error) {
+      return err('creating folder', error);
+    }
+  },
+};
+
+export const renameNewsFolderTool = {
+  name: 'rename_news_folder',
+  description: 'Rename a News folder.',
+  inputSchema: z.object({
+    folderId: z.number().describe('The folder ID to rename'),
+    name: z.string().describe('The new folder name'),
+  }),
+  handler: async (args: { folderId: number; name: string }) => {
+    try {
+      await fetchNewsAPI(`/folders/${args.folderId}`, {
+        method: 'PUT',
+        body: { name: args.name },
+      });
+      return text(`Renamed folder ${args.folderId} to "${args.name}".`);
+    } catch (error) {
+      return err('renaming folder', error);
+    }
+  },
+};
+
+export const deleteNewsFolderTool = {
+  name: 'delete_news_folder',
+  description: 'Delete a News folder and all feeds it contains.',
+  inputSchema: z.object({
+    folderId: z.number().describe('The folder ID to delete'),
+  }),
+  handler: async (args: { folderId: number }) => {
+    try {
+      await fetchNewsAPI(`/folders/${args.folderId}`, { method: 'DELETE' });
+      return text(`Deleted folder ${args.folderId}.`);
+    } catch (error) {
+      return err('deleting folder', error);
+    }
+  },
+};
+
+export const markNewsFolderReadTool = {
+  name: 'mark_news_folder_read',
+  description: 'Mark all items in a folder as read up to (and including) the given newest item ID.',
+  inputSchema: z.object({
+    folderId: z.number().describe('The folder ID'),
+    newestItemId: z.number().describe('Mark all items with ID <= this value as read'),
+  }),
+  handler: async (args: { folderId: number; newestItemId: number }) => {
+    try {
+      await fetchNewsAPI(`/folders/${args.folderId}/read`, {
+        method: 'POST',
+        body: { newestItemId: args.newestItemId },
+      });
+      return text(`Marked folder ${args.folderId} read up to item ${args.newestItemId}.`);
+    } catch (error) {
+      return err('marking folder read', error);
+    }
+  },
+};
+
+// ── Item / article tools ────────────────────────────────────────────────────
+
+export const listNewsItemsTool = {
+  name: 'list_news_items',
+  description:
+    'List news articles (items). Filter by feed, folder, starred, or all; supports pagination and read/unread filtering.',
+  inputSchema: z.object({
+    type: z
+      .enum(['feed', 'folder', 'starred', 'all'])
+      .optional()
+      .describe('Scope of items to return (default "all")'),
+    id: z
+      .number()
+      .optional()
+      .describe('Feed or folder ID when type is "feed" or "folder" (default 0)'),
+    batchSize: z.number().optional().describe('Max items to return (default 20, -1 for all)'),
+    offset: z.number().optional().describe('Return items older than this item ID (pagination)'),
+    getRead: z.boolean().optional().describe('Include already-read items (default false)'),
+    oldestFirst: z
+      .boolean()
+      .optional()
+      .describe('Return oldest items first (default newest first)'),
+  }),
+  handler: async (args: {
+    type?: 'feed' | 'folder' | 'starred' | 'all';
+    id?: number;
+    batchSize?: number;
+    offset?: number;
+    getRead?: boolean;
+    oldestFirst?: boolean;
+  }) => {
+    try {
+      const typeMap = { feed: 0, folder: 1, starred: 2, all: 3 } as const;
+      const queryParams: Record<string, string | number | boolean | undefined> = {
+        type: typeMap[args.type ?? 'all'],
+        id: args.id ?? 0,
+        batchSize: args.batchSize ?? 20,
+        getRead: args.getRead ?? false,
+        oldestFirst: args.oldestFirst ?? false,
+      };
+      if (args.offset !== undefined) queryParams.offset = args.offset;
+
+      const result = await fetchNewsAPI<ItemsResponse>('/items', { queryParams });
+      if (!result.items || result.items.length === 0) {
+        return text('No items found.');
+      }
+      const formatted = result.items.map(formatItem).join('\n\n');
+      return text(`Items (${result.items.length}):\n\n${formatted}`);
+    } catch (error) {
+      return err('listing items', error);
+    }
+  },
+};
+
+export const markItemReadTool = {
+  name: 'mark_item_read',
+  description: 'Mark a single news item as read.',
+  inputSchema: z.object({
+    itemId: z.number().describe('The item ID'),
+  }),
+  handler: async (args: { itemId: number }) => {
+    try {
+      await fetchNewsAPI(`/items/${args.itemId}/read`, { method: 'POST' });
+      return text(`Marked item ${args.itemId} read.`);
+    } catch (error) {
+      return err('marking item read', error);
+    }
+  },
+};
+
+export const markItemUnreadTool = {
+  name: 'mark_item_unread',
+  description: 'Mark a single news item as unread.',
+  inputSchema: z.object({
+    itemId: z.number().describe('The item ID'),
+  }),
+  handler: async (args: { itemId: number }) => {
+    try {
+      await fetchNewsAPI(`/items/${args.itemId}/unread`, { method: 'POST' });
+      return text(`Marked item ${args.itemId} unread.`);
+    } catch (error) {
+      return err('marking item unread', error);
+    }
+  },
+};
+
+export const starItemTool = {
+  name: 'star_item',
+  description: 'Star (favorite) a single news item.',
+  inputSchema: z.object({
+    itemId: z.number().describe('The item ID'),
+  }),
+  handler: async (args: { itemId: number }) => {
+    try {
+      await fetchNewsAPI(`/items/${args.itemId}/star`, { method: 'POST' });
+      return text(`Starred item ${args.itemId}.`);
+    } catch (error) {
+      return err('starring item', error);
+    }
+  },
+};
+
+export const unstarItemTool = {
+  name: 'unstar_item',
+  description: 'Remove the star from a single news item.',
+  inputSchema: z.object({
+    itemId: z.number().describe('The item ID'),
+  }),
+  handler: async (args: { itemId: number }) => {
+    try {
+      await fetchNewsAPI(`/items/${args.itemId}/unstar`, { method: 'POST' });
+      return text(`Unstarred item ${args.itemId}.`);
+    } catch (error) {
+      return err('unstarring item', error);
+    }
+  },
+};
+
+export const markItemsReadTool = {
+  name: 'mark_items_read',
+  description: 'Mark multiple news items as read in one call.',
+  inputSchema: z.object({
+    itemIds: z.array(z.number()).describe('The item IDs to mark as read'),
+  }),
+  handler: async (args: { itemIds: number[] }) => {
+    try {
+      await fetchNewsAPI('/items/read/multiple', {
+        method: 'POST',
+        body: { itemIds: args.itemIds },
+      });
+      return text(`Marked ${args.itemIds.length} item(s) read.`);
+    } catch (error) {
+      return err('marking items read', error);
+    }
+  },
+};
+
+// ── Export ──────────────────────────────────────────────────────────────────
+
+export const newsTools = [
+  listFeedsTool,
+  addFeedTool,
+  deleteFeedTool,
+  moveFeedTool,
+  renameFeedTool,
+  markFeedReadTool,
+  listNewsFoldersTool,
+  createNewsFolderTool,
+  renameNewsFolderTool,
+  deleteNewsFolderTool,
+  markNewsFolderReadTool,
+  listNewsItemsTool,
+  markItemReadTool,
+  markItemUnreadTool,
+  starItemTool,
+  unstarItemTool,
+  markItemsReadTool,
+];

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.17</version>
+    <version>0.3.18</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
## Summary

Implements **#120** — exposes the Nextcloud News app to the MCP server so an AI assistant can read and manage RSS subscriptions.

Adds a `news` tool category (auto-registered when the News app is enabled) with **17 tools** covering the full News REST API v1-3:

- **Feeds**: `list_feeds`, `add_feed`, `delete_feed`, `move_feed`, `rename_feed`, `mark_feed_read`
- **Folders**: `list_news_folders`, `create_news_folder`, `rename_news_folder`, `delete_news_folder`, `mark_news_folder_read`
- **Items**: `list_news_items`, `mark_item_read`, `mark_item_unread`, `star_item`, `unstar_item`, `mark_items_read`

Tool names are globally unique (`news_`/`feed` prefixes) to avoid collision with other apps' folder concepts. Article bodies are HTML-stripped and truncated in summaries.

## Implementation

- `mcp-server/src/client/news.ts` — plain-JSON + Basic Auth client, mirrors the Notes client pattern
- `mcp-server/src/tools/apps/news.ts` — tool definitions
- `mcp-server/src/tool-registry.ts` — `{ category: 'news', appIds: ['news'], tools: newsTools }`
- `mcp-server/src/__tests__/tools-news.test.ts` — unit tests
- Docs: new `docs/mcp/tools/apps/news.md` + index entries
- Patch version bump to **0.3.18** across all release locations

## Testing

- `npm run build` — clean
- `npm test` — 741 passed (incl. new News tests)
- `npx prettier --check src/` + `npm run lint` — pass (0 errors)

End-to-end verification against a live stack with the News app enabled is recommended (`MCP_TOOLS=news npm run dev`, then `list_feeds` / `add_feed` / `list_news_items` / `mark_item_read` / `delete_feed`).

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)