### PR TITLE
feat(mcp): registration management

### DIFF
--- a/mcp-server/src/__tests__/tools-registration.test.ts
+++ b/mcp-server/src/__tests__/tools-registration.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFetchOCS = vi.fn();
+
+vi.mock('../client/ocs.js', () => ({
+  fetchOCS: (...args: unknown[]) => mockFetchOCS(...args),
+}));
+
+const APPCONFIG_BASE = '/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/registration';
+
+function ok(data: unknown) {
+  return { ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data } };
+}
+
+describe('Registration Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXTCLOUD_URL = 'https://cloud.example.com';
+    process.env.NEXTCLOUD_USER = 'admin';
+    process.env.NEXTCLOUD_PASSWORD = 'testpass';
+  });
+
+  describe('get_registration_settings', () => {
+    it('should read each known key and format the result', async () => {
+      mockFetchOCS.mockImplementation((path: string) => {
+        if (path.endsWith('/admin_approval_required')) return Promise.resolve(ok('yes'));
+        return Promise.resolve(ok(''));
+      });
+
+      const { getRegistrationSettingsTool } = await import('../tools/apps/registration.js');
+      const result = await getRegistrationSettingsTool.handler();
+
+      expect(result.content[0].text).toContain('admin_approval_required: yes');
+      expect(result.content[0].text).toContain('allowed_domains: (default)');
+      expect(mockFetchOCS).toHaveBeenCalledWith(`${APPCONFIG_BASE}/admin_approval_required`);
+    });
+
+    it('should return isError on failure', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('boom'));
+
+      const { getRegistrationSettingsTool } = await import('../tools/apps/registration.js');
+      const result = await getRegistrationSettingsTool.handler();
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('boom');
+    });
+  });
+
+  describe('update_registration_settings', () => {
+    it('should POST each setting with a form value body', async () => {
+      mockFetchOCS.mockResolvedValue(ok(true));
+
+      const { updateRegistrationSettingsTool } = await import('../tools/apps/registration.js');
+      const result = await updateRegistrationSettingsTool.handler({
+        settings: [
+          { key: 'admin_approval_required', value: 'yes' },
+          { key: 'registered_user_group', value: 'newcomers' },
+        ],
+      });
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(`${APPCONFIG_BASE}/admin_approval_required`, {
+        method: 'POST',
+        body: { value: 'yes' },
+      });
+      expect(mockFetchOCS).toHaveBeenCalledWith(`${APPCONFIG_BASE}/registered_user_group`, {
+        method: 'POST',
+        body: { value: 'newcomers' },
+      });
+      expect(result.content[0].text).toContain('admin_approval_required = yes');
+    });
+
+    it('should return isError on failure', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('denied'));
+
+      const { updateRegistrationSettingsTool } = await import('../tools/apps/registration.js');
+      const result = await updateRegistrationSettingsTool.handler({
+        settings: [{ key: 'show_phone', value: 'no' }],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('denied');
+    });
+  });
+
+  describe('reset_registration_setting', () => {
+    it('should DELETE the key', async () => {
+      mockFetchOCS.mockResolvedValue(ok(true));
+
+      const { resetRegistrationSettingTool } = await import('../tools/apps/registration.js');
+      const result = await resetRegistrationSettingTool.handler({ key: 'allowed_domains' });
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(`${APPCONFIG_BASE}/allowed_domains`, {
+        method: 'DELETE',
+      });
+      expect(result.content[0].text).toContain("Reset registration setting 'allowed_domains'");
+    });
+
+    it('should return isError on failure', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('nope'));
+
+      const { resetRegistrationSettingTool } = await import('../tools/apps/registration.js');
+      const result = await resetRegistrationSettingTool.handler({ key: 'allowed_domains' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('nope');
+    });
+  });
+});

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -38,6 +38,7 @@ import { absenceTools } from './tools/apps/absence.js';
 import { notificationsTools } from './tools/apps/notifications.js';
 import { activityTools } from './tools/apps/activity.js';
 import { announcementTools } from './tools/apps/announcements.js';
+import { registrationTools } from './tools/apps/registration.js';
 import { trashTools } from './tools/apps/trash.js';
 import { versionsTools } from './tools/apps/versions.js';
 import { projectsTools } from './tools/apps/projects.js';
@@ -113,6 +114,7 @@ export const TOOL_REGISTRY: ToolSetEntry[] = [
   { category: 'notifications', appIds: ['notifications'], tools: notificationsTools },
   { category: 'activity', appIds: ['activity'], tools: activityTools },
   { category: 'announcements', appIds: ['announcementcenter'], tools: announcementTools },
+  { category: 'registration', appIds: ['registration'], tools: registrationTools },
 ];
 
 const ALL_CATEGORIES = new Set(TOOL_REGISTRY.map((e) => e.category));

--- a/mcp-server/src/tools/apps/registration.ts
+++ b/mcp-server/src/tools/apps/registration.ts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MIT
+
+import { z } from 'zod';
+import { fetchOCS } from '../../client/ocs.js';
+
+/**
+ * Nextcloud Registration Tools
+ *
+ * The Registration app (https://github.com/nextcloud/registration) lets visitors
+ * self-register accounts via an email-verification flow. It exposes no API of its
+ * own — all admin behaviour is driven by app config keys stored under the
+ * `registration` app id. These tools read and write those keys through core's
+ * provisioning_api appconfig OCS endpoints.
+ *
+ * Pending registrations are not exposed by any API. When `admin_approval_required`
+ * is enabled, registrants become disabled Nextcloud users — approve or reject them
+ * with the standard user tools (enable_user / delete_user).
+ */
+
+const APPCONFIG_BASE = '/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/registration';
+
+/** Known Registration app config keys, with short descriptions. */
+const REGISTRATION_KEYS: Record<string, string> = {
+  allowed_domains:
+    'Email domains allowed (or, with domains_is_blocklist, blocked) for registration (JSON array string)',
+  domains_is_blocklist: 'Treat allowed_domains as a blocklist instead of an allowlist (yes/no)',
+  show_domains: 'Show the email domain list to users (yes/no)',
+  admin_approval_required: 'Newly registered users must be validated by an admin (yes/no)',
+  registered_user_group: 'Group id newly registered users are added to',
+  email_is_optional: 'Email address is optional during registration (yes/no)',
+  email_is_login: 'Force the email address as the user id / login (yes/no)',
+  disable_email_verification: 'Skip the email verification step (yes/no)',
+  email_verification_hint: 'Text embedded in the verification email',
+  additional_hint: 'Text displayed on the account creation form',
+  username_policy_regex: 'Optional regex the chosen username must match',
+  show_fullname: 'Show the full name field on the registration form (yes/no)',
+  enforce_fullname: 'Make the full name field mandatory (yes/no)',
+  show_phone: 'Show the phone field on the registration form (yes/no)',
+  enforce_phone: 'Make the phone field mandatory (yes/no)',
+};
+
+const KNOWN_KEYS = Object.keys(REGISTRATION_KEYS);
+
+// ---------------------------------------------------------------------------
+// get_registration_settings
+// ---------------------------------------------------------------------------
+
+export const getRegistrationSettingsTool = {
+  name: 'get_registration_settings',
+  description:
+    'Read the Nextcloud Registration app settings (self-service signup configuration), such as ' +
+    'allowed email domains, whether admin approval is required, and the default group for new ' +
+    'users. Requires the configured Nextcloud user to be an admin.',
+  inputSchema: z.object({}),
+  handler: async () => {
+    try {
+      const entries = await Promise.all(
+        KNOWN_KEYS.map(async (key) => {
+          const result = await fetchOCS<string>(`${APPCONFIG_BASE}/${key}`);
+          return [key, result.ocs.data] as const;
+        })
+      );
+
+      const text = entries
+        .map(([key, value]) => `- ${key}: ${value === '' ? '(default)' : value}`)
+        .join('\n');
+
+      return {
+        content: [{ type: 'text' as const, text: `Registration settings:\n${text}` }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error reading registration settings: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// update_registration_settings
+// ---------------------------------------------------------------------------
+
+export const updateRegistrationSettingsTool = {
+  name: 'update_registration_settings',
+  description:
+    'Update one or more Nextcloud Registration app settings. Boolean settings use the strings ' +
+    "'yes'/'no'; allowed_domains takes a JSON array string (e.g. '[\"example.com\"]'). Requires " +
+    'the configured Nextcloud user to be an admin.',
+  inputSchema: z.object({
+    settings: z
+      .array(
+        z.object({
+          key: z
+            .enum(KNOWN_KEYS as [string, ...string[]])
+            .describe('The Registration config key to set'),
+          value: z.string().describe('The value to store (boolean keys: "yes"/"no")'),
+        })
+      )
+      .min(1)
+      .describe('One or more key/value pairs to update'),
+  }),
+  handler: async (args: { settings: Array<{ key: string; value: string }> }) => {
+    try {
+      const updated: string[] = [];
+      for (const { key, value } of args.settings) {
+        await fetchOCS(`${APPCONFIG_BASE}/${key}`, {
+          method: 'POST',
+          body: { value },
+        });
+        updated.push(`${key} = ${value}`);
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Updated registration settings:\n${updated.map((u) => `- ${u}`).join('\n')}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error updating registration settings: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// reset_registration_setting
+// ---------------------------------------------------------------------------
+
+export const resetRegistrationSettingTool = {
+  name: 'reset_registration_setting',
+  description:
+    'Reset a Nextcloud Registration app setting to its default by deleting the stored value. ' +
+    'Requires the configured Nextcloud user to be an admin.',
+  inputSchema: z.object({
+    key: z
+      .enum(KNOWN_KEYS as [string, ...string[]])
+      .describe('The Registration config key to reset to its default'),
+  }),
+  handler: async (args: { key: string }) => {
+    try {
+      await fetchOCS(`${APPCONFIG_BASE}/${args.key}`, { method: 'DELETE' });
+
+      return {
+        content: [
+          { type: 'text' as const, text: `Reset registration setting '${args.key}' to default.` },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error resetting registration setting: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export const registrationTools = [
+  getRegistrationSettingsTool,
+  updateRegistrationSettingsTool,
+  resetRegistrationSettingTool,
+];


### PR DESCRIPTION
## Summary

Adds an MCP integration for the Nextcloud [Registration](https://github.com/nextcloud/registration) app (self-service signup), implementing #126.

The Registration app exposes no OCS API or OCC commands of its own — all admin behaviour is driven by **app config keys**. These tools read and write those keys through Nextcloud core's `provisioning_api` appconfig OCS endpoints, slotting into the existing `fetchOCS` client and per-app tool pattern.

### Tools (gated on the `registration` app)
- `get_registration_settings` — read all known config keys (allowed domains, admin-approval requirement, default group, field visibility, etc.)
- `update_registration_settings` — set one or more keys (Zod-validated against the known key set)
- `reset_registration_setting` — delete a key to restore its default

### Non-goals
- Pending registrations have no API. When `admin_approval_required` is set, registrants become disabled Nextcloud users — already manageable via the existing user tools (`enable_user` / `delete_user`).

## Test plan
- `npm run build` ✓
- `npm test` — full suite 781/781 ✓ (incl. new `tools-registration.test.ts`)
- `npm run lint` (0 errors) ✓ and `npx prettier --check src/` ✓

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)