### PR TITLE
feat(mcp): terms of service management

### DIFF
--- a/mcp-server/src/__tests__/tools-terms-of-service.test.ts
+++ b/mcp-server/src/__tests__/tools-terms-of-service.test.ts
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFetchOCS = vi.fn();
+
+vi.mock('../client/ocs.js', () => ({
+  fetchOCS: (...args: unknown[]) => mockFetchOCS(...args),
+}));
+
+const OCS_BASE = '/ocs/v2.php/apps/terms_of_service';
+const APPCONFIG_BASE = '/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/terms_of_service';
+
+function ok(data: unknown) {
+  return { ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data } };
+}
+
+describe('Terms of Service Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXTCLOUD_URL = 'https://cloud.example.com';
+    process.env.NEXTCLOUD_USER = 'admin';
+    process.env.NEXTCLOUD_PASSWORD = 'testpass';
+  });
+
+  describe('get_terms_of_service', () => {
+    it('should fetch admin form data and format terms, settings and codes', async () => {
+      mockFetchOCS.mockResolvedValue(
+        ok({
+          terms: [{ id: 3, countryCode: '--', languageCode: 'en', body: 'Be nice.' }],
+          countries: { '--': 'Global', DE: 'Germany' },
+          languages: { en: 'English', de: 'German' },
+          tos_on_public_shares: '0',
+          tos_for_users: '1',
+        })
+      );
+
+      const { getTermsOfServiceTool } = await import('../tools/apps/terms-of-service.js');
+      const result = await getTermsOfServiceTool.handler();
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(`${OCS_BASE}/terms/admin`);
+      expect(result.content[0].text).toContain('#3 [--/en] Be nice.');
+      expect(result.content[0].text).toContain('tos_for_users: 1');
+      expect(result.content[0].text).toContain('tos_on_public_shares: 0');
+      expect(result.content[0].text).toContain('DE');
+      expect(result.content[0].text).toContain('de');
+    });
+
+    it('should return isError on failure', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('boom'));
+
+      const { getTermsOfServiceTool } = await import('../tools/apps/terms-of-service.js');
+      const result = await getTermsOfServiceTool.handler();
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('boom');
+    });
+  });
+
+  describe('set_terms_of_service', () => {
+    it('should POST country/language/body and report the saved id', async () => {
+      mockFetchOCS.mockResolvedValue(
+        ok({ id: 7, countryCode: 'DE', languageCode: 'de', body: 'x' })
+      );
+
+      const { setTermsOfServiceTool } = await import('../tools/apps/terms-of-service.js');
+      const result = await setTermsOfServiceTool.handler({
+        countryCode: 'DE',
+        languageCode: 'de',
+        body: 'x',
+      });
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(`${OCS_BASE}/terms`, {
+        method: 'POST',
+        body: { countryCode: 'DE', languageCode: 'de', body: 'x' },
+      });
+      expect(result.content[0].text).toContain('Saved terms #7 for [DE/de]');
+    });
+
+    it('should default countryCode to "--"', async () => {
+      mockFetchOCS.mockResolvedValue(
+        ok({ id: 1, countryCode: '--', languageCode: 'en', body: 'x' })
+      );
+
+      const { setTermsOfServiceTool } = await import('../tools/apps/terms-of-service.js');
+      await setTermsOfServiceTool.handler({ languageCode: 'en', body: 'x' });
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(`${OCS_BASE}/terms`, {
+        method: 'POST',
+        body: { countryCode: '--', languageCode: 'en', body: 'x' },
+      });
+    });
+
+    it('should return isError on failure', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('417'));
+
+      const { setTermsOfServiceTool } = await import('../tools/apps/terms-of-service.js');
+      const result = await setTermsOfServiceTool.handler({ languageCode: 'zz', body: 'x' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('417');
+    });
+  });
+
+  describe('delete_terms_of_service', () => {
+    it('should DELETE the term by id', async () => {
+      mockFetchOCS.mockResolvedValue(ok([]));
+
+      const { deleteTermsOfServiceTool } = await import('../tools/apps/terms-of-service.js');
+      const result = await deleteTermsOfServiceTool.handler({ id: 5 });
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(`${OCS_BASE}/terms/5`, { method: 'DELETE' });
+      expect(result.content[0].text).toContain('Deleted terms #5');
+    });
+
+    it('should return isError on failure', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('nope'));
+
+      const { deleteTermsOfServiceTool } = await import('../tools/apps/terms-of-service.js');
+      const result = await deleteTermsOfServiceTool.handler({ id: 5 });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('nope');
+    });
+  });
+
+  describe('reset_terms_signatures', () => {
+    it('should DELETE the sign endpoint', async () => {
+      mockFetchOCS.mockResolvedValue(ok([]));
+
+      const { resetTermsSignaturesTool } = await import('../tools/apps/terms-of-service.js');
+      const result = await resetTermsSignaturesTool.handler();
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(`${OCS_BASE}/sign`, { method: 'DELETE' });
+      expect(result.content[0].text).toContain('Reset all terms of service signatures');
+    });
+
+    it('should return isError on failure', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('boom'));
+
+      const { resetTermsSignaturesTool } = await import('../tools/apps/terms-of-service.js');
+      const result = await resetTermsSignaturesTool.handler();
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('boom');
+    });
+  });
+
+  describe('update_terms_settings', () => {
+    it('should write yes/no for the provided settings', async () => {
+      mockFetchOCS.mockResolvedValue(ok(''));
+
+      const { updateTermsSettingsTool } = await import('../tools/apps/terms-of-service.js');
+      const result = await updateTermsSettingsTool.handler({
+        tosForUsers: true,
+        tosOnPublicShares: false,
+      });
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(`${APPCONFIG_BASE}/tos_for_users`, {
+        method: 'POST',
+        body: { value: 'yes' },
+      });
+      expect(mockFetchOCS).toHaveBeenCalledWith(`${APPCONFIG_BASE}/tos_on_public_shares`, {
+        method: 'POST',
+        body: { value: 'no' },
+      });
+      expect(result.content[0].text).toContain('tos_for_users = yes');
+      expect(result.content[0].text).toContain('tos_on_public_shares = no');
+    });
+
+    it('should error when no settings are provided', async () => {
+      const { updateTermsSettingsTool } = await import('../tools/apps/terms-of-service.js');
+      const result = await updateTermsSettingsTool.handler({});
+
+      expect(result.isError).toBe(true);
+      expect(mockFetchOCS).not.toHaveBeenCalled();
+    });
+
+    it('should return isError on failure', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('boom'));
+
+      const { updateTermsSettingsTool } = await import('../tools/apps/terms-of-service.js');
+      const result = await updateTermsSettingsTool.handler({ tosForUsers: true });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('boom');
+    });
+  });
+});

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -39,6 +39,7 @@ import { notificationsTools } from './tools/apps/notifications.js';
 import { activityTools } from './tools/apps/activity.js';
 import { announcementTools } from './tools/apps/announcements.js';
 import { registrationTools } from './tools/apps/registration.js';
+import { termsOfServiceTools } from './tools/apps/terms-of-service.js';
 import { trashTools } from './tools/apps/trash.js';
 import { versionsTools } from './tools/apps/versions.js';
 import { projectsTools } from './tools/apps/projects.js';
@@ -115,6 +116,11 @@ export const TOOL_REGISTRY: ToolSetEntry[] = [
   { category: 'activity', appIds: ['activity'], tools: activityTools },
   { category: 'announcements', appIds: ['announcementcenter'], tools: announcementTools },
   { category: 'registration', appIds: ['registration'], tools: registrationTools },
+  {
+    category: 'terms_of_service',
+    appIds: ['terms_of_service'],
+    tools: termsOfServiceTools,
+  },
 ];
 
 const ALL_CATEGORIES = new Set(TOOL_REGISTRY.map((e) => e.category));

--- a/mcp-server/src/tools/apps/terms-of-service.ts
+++ b/mcp-server/src/tools/apps/terms-of-service.ts
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: MIT
+
+import { z } from 'zod';
+import { fetchOCS } from '../../client/ocs.js';
+
+/**
+ * Nextcloud Terms of Service Tools
+ *
+ * The Terms of Service app (https://github.com/nextcloud/terms_of_service) lets admins
+ * publish per-country / per-language terms that users must accept. It exposes its own OCS
+ * API under `/ocs/v2.php/apps/terms_of_service`, so most tools call those endpoints
+ * directly.
+ *
+ * Two enforcement flags (`tos_for_users`, `tos_on_public_shares`) are plain app config
+ * keys: they are read via the admin form endpoint and written through core's
+ * provisioning_api appconfig endpoints.
+ */
+
+const OCS_BASE = '/ocs/v2.php/apps/terms_of_service';
+const APPCONFIG_BASE = '/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/terms_of_service';
+
+interface Terms {
+  id: number;
+  countryCode: string;
+  languageCode: string;
+  body: string;
+}
+
+interface AdminFormData {
+  terms: Terms[];
+  countries: Record<string, string>;
+  languages: Record<string, string>;
+  tos_on_public_shares: string;
+  tos_for_users: string;
+}
+
+function preview(body: string): string {
+  const oneLine = body.replace(/\s+/g, ' ').trim();
+  return oneLine.length > 80 ? `${oneLine.slice(0, 80)}…` : oneLine;
+}
+
+// ---------------------------------------------------------------------------
+// get_terms_of_service
+// ---------------------------------------------------------------------------
+
+export const getTermsOfServiceTool = {
+  name: 'get_terms_of_service',
+  description:
+    'Read the Nextcloud Terms of Service admin configuration: all published terms (by ' +
+    'country/language), the enforcement settings (tos_for_users, tos_on_public_shares), and ' +
+    'the valid country and language codes that can be used when setting terms. Requires the ' +
+    'configured Nextcloud user to be an admin.',
+  inputSchema: z.object({}),
+  handler: async () => {
+    try {
+      const result = await fetchOCS<AdminFormData>(`${OCS_BASE}/terms/admin`);
+      const data = result.ocs.data;
+
+      const termsText =
+        data.terms.length === 0
+          ? '(none)'
+          : data.terms
+              .map((t) => `- #${t.id} [${t.countryCode}/${t.languageCode}] ${preview(t.body)}`)
+              .join('\n');
+
+      const settings = [
+        `- tos_for_users: ${data.tos_for_users}`,
+        `- tos_on_public_shares: ${data.tos_on_public_shares}`,
+      ].join('\n');
+
+      const countries = Object.keys(data.countries).join(', ');
+      const languages = Object.keys(data.languages).join(', ');
+
+      const text =
+        `Terms of Service:\n${termsText}\n\n` +
+        `Settings:\n${settings}\n\n` +
+        `Valid country codes (use "--" for global): ${countries}\n` +
+        `Valid language codes: ${languages}`;
+
+      return {
+        content: [{ type: 'text' as const, text }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error reading terms of service: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// set_terms_of_service
+// ---------------------------------------------------------------------------
+
+export const setTermsOfServiceTool = {
+  name: 'set_terms_of_service',
+  description:
+    'Create or update the terms of service for a given country/language pair. If terms ' +
+    'already exist for that pair they are replaced, otherwise new terms are created. Use ' +
+    'get_terms_of_service to discover valid country/language codes; an invalid code returns ' +
+    'an error (HTTP 417). Requires the configured Nextcloud user to be an admin.',
+  inputSchema: z.object({
+    countryCode: z
+      .string()
+      .default('--')
+      .describe('2-letter region code, or "--" for global (default)'),
+    languageCode: z.string().describe('2-letter language code (e.g. "en")'),
+    body: z.string().describe('The terms text (markdown: headers, formatting, lists, links)'),
+  }),
+  handler: async (args: { countryCode?: string; languageCode: string; body: string }) => {
+    const countryCode = args.countryCode ?? '--';
+    try {
+      const result = await fetchOCS<Terms>(`${OCS_BASE}/terms`, {
+        method: 'POST',
+        body: {
+          countryCode,
+          languageCode: args.languageCode,
+          body: args.body,
+        },
+      });
+      const t = result.ocs.data;
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Saved terms #${t.id} for [${t.countryCode}/${t.languageCode}].`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error saving terms of service: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// delete_terms_of_service
+// ---------------------------------------------------------------------------
+
+export const deleteTermsOfServiceTool = {
+  name: 'delete_terms_of_service',
+  description:
+    'Delete a single terms of service entry by its id (see get_terms_of_service). Requires ' +
+    'the configured Nextcloud user to be an admin.',
+  inputSchema: z.object({
+    id: z.number().describe('The terms id to delete'),
+  }),
+  handler: async (args: { id: number }) => {
+    try {
+      await fetchOCS(`${OCS_BASE}/terms/${args.id}`, { method: 'DELETE' });
+
+      return {
+        content: [{ type: 'text' as const, text: `Deleted terms #${args.id}.` }],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error deleting terms of service: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// reset_terms_signatures
+// ---------------------------------------------------------------------------
+
+export const resetTermsSignaturesTool = {
+  name: 'reset_terms_signatures',
+  description:
+    "Reset ALL users' terms of service signatures org-wide, forcing every user to accept " +
+    'the terms again on next login. This is destructive and cannot be undone. Requires the ' +
+    'configured Nextcloud user to be an admin.',
+  inputSchema: z.object({}),
+  handler: async () => {
+    try {
+      await fetchOCS(`${OCS_BASE}/sign`, { method: 'DELETE' });
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'Reset all terms of service signatures. All users must accept the terms again.',
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error resetting terms signatures: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// update_terms_settings
+// ---------------------------------------------------------------------------
+
+export const updateTermsSettingsTool = {
+  name: 'update_terms_settings',
+  description:
+    'Update the Terms of Service enforcement settings: whether logged-in users must accept ' +
+    'the terms (tos_for_users) and whether the terms apply to public shares ' +
+    '(tos_on_public_shares). Requires the configured Nextcloud user to be an admin.',
+  inputSchema: z.object({
+    tosForUsers: z.boolean().optional().describe('Require logged-in users to accept the terms'),
+    tosOnPublicShares: z.boolean().optional().describe('Apply the terms to public shares'),
+  }),
+  handler: async (args: { tosForUsers?: boolean; tosOnPublicShares?: boolean }) => {
+    const updates: Array<[string, boolean]> = [];
+    if (args.tosForUsers !== undefined) updates.push(['tos_for_users', args.tosForUsers]);
+    if (args.tosOnPublicShares !== undefined) {
+      updates.push(['tos_on_public_shares', args.tosOnPublicShares]);
+    }
+
+    if (updates.length === 0) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'No settings provided. Specify tosForUsers and/or tosOnPublicShares.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    try {
+      const applied: string[] = [];
+      for (const [key, enabled] of updates) {
+        const value = enabled ? 'yes' : 'no';
+        await fetchOCS(`${APPCONFIG_BASE}/${key}`, {
+          method: 'POST',
+          body: { value },
+        });
+        applied.push(`${key} = ${value}`);
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Updated terms of service settings:\n${applied.map((u) => `- ${u}`).join('\n')}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error updating terms settings: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export const termsOfServiceTools = [
+  getTermsOfServiceTool,
+  setTermsOfServiceTool,
+  deleteTermsOfServiceTool,
+  resetTermsSignaturesTool,
+  updateTermsSettingsTool,
+];


### PR DESCRIPTION
## Summary

Adds a management integration for the Nextcloud [Terms of Service](https://github.com/nextcloud/terms_of_service) app, mirroring the existing Registration integration. Most tools call the app's own OCS API directly; the two enforcement flags are app config keys written via core's `provisioning_api` appconfig endpoints.

## Tools (gated on the `terms_of_service` app)

- `get_terms_of_service` — read all published terms (by country/language), enforcement settings, and valid country/language codes (`GET /terms/admin`)
- `set_terms_of_service` — create or update terms for a country/language pair (`POST /terms`)
- `delete_terms_of_service` — delete a term by id (`DELETE /terms/{id}`)
- `reset_terms_signatures` — clear all users' signatures org-wide (`DELETE /sign`), flagged as destructive
- `update_terms_settings` — toggle `tos_for_users` / `tos_on_public_shares`

## Test plan

- `npm test` — new `tools-terms-of-service.test.ts` (12 tests) plus full suite green
- `npm run lint` — 0 errors
- `npx prettier --check src/` — clean
- `npm run build` — compiles

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)