### PR TITLE
feat(mcp): Announcement Center integration (#125)

### DIFF
--- a/mcp-server/src/__tests__/tools-announcements.test.ts
+++ b/mcp-server/src/__tests__/tools-announcements.test.ts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFetchOCS = vi.fn();
+
+vi.mock('../client/ocs.js', () => ({
+  fetchOCS: (...args: unknown[]) => mockFetchOCS(...args),
+}));
+
+const sampleAnnouncement = {
+  id: 7,
+  author_id: 'admin',
+  author: 'Administrator',
+  time: 1_700_000_000,
+  subject: 'Maintenance window',
+  message: 'We will be down on Sunday.',
+  groups: [{ id: 'everyone', name: 'everyone' }],
+  comments: 0,
+  schedule_time: null,
+  delete_time: null,
+};
+
+function ok(data: unknown) {
+  return { ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data } };
+}
+
+describe('Announcement Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXTCLOUD_URL = 'https://cloud.example.com';
+    process.env.NEXTCLOUD_USER = 'admin';
+    process.env.NEXTCLOUD_PASSWORD = 'testpass';
+  });
+
+  describe('list_announcements', () => {
+    it('should list announcements and report the last id', async () => {
+      mockFetchOCS.mockResolvedValue(ok([sampleAnnouncement]));
+
+      const { listAnnouncementsTool } = await import('../tools/apps/announcements.js');
+      const result = await listAnnouncementsTool.handler({});
+
+      expect(result.content[0].text).toContain('Maintenance window');
+      expect(result.content[0].text).toContain('Last id: 7');
+    });
+
+    it('should default offset to 0', async () => {
+      mockFetchOCS.mockResolvedValue(ok([sampleAnnouncement]));
+
+      const { listAnnouncementsTool } = await import('../tools/apps/announcements.js');
+      await listAnnouncementsTool.handler({});
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(
+        '/ocs/v2.php/apps/announcementcenter/api/v1/announcements',
+        { queryParams: { offset: '0' } }
+      );
+    });
+
+    it('should pass offset through', async () => {
+      mockFetchOCS.mockResolvedValue(ok([sampleAnnouncement]));
+
+      const { listAnnouncementsTool } = await import('../tools/apps/announcements.js');
+      await listAnnouncementsTool.handler({ offset: 5 });
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(
+        '/ocs/v2.php/apps/announcementcenter/api/v1/announcements',
+        { queryParams: { offset: '5' } }
+      );
+    });
+
+    it('should handle empty results', async () => {
+      mockFetchOCS.mockResolvedValue(ok([]));
+
+      const { listAnnouncementsTool } = await import('../tools/apps/announcements.js');
+      const result = await listAnnouncementsTool.handler({});
+
+      expect(result.content[0].text).toBe('No announcements.');
+    });
+
+    it('should report errors', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('boom'));
+
+      const { listAnnouncementsTool } = await import('../tools/apps/announcements.js');
+      const result = await listAnnouncementsTool.handler({});
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('boom');
+    });
+  });
+
+  describe('create_announcement', () => {
+    it('should POST with sensible defaults (everyone, plainMessage fallback)', async () => {
+      mockFetchOCS.mockResolvedValue(ok(sampleAnnouncement));
+
+      const { createAnnouncementTool } = await import('../tools/apps/announcements.js');
+      const result = await createAnnouncementTool.handler({
+        subject: 'Maintenance window',
+        message: 'We will be down on Sunday.',
+      });
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(
+        '/ocs/v2.php/apps/announcementcenter/api/v1/announcements',
+        {
+          method: 'POST',
+          jsonBody: {
+            subject: 'Maintenance window',
+            message: 'We will be down on Sunday.',
+            plainMessage: 'We will be down on Sunday.',
+            groups: ['everyone'],
+            activities: true,
+            notifications: true,
+            emails: false,
+            comments: true,
+          },
+        }
+      );
+      expect(result.content[0].text).toContain('Created announcement #7');
+    });
+
+    it('should pass explicit fields including schedule/delete times', async () => {
+      mockFetchOCS.mockResolvedValue(ok(sampleAnnouncement));
+
+      const { createAnnouncementTool } = await import('../tools/apps/announcements.js');
+      await createAnnouncementTool.handler({
+        subject: 'Hi',
+        message: 'msg',
+        plainMessage: 'plain',
+        groups: ['staff'],
+        activities: false,
+        notifications: false,
+        emails: true,
+        comments: false,
+        scheduleTime: 100,
+        deleteTime: 200,
+      });
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(
+        '/ocs/v2.php/apps/announcementcenter/api/v1/announcements',
+        {
+          method: 'POST',
+          jsonBody: {
+            subject: 'Hi',
+            message: 'msg',
+            plainMessage: 'plain',
+            groups: ['staff'],
+            activities: false,
+            notifications: false,
+            emails: true,
+            comments: false,
+            scheduleTime: 100,
+            deleteTime: 200,
+          },
+        }
+      );
+    });
+
+    it('should report errors', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('forbidden'));
+
+      const { createAnnouncementTool } = await import('../tools/apps/announcements.js');
+      const result = await createAnnouncementTool.handler({ subject: 's', message: 'm' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('forbidden');
+    });
+  });
+
+  describe('delete_announcement', () => {
+    it('should DELETE the announcement by id', async () => {
+      mockFetchOCS.mockResolvedValue(ok(null));
+
+      const { deleteAnnouncementTool } = await import('../tools/apps/announcements.js');
+      const result = await deleteAnnouncementTool.handler({ id: 7 });
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(
+        '/ocs/v2.php/apps/announcementcenter/api/v1/announcements/7',
+        { method: 'DELETE' }
+      );
+      expect(result.content[0].text).toContain('Deleted announcement #7');
+    });
+
+    it('should report errors', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('nope'));
+
+      const { deleteAnnouncementTool } = await import('../tools/apps/announcements.js');
+      const result = await deleteAnnouncementTool.handler({ id: 7 });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('nope');
+    });
+  });
+});

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -37,6 +37,7 @@ import { userStatusTools } from './tools/apps/user-status.js';
 import { absenceTools } from './tools/apps/absence.js';
 import { notificationsTools } from './tools/apps/notifications.js';
 import { activityTools } from './tools/apps/activity.js';
+import { announcementTools } from './tools/apps/announcements.js';
 import { trashTools } from './tools/apps/trash.js';
 import { versionsTools } from './tools/apps/versions.js';
 import { projectsTools } from './tools/apps/projects.js';
@@ -111,6 +112,7 @@ export const TOOL_REGISTRY: ToolSetEntry[] = [
   { category: 'user_status', appIds: ['user_status'], tools: userStatusTools },
   { category: 'notifications', appIds: ['notifications'], tools: notificationsTools },
   { category: 'activity', appIds: ['activity'], tools: activityTools },
+  { category: 'announcements', appIds: ['announcementcenter'], tools: announcementTools },
 ];
 
 const ALL_CATEGORIES = new Set(TOOL_REGISTRY.map((e) => e.category));

--- a/mcp-server/src/tools/apps/announcements.ts
+++ b/mcp-server/src/tools/apps/announcements.ts
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: MIT
+
+import { z } from 'zod';
+import { fetchOCS } from '../../client/ocs.js';
+
+/**
+ * Nextcloud Announcement Center Tools
+ * Read and manage org-wide announcements via the Announcement Center OCS API.
+ */
+
+interface Announcement {
+  id: number;
+  author_id: string;
+  author: string;
+  time: number;
+  subject: string;
+  message: string;
+  groups: Array<{ id: string; name: string }> | null;
+  comments: number | false;
+  schedule_time: number | null;
+  delete_time: number | null;
+}
+
+function formatTime(ts: number | null): string {
+  if (!ts) return '';
+  return new Date(ts * 1000).toISOString();
+}
+
+function formatAnnouncements(items: Announcement[]): string {
+  return items
+    .map((a) => {
+      const time = a.time ? ` (${formatTime(a.time)})` : '';
+      const schedule = a.schedule_time ? `\n  scheduled: ${formatTime(a.schedule_time)}` : '';
+      const del = a.delete_time ? `\n  deletes: ${formatTime(a.delete_time)}` : '';
+      return `- #${a.id} [${a.author}] ${a.subject}${time}${schedule}${del}`;
+    })
+    .join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// list_announcements
+// ---------------------------------------------------------------------------
+
+export const listAnnouncementsTool = {
+  name: 'list_announcements',
+  description:
+    'List announcements from the Nextcloud Announcement Center (org-wide notices such as ' +
+    'maintenance windows, events, or news). Returns newest first.',
+  inputSchema: z.object({
+    offset: z
+      .number()
+      .optional()
+      .describe('Return announcements before this offset (for pagination, default 0)'),
+  }),
+  handler: async (args: { offset?: number }) => {
+    try {
+      const queryParams: Record<string, string> = {
+        offset: String(args.offset ?? 0),
+      };
+
+      const result = await fetchOCS<Announcement[]>(
+        '/ocs/v2.php/apps/announcementcenter/api/v1/announcements',
+        { queryParams }
+      );
+
+      const items = result.ocs.data;
+      if (items.length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: 'No announcements.' }],
+        };
+      }
+
+      const lastId = items[items.length - 1].id;
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text:
+              `Announcements (${items.length}):\n${formatAnnouncements(items)}\n\n` +
+              `Last id: ${lastId} (pass as 'offset' to page further).`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error listing announcements: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// create_announcement
+// ---------------------------------------------------------------------------
+
+export const createAnnouncementTool = {
+  name: 'create_announcement',
+  description:
+    'Create a new announcement in the Announcement Center. This is visible to all or ' +
+    'selected groups and can trigger notifications/emails — use deliberately. Requires the ' +
+    'configured Nextcloud user to be an admin.',
+  inputSchema: z.object({
+    subject: z.string().describe('The announcement title (kept short)'),
+    message: z.string().describe('The announcement body (Markdown supported)'),
+    plainMessage: z
+      .string()
+      .optional()
+      .describe('Plain-text version of the message (defaults to message)'),
+    groups: z
+      .array(z.string())
+      .optional()
+      .describe("Group IDs to target, or ['everyone'] for all users (default)"),
+    activities: z.boolean().optional().describe('Publish to the activity feed (default true)'),
+    notifications: z.boolean().optional().describe('Send notifications (default true)'),
+    emails: z.boolean().optional().describe('Send emails (default false)'),
+    comments: z.boolean().optional().describe('Allow comments (default true)'),
+    scheduleTime: z
+      .number()
+      .optional()
+      .describe('Unix timestamp (seconds) to publish the announcement later'),
+    deleteTime: z
+      .number()
+      .optional()
+      .describe('Unix timestamp (seconds) to automatically delete the announcement'),
+  }),
+  handler: async (args: {
+    subject: string;
+    message: string;
+    plainMessage?: string;
+    groups?: string[];
+    activities?: boolean;
+    notifications?: boolean;
+    emails?: boolean;
+    comments?: boolean;
+    scheduleTime?: number;
+    deleteTime?: number;
+  }) => {
+    try {
+      const jsonBody: Record<string, unknown> = {
+        subject: args.subject,
+        message: args.message,
+        plainMessage: args.plainMessage ?? args.message,
+        groups: args.groups ?? ['everyone'],
+        activities: args.activities ?? true,
+        notifications: args.notifications ?? true,
+        emails: args.emails ?? false,
+        comments: args.comments ?? true,
+      };
+      if (args.scheduleTime !== undefined) jsonBody.scheduleTime = args.scheduleTime;
+      if (args.deleteTime !== undefined) jsonBody.deleteTime = args.deleteTime;
+
+      const result = await fetchOCS<Announcement>(
+        '/ocs/v2.php/apps/announcementcenter/api/v1/announcements',
+        { method: 'POST', jsonBody }
+      );
+
+      const created = result.ocs.data;
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Created announcement #${created.id}: "${created.subject}"`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error creating announcement: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// delete_announcement
+// ---------------------------------------------------------------------------
+
+export const deleteAnnouncementTool = {
+  name: 'delete_announcement',
+  description:
+    'Delete an announcement by its ID. Requires the configured Nextcloud user to be an admin.',
+  inputSchema: z.object({
+    id: z.number().describe('The announcement ID to delete'),
+  }),
+  handler: async (args: { id: number }) => {
+    try {
+      await fetchOCS(`/ocs/v2.php/apps/announcementcenter/api/v1/announcements/${args.id}`, {
+        method: 'DELETE',
+      });
+
+      return {
+        content: [{ type: 'text' as const, text: `Deleted announcement #${args.id}.` }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error deleting announcement: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export const announcementTools = [
+  listAnnouncementsTool,
+  createAnnouncementTool,
+  deleteAnnouncementTool,
+];


### PR DESCRIPTION
## Summary

Integrates the Nextcloud **Announcement Center** app (`announcementcenter`) into the MCP server, closing #125. Follows the existing activity-feed integration pattern.

New tools (`mcp-server/src/tools/apps/announcements.ts`):
- **`list_announcements`** — read the feed with `offset` pagination
- **`create_announcement`** — POST (admin-only); defaults to `groups: ['everyone']`, activities/notifications/comments on, emails off, `plainMessage` falling back to `message`; supports `scheduleTime`/`deleteTime`
- **`delete_announcement`** — delete by id (admin-only)

Registered in `tool-registry.ts`, gated on the `announcementcenter` app being enabled. The 403 admin-permission case is surfaced via the centralized handling in `fetchOCS`.

## Test plan

- `npm run format` / `prettier --check` / `npm run lint` (0 errors)
- `npm test` — new `tools-announcements.test.ts` (10 tests) passing
- `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)