### PR TITLE
feat(mcp): activity feed integration (#124)

### DIFF
--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -221,6 +221,12 @@ Nextcloud apps and administration:
 | `unstar_item` | Unstar an article | [News](tools/apps/news.md#unstar_item) |
 | `mark_items_read` | Mark multiple articles read | [News](tools/apps/news.md#mark_items_read) |
 
+#### Activity (2 tools)
+| Tool | Description | Documentation |
+|------|-------------|---------------|
+| `list_activity` | List recent activity feed entries | [Activity](tools/apps/activity.md#list_activity) |
+| `get_object_activity` | List activity history for one object | [Activity](tools/apps/activity.md#get_object_activity) |
+
 #### Polls (21 tools)
 | Tool | Description | Documentation |
 |------|-------------|---------------|

--- a/docs/mcp/tools/apps/activity.md
+++ b/docs/mcp/tools/apps/activity.md
@@ -1,0 +1,43 @@
+# Nextcloud Activity Tools
+
+Integration with the Nextcloud Activity app. Read the per-user activity feed — file
+changes, shares, comments, calendar/contact edits, and more — through Claude.
+
+## Prerequisites
+
+- Nextcloud Activity app must be installed and enabled (bundled with Nextcloud by default)
+- Uses the Activity OCS API v2 (`/ocs/v2.php/apps/activity/api/v2/activity`)
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_activity` | List recent activity feed entries |
+| `get_object_activity` | List activity history for a single object (e.g. one file) |
+
+---
+
+## list_activity
+
+List recent entries from the activity feed for the current user.
+
+Parameters:
+
+- `filter` (optional) — which feed to read: `all` (default), `self` (your own actions),
+  or `by` (others' actions)
+- `limit` (optional) — maximum number of activities to return (default 50)
+- `since` (optional) — return activities after this `activity_id` (for pagination)
+- `sort` (optional) — time order: `desc` (newest first, default) or `asc`
+
+The response includes the last `activity_id`, which can be passed back as `since` to page
+through older entries.
+
+## get_object_activity
+
+List the activity history for a single object, e.g. one file.
+
+Parameters:
+
+- `object_type` (optional) — the object type to filter by (default `files`)
+- `object_id` (required) — the object ID (e.g. the Nextcloud file ID)
+- `limit` (optional) — maximum number of activities to return (default 50)

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.21",
+      "version": "0.3.22",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "Nextcloud MCP server — files, calendar, contacts, mail, maps, notes, tasks & 120+ more tools",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,7 +18,7 @@
       ]
     }
   ],
-  "version": "0.3.21",
+  "version": "0.3.22",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "remotes": [
     {
@@ -36,7 +36,7 @@
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.21",
+      "version": "0.3.22",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -64,7 +64,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.21",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.22",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/__tests__/tools-activity.test.ts
+++ b/mcp-server/src/__tests__/tools-activity.test.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFetchOCS = vi.fn();
+
+vi.mock('../client/ocs.js', () => ({
+  fetchOCS: (...args: unknown[]) => mockFetchOCS(...args),
+}));
+
+const sampleActivity = {
+  activity_id: 42,
+  app: 'files',
+  type: 'file_created',
+  user: 'admin',
+  subject: 'You created document.pdf',
+  message: '',
+  object_type: 'files',
+  object_id: 123,
+  object_name: 'document.pdf',
+  link: 'https://cloud.example.com/f/123',
+  datetime: '2026-06-13T12:00:00+00:00',
+};
+
+describe('Activity Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXTCLOUD_URL = 'https://cloud.example.com';
+    process.env.NEXTCLOUD_USER = 'admin';
+    process.env.NEXTCLOUD_PASSWORD = 'testpass';
+  });
+
+  describe('list_activity', () => {
+    it('should list activities and report the last activity_id', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data: [sampleActivity] },
+      });
+
+      const { listActivityTool } = await import('../tools/apps/activity.js');
+      const result = await listActivityTool.handler({});
+
+      expect(result.content[0].text).toContain('You created document.pdf');
+      expect(result.content[0].text).toContain('Last activity_id: 42');
+    });
+
+    it('should default to the "all" feed with limit 50 / sort desc', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data: [sampleActivity] },
+      });
+
+      const { listActivityTool } = await import('../tools/apps/activity.js');
+      await listActivityTool.handler({});
+
+      expect(mockFetchOCS).toHaveBeenCalledWith('/ocs/v2.php/apps/activity/api/v2/activity/all', {
+        queryParams: { limit: '50', sort: 'desc' },
+      });
+    });
+
+    it('should pass filter, limit, sort and since through', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data: [sampleActivity] },
+      });
+
+      const { listActivityTool } = await import('../tools/apps/activity.js');
+      await listActivityTool.handler({ filter: 'self', limit: 10, since: 100, sort: 'asc' });
+
+      expect(mockFetchOCS).toHaveBeenCalledWith('/ocs/v2.php/apps/activity/api/v2/activity/self', {
+        queryParams: { limit: '10', sort: 'asc', since: '100' },
+      });
+    });
+
+    it('should handle an empty feed', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data: [] },
+      });
+
+      const { listActivityTool } = await import('../tools/apps/activity.js');
+      const result = await listActivityTool.handler({});
+
+      expect(result.content[0].text).toContain('No activity');
+    });
+
+    it('should set isError on failure', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('500 Internal Server Error'));
+
+      const { listActivityTool } = await import('../tools/apps/activity.js');
+      const result = await listActivityTool.handler({});
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('500');
+    });
+  });
+
+  describe('get_object_activity', () => {
+    it('should query the filter path with object params', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data: [sampleActivity] },
+      });
+
+      const { getObjectActivityTool } = await import('../tools/apps/activity.js');
+      const result = await getObjectActivityTool.handler({ object_id: '123' });
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(
+        '/ocs/v2.php/apps/activity/api/v2/activity/filter',
+        { queryParams: { object_type: 'files', object_id: '123', limit: '50' } }
+      );
+      expect(result.content[0].text).toContain('document.pdf');
+    });
+
+    it('should report no activity for an object with none', async () => {
+      mockFetchOCS.mockResolvedValue({
+        ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data: [] },
+      });
+
+      const { getObjectActivityTool } = await import('../tools/apps/activity.js');
+      const result = await getObjectActivityTool.handler({ object_id: '999' });
+
+      expect(result.content[0].text).toContain('No activity for this object');
+    });
+  });
+});

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -36,6 +36,7 @@ import { talkTools } from './tools/apps/talk.js';
 import { userStatusTools } from './tools/apps/user-status.js';
 import { absenceTools } from './tools/apps/absence.js';
 import { notificationsTools } from './tools/apps/notifications.js';
+import { activityTools } from './tools/apps/activity.js';
 import { trashTools } from './tools/apps/trash.js';
 import { versionsTools } from './tools/apps/versions.js';
 import { projectsTools } from './tools/apps/projects.js';
@@ -109,6 +110,7 @@ export const TOOL_REGISTRY: ToolSetEntry[] = [
   { category: 'translate', appIds: ['text_translate', 'translate'], tools: translateTools },
   { category: 'user_status', appIds: ['user_status'], tools: userStatusTools },
   { category: 'notifications', appIds: ['notifications'], tools: notificationsTools },
+  { category: 'activity', appIds: ['activity'], tools: activityTools },
 ];
 
 const ALL_CATEGORIES = new Set(TOOL_REGISTRY.map((e) => e.category));

--- a/mcp-server/src/tools/apps/activity.ts
+++ b/mcp-server/src/tools/apps/activity.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MIT
+
+import { z } from 'zod';
+import { fetchOCS } from '../../client/ocs.js';
+
+/**
+ * Nextcloud Activity Tools
+ * Read the per-user activity feed via the Activity app OCS API.
+ */
+
+interface Activity {
+  activity_id: number;
+  app: string;
+  type: string;
+  user: string;
+  subject: string;
+  message: string;
+  object_type: string;
+  object_id: number | string;
+  object_name: string;
+  link: string;
+  datetime: string;
+}
+
+function formatActivities(activities: Activity[]): string {
+  return activities
+    .map((a) => {
+      const time = a.datetime ? ` (${a.datetime})` : '';
+      const msg = a.message ? `\n  ${a.message}` : '';
+      return `- [${a.app}] ${a.subject}${time}${msg}`;
+    })
+    .join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// list_activity
+// ---------------------------------------------------------------------------
+
+export const listActivityTool = {
+  name: 'list_activity',
+  description:
+    'List recent entries from the Nextcloud activity feed (file changes, shares, ' +
+    'comments, calendar/contact edits, etc.) for the current user.',
+  inputSchema: z.object({
+    filter: z
+      .enum(['all', 'self', 'by'])
+      .optional()
+      .describe(
+        "Which feed to read: 'all' (default), 'self' (your own actions), or 'by' (others' actions)"
+      ),
+    limit: z.number().optional().describe('Maximum number of activities to return (default 50)'),
+    since: z
+      .number()
+      .optional()
+      .describe('Return activities after this activity_id (for pagination)'),
+    sort: z
+      .enum(['asc', 'desc'])
+      .optional()
+      .describe("Sort order by time: 'desc' (newest first, default) or 'asc'"),
+  }),
+  handler: async (args: {
+    filter?: 'all' | 'self' | 'by';
+    limit?: number;
+    since?: number;
+    sort?: 'asc' | 'desc';
+  }) => {
+    try {
+      const filter = args.filter ?? 'all';
+      const queryParams: Record<string, string> = {
+        limit: String(args.limit ?? 50),
+        sort: args.sort ?? 'desc',
+      };
+      if (args.since !== undefined) queryParams.since = String(args.since);
+
+      const result = await fetchOCS<Activity[]>(
+        `/ocs/v2.php/apps/activity/api/v2/activity/${filter}`,
+        { queryParams }
+      );
+
+      const activities = result.ocs.data;
+      if (activities.length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: 'No activity.' }],
+        };
+      }
+
+      const lastId = activities[activities.length - 1].activity_id;
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text:
+              `Activity (${activities.length}):\n${formatActivities(activities)}\n\n` +
+              `Last activity_id: ${lastId} (pass as 'since' to page further).`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error listing activity: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// get_object_activity
+// ---------------------------------------------------------------------------
+
+export const getObjectActivityTool = {
+  name: 'get_object_activity',
+  description:
+    'List the activity history for a single object, e.g. one file. Use object_type ' +
+    "'files' with a file ID to see what happened to that file.",
+  inputSchema: z.object({
+    object_type: z.string().optional().describe("The object type to filter by (default 'files')"),
+    object_id: z.string().describe('The object ID (e.g. the Nextcloud file ID)'),
+    limit: z.number().optional().describe('Maximum number of activities to return (default 50)'),
+  }),
+  handler: async (args: { object_type?: string; object_id: string; limit?: number }) => {
+    try {
+      const result = await fetchOCS<Activity[]>(
+        '/ocs/v2.php/apps/activity/api/v2/activity/filter',
+        {
+          queryParams: {
+            object_type: args.object_type ?? 'files',
+            object_id: args.object_id,
+            limit: String(args.limit ?? 50),
+          },
+        }
+      );
+
+      const activities = result.ocs.data;
+      if (activities.length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: 'No activity for this object.' }],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Activity (${activities.length}):\n${formatActivities(activities)}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error getting object activity: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export const activityTools = [listActivityTool, getObjectActivityTool];

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.21</version>
+    <version>0.3.22</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
Closes #124.

Exposes the Nextcloud **Activity** app feed through the MCP server, following the same OCS read pattern as the notifications tool group.

## Tools
- `list_activity` — recent activity feed (`all`/`self`/`by`), with `limit`, `sort`, and `since`-based pagination. Reports the last `activity_id` for paging.
- `get_object_activity` — activity history for a single object (e.g. one file via `object_type=files` + `object_id`).

## Details
- New `mcp-server/src/tools/apps/activity.ts` reuses `fetchOCS`; no new client infra.
- Registered in `tool-registry.ts` under `category: 'activity'`, gated on the `activity` app.
- Tests in `tools-activity.test.ts` (7 cases): formatting, query-param mapping, empty feed, error path, object filter.
- Docs: `docs/mcp/tools/apps/activity.md` + entry in `docs/mcp/README.md`.

## Version
- Bumped both components to **0.3.22** (`package.json` ×2, `server.json` + image tag, `appinfo/info.xml`, lock file).

## Verification
- `npm run build`, `npm test` (765 passing), `npm run lint` (0 errors), `npx prettier --check src/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)