### PR TITLE
fix(nextcloud): Coworker/Prompt/Project crash on PostgreSQL

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.22",
+      "version": "0.3.23",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -2566,9 +2566,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "Nextcloud MCP server — files, calendar, contacts, mail, maps, notes, tasks & 120+ more tools",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,7 +18,7 @@
       ]
     }
   ],
-  "version": "0.3.22",
+  "version": "0.3.23",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "remotes": [
     {
@@ -36,7 +36,7 @@
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.22",
+      "version": "0.3.23",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -64,7 +64,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.22",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.23",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.22</version>
+    <version>0.3.23</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/lib/Db/Coworker.php
+++ b/nextcloud-app/lib/Db/Coworker.php
@@ -25,8 +25,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setOwnerApp(?string $ownerApp)
  * @method string getTaskType()
  * @method void setTaskType(string $taskType)
- * @method bool getPaused()
- * @method void setPaused(bool $paused)
+ * @method int getPaused()
+ * @method void setPaused(int $paused)
  * @method string|null getOptions()
  * @method void setOptions(?string $options)
  * @method string getCronSchedule()
@@ -39,8 +39,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setOutputType(string $outputType)
  * @method string|null getOutputPath()
  * @method void setOutputPath(?string $outputPath)
- * @method bool getIsActive()
- * @method void setIsActive(bool $isActive)
+ * @method int getIsActive()
+ * @method void setIsActive(int $isActive)
  * @method int|null getLastRunAt()
  * @method void setLastRunAt(?int $lastRunAt)
  * @method int|null getNextRunAt()
@@ -54,7 +54,7 @@ use OCP\AppFramework\Db\Entity;
  * @method int getUpdatedAt()
  * @method void setUpdatedAt(int $updatedAt)
  */
-class Coworker extends Entity {
+class Coworker extends Entity implements \JsonSerializable {
     protected string $userId = '';
     protected string $title = '';
     protected ?string $description = null;
@@ -63,14 +63,14 @@ class Coworker extends Entity {
     protected ?string $model = null;
     protected ?string $ownerApp = null;
     protected string $taskType = 'vision:classify';
-    protected bool $paused = false;
+    protected int $paused = 0;
     protected ?string $options = null;
     protected string $cronSchedule = '';
     protected string $inputType = '';
     protected ?string $inputPath = null;
     protected string $outputType = '';
     protected ?string $outputPath = null;
-    protected bool $isActive = true;
+    protected int $isActive = 1;
     protected ?int $lastRunAt = null;
     protected ?int $nextRunAt = null;
     protected ?string $lastStatus = null;
@@ -87,19 +87,51 @@ class Coworker extends Entity {
         $this->addType('model', 'string');
         $this->addType('ownerApp', 'string');
         $this->addType('taskType', 'string');
-        $this->addType('paused', 'boolean');
+        $this->addType('paused', 'integer');
         $this->addType('options', 'string');
         $this->addType('cronSchedule', 'string');
         $this->addType('inputType', 'string');
         $this->addType('inputPath', 'string');
         $this->addType('outputType', 'string');
         $this->addType('outputPath', 'string');
-        $this->addType('isActive', 'boolean');
+        $this->addType('isActive', 'integer');
         $this->addType('lastRunAt', 'integer');
         $this->addType('nextRunAt', 'integer');
         $this->addType('lastStatus', 'string');
         $this->addType('lastError', 'string');
         $this->addType('createdAt', 'integer');
         $this->addType('updatedAt', 'integer');
+    }
+
+    public function jsonSerialize(): array {
+        $options = json_decode($this->getOptions() ?? '', true);
+        if (!is_array($options)) {
+            $options = [];
+        }
+        return [
+            'id' => $this->getId(),
+            'userId' => $this->getUserId(),
+            'title' => $this->getTitle(),
+            'description' => $this->getDescription(),
+            'promptId' => $this->getPromptId(),
+            'customPrompt' => $this->getCustomPrompt(),
+            'model' => $this->getModel(),
+            'ownerApp' => $this->getOwnerApp(),
+            'taskType' => $this->getTaskType(),
+            'paused' => (bool)$this->getPaused(),
+            'options' => $options,
+            'cronSchedule' => $this->getCronSchedule(),
+            'inputType' => $this->getInputType(),
+            'inputPath' => $this->getInputPath(),
+            'outputType' => $this->getOutputType(),
+            'outputPath' => $this->getOutputPath(),
+            'isActive' => (bool)$this->getIsActive(),
+            'lastRunAt' => $this->getLastRunAt(),
+            'nextRunAt' => $this->getNextRunAt(),
+            'lastStatus' => $this->getLastStatus(),
+            'lastError' => $this->getLastError(),
+            'createdAt' => $this->getCreatedAt(),
+            'updatedAt' => $this->getUpdatedAt(),
+        ];
     }
 }

--- a/nextcloud-app/lib/Db/CoworkerMapper.php
+++ b/nextcloud-app/lib/Db/CoworkerMapper.php
@@ -94,8 +94,8 @@ class CoworkerMapper extends QBMapper {
         $qb = $this->db->getQueryBuilder();
         $qb->select('*')
             ->from($this->getTableName())
-            ->where($qb->expr()->eq('is_active', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
-            ->andWhere($qb->expr()->eq('paused', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)))
+            ->where($qb->expr()->eq('is_active', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)))
+            ->andWhere($qb->expr()->eq('paused', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
             ->andWhere($qb->expr()->lte('next_run_at', $qb->createNamedParameter($now, IQueryBuilder::PARAM_INT)));
 
         return $this->findEntities($qb);

--- a/nextcloud-app/lib/Db/CoworkerRun.php
+++ b/nextcloud-app/lib/Db/CoworkerRun.php
@@ -27,7 +27,7 @@ use OCP\AppFramework\Db\Entity;
  * @method int|null getFinishedAt()
  * @method void setFinishedAt(?int $finishedAt)
  */
-class CoworkerRun extends Entity {
+class CoworkerRun extends Entity implements \JsonSerializable {
     protected int $coworkerId = 0;
     protected string $userId = '';
     protected string $status = 'running';
@@ -48,5 +48,20 @@ class CoworkerRun extends Entity {
         $this->addType('error', 'string');
         $this->addType('startedAt', 'integer');
         $this->addType('finishedAt', 'integer');
+    }
+
+    public function jsonSerialize(): array {
+        return [
+            'id' => $this->getId(),
+            'coworkerId' => $this->getCoworkerId(),
+            'userId' => $this->getUserId(),
+            'status' => $this->getStatus(),
+            'itemsTotal' => $this->getItemsTotal(),
+            'itemsProcessed' => $this->getItemsProcessed(),
+            'summary' => $this->getSummary(),
+            'error' => $this->getError(),
+            'startedAt' => $this->getStartedAt(),
+            'finishedAt' => $this->getFinishedAt(),
+        ];
     }
 }

--- a/nextcloud-app/lib/Db/Project.php
+++ b/nextcloud-app/lib/Db/Project.php
@@ -17,8 +17,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setDescription(?string $description)
  * @method string|null getSystemPrompt()
  * @method void setSystemPrompt(?string $systemPrompt)
- * @method bool getIsActive()
- * @method void setIsActive(bool $isActive)
+ * @method int getIsActive()
+ * @method void setIsActive(int $isActive)
  * @method int getCreatedAt()
  * @method void setCreatedAt(int $createdAt)
  * @method int getUpdatedAt()
@@ -29,7 +29,7 @@ class Project extends Entity implements \JsonSerializable {
     protected string $title = '';
     protected ?string $description = null;
     protected ?string $systemPrompt = null;
-    protected bool $isActive = true;
+    protected int $isActive = 1;
     protected int $createdAt = 0;
     protected int $updatedAt = 0;
 
@@ -38,7 +38,7 @@ class Project extends Entity implements \JsonSerializable {
         $this->addType('title', 'string');
         $this->addType('description', 'string');
         $this->addType('systemPrompt', 'string');
-        $this->addType('isActive', 'boolean');
+        $this->addType('isActive', 'integer');
         $this->addType('createdAt', 'integer');
         $this->addType('updatedAt', 'integer');
     }
@@ -50,7 +50,7 @@ class Project extends Entity implements \JsonSerializable {
             'title' => $this->getTitle(),
             'description' => $this->getDescription(),
             'systemPrompt' => $this->getSystemPrompt(),
-            'isActive' => $this->getIsActive(),
+            'isActive' => (bool)$this->getIsActive(),
             'createdAt' => $this->getCreatedAt(),
             'updatedAt' => $this->getUpdatedAt(),
         ];

--- a/nextcloud-app/lib/Db/Prompt.php
+++ b/nextcloud-app/lib/Db/Prompt.php
@@ -17,8 +17,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setDescription(?string $description)
  * @method string getContent()
  * @method void setContent(string $content)
- * @method bool getIsActive()
- * @method void setIsActive(bool $isActive)
+ * @method int getIsActive()
+ * @method void setIsActive(int $isActive)
  * @method int getCreatedAt()
  * @method void setCreatedAt(int $createdAt)
  * @method int getUpdatedAt()
@@ -29,7 +29,7 @@ class Prompt extends Entity {
     protected string $title = '';
     protected ?string $description = null;
     protected string $content = '';
-    protected bool $isActive = true;
+    protected int $isActive = 1;
     protected int $createdAt = 0;
     protected int $updatedAt = 0;
 
@@ -38,7 +38,7 @@ class Prompt extends Entity {
         $this->addType('title', 'string');
         $this->addType('description', 'string');
         $this->addType('content', 'string');
-        $this->addType('isActive', 'boolean');
+        $this->addType('isActive', 'integer');
         $this->addType('createdAt', 'integer');
         $this->addType('updatedAt', 'integer');
     }

--- a/nextcloud-app/lib/Db/PromptMapper.php
+++ b/nextcloud-app/lib/Db/PromptMapper.php
@@ -41,7 +41,7 @@ class PromptMapper extends QBMapper {
             ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)));
 
         if ($activeOnly) {
-            $qb->andWhere($qb->expr()->eq('is_active', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)));
+            $qb->andWhere($qb->expr()->eq('is_active', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)));
         }
 
         $qb->orderBy('title', 'ASC');

--- a/nextcloud-app/lib/Service/CoworkManager.php
+++ b/nextcloud-app/lib/Service/CoworkManager.php
@@ -53,13 +53,13 @@ class CoworkManager implements ICoworkManager {
 
     public function setPaused(string $appId, int $id, bool $paused): array {
         $coworker = $this->mapper->findByIdAndApp($id, $appId);
-        $coworker->setPaused($paused);
+        $coworker->setPaused($paused ? 1 : 0);
         return $this->service->persistScheduled($coworker)->jsonSerialize();
     }
 
     public function setActive(string $appId, int $id, bool $active): array {
         $coworker = $this->mapper->findByIdAndApp($id, $appId);
-        $coworker->setIsActive($active);
+        $coworker->setIsActive($active ? 1 : 0);
         return $this->service->persistScheduled($coworker)->jsonSerialize();
     }
 

--- a/nextcloud-app/lib/Service/CoworkerService.php
+++ b/nextcloud-app/lib/Service/CoworkerService.php
@@ -113,7 +113,7 @@ class CoworkerService {
      */
     public function setPaused(int $id, string $userId, bool $paused): Coworker {
         $coworker = $this->mapper->findByIdAndUser($id, $userId);
-        $coworker->setPaused($paused);
+        $coworker->setPaused($paused ? 1 : 0);
         return $this->persistScheduled($coworker);
     }
 
@@ -122,7 +122,7 @@ class CoworkerService {
      */
     public function setActive(int $id, string $userId, bool $active): Coworker {
         $coworker = $this->mapper->findByIdAndUser($id, $userId);
-        $coworker->setIsActive($active);
+        $coworker->setIsActive($active ? 1 : 0);
         return $this->persistScheduled($coworker);
     }
 
@@ -289,10 +289,10 @@ class CoworkerService {
             $coworker->setOutputPath($data['output_path'] !== null ? (string)$data['output_path'] : null);
         }
         if (array_key_exists('is_active', $data)) {
-            $coworker->setIsActive((bool)$data['is_active']);
+            $coworker->setIsActive(!empty($data['is_active']) ? 1 : 0);
         }
         if (array_key_exists('paused', $data)) {
-            $coworker->setPaused((bool)$data['paused']);
+            $coworker->setPaused(!empty($data['paused']) ? 1 : 0);
         }
         if (array_key_exists('options', $data)) {
             $options = $data['options'];

--- a/nextcloud-app/package-lock.json
+++ b/nextcloud-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila",
-  "version": "0.3.20",
+  "version": "0.3.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila",
-      "version": "0.3.20",
+      "version": "0.3.22",
       "license": "AGPL-3.0",
       "dependencies": {
         "@nextcloud/axios": "^2.6.0",
@@ -3633,9 +3633,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -7596,9 +7596,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",
@@ -24,7 +24,7 @@
   },
   "overrides": {
     "brace-expansion": "^2.0.3",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.11",
     "esbuild": ">=0.28.1",
     "follow-redirects": "^1.16.0"
   },

--- a/nextcloud-app/tests/Unit/Db/CoworkerMapperTest.php
+++ b/nextcloud-app/tests/Unit/Db/CoworkerMapperTest.php
@@ -102,7 +102,7 @@ class CoworkerMapperTest extends MapperTestCase {
 
     public function testFindDueForRunCallsFindEntities(): void {
         $cw = new Coworker();
-        $cw->setIsActive(true);
+        $cw->setIsActive(1);
         $cw->setNextRunAt(1000);
 
         $mapper = $this->makeMapper();

--- a/nextcloud-app/tests/Unit/Db/EntitiesTest.php
+++ b/nextcloud-app/tests/Unit/Db/EntitiesTest.php
@@ -197,7 +197,7 @@ class EntitiesTest extends TestCase {
         $this->assertEquals('', $p->getTitle());
         $this->assertNull($p->getDescription());
         $this->assertEquals('', $p->getContent());
-        $this->assertTrue($p->getIsActive());
+        $this->assertSame(1, $p->getIsActive());
         $this->assertEquals(0, $p->getCreatedAt());
         $this->assertEquals(0, $p->getUpdatedAt());
     }
@@ -208,13 +208,13 @@ class EntitiesTest extends TestCase {
         $p->setTitle('Summarizer');
         $p->setDescription('Summarizes text');
         $p->setContent('Summarize: {input}');
-        $p->setIsActive(false);
+        $p->setIsActive(0);
 
         $this->assertEquals('charlie', $p->getUserId());
         $this->assertEquals('Summarizer', $p->getTitle());
         $this->assertEquals('Summarizes text', $p->getDescription());
         $this->assertEquals('Summarize: {input}', $p->getContent());
-        $this->assertFalse($p->getIsActive());
+        $this->assertSame(0, $p->getIsActive());
     }
 
     public function testPromptRegistersTypes(): void {
@@ -223,7 +223,7 @@ class EntitiesTest extends TestCase {
         $this->assertEquals('string',  $types['title']);
         $this->assertEquals('string',  $types['description']);
         $this->assertEquals('string',  $types['content']);
-        $this->assertEquals('boolean', $types['isActive']);
+        $this->assertEquals('integer', $types['isActive']);
         $this->assertEquals('integer', $types['createdAt']);
         $this->assertEquals('integer', $types['updatedAt']);
     }

--- a/nextcloud-app/tests/Unit/Db/EntitiesTest.php
+++ b/nextcloud-app/tests/Unit/Db/EntitiesTest.php
@@ -243,7 +243,7 @@ class EntitiesTest extends TestCase {
         $this->assertNull($cw->getInputPath());
         $this->assertEquals('', $cw->getOutputType());
         $this->assertNull($cw->getOutputPath());
-        $this->assertTrue($cw->getIsActive());
+        $this->assertSame(1, $cw->getIsActive());
         $this->assertNull($cw->getLastRunAt());
         $this->assertNull($cw->getNextRunAt());
         $this->assertNull($cw->getLastStatus());
@@ -258,7 +258,7 @@ class EntitiesTest extends TestCase {
         $cw->setInputType('file');
         $cw->setInputPath('/reports/input.txt');
         $cw->setOutputType('email');
-        $cw->setIsActive(false);
+        $cw->setIsActive(0);
         $cw->setNextRunAt(9999);
         $cw->setLastStatus('ok');
 
@@ -268,14 +268,14 @@ class EntitiesTest extends TestCase {
         $this->assertEquals('file', $cw->getInputType());
         $this->assertEquals('/reports/input.txt', $cw->getInputPath());
         $this->assertEquals('email', $cw->getOutputType());
-        $this->assertFalse($cw->getIsActive());
+        $this->assertSame(0, $cw->getIsActive());
         $this->assertEquals(9999, $cw->getNextRunAt());
         $this->assertEquals('ok', $cw->getLastStatus());
     }
 
     public function testCoworkerRegistersTypes(): void {
         $types = (new Coworker())->getFieldTypes();
-        $this->assertEquals('boolean', $types['isActive']);
+        $this->assertEquals('integer', $types['isActive']);
         $this->assertEquals('integer', $types['promptId']);
         $this->assertEquals('integer', $types['lastRunAt']);
         $this->assertEquals('integer', $types['nextRunAt']);


### PR DESCRIPTION
Fixes #372.

Every Coworker endpoint crashed on PostgreSQL, and Prompt/Project carried the same latent bug.

## Bug 1 — `jsonSerialize does not exist`
`Coworker` and `CoworkerRun` extended `Entity` without implementing `\JsonSerializable`, so the controller's `jsonSerialize()` calls threw `BadFunctionCallException`. Added `jsonSerialize()` to both, emitting the camelCase shape the Vue frontend already consumes.

## Bug 2 — `invalid input syntax for type smallint: "f"`
`is_active`/`paused` are `SMALLINT` columns but the entities declared them `boolean`, so Nextcloud bound `PARAM_BOOL` → PostgreSQL rejected `'t'`/`'f'`. Aligned the entity field types to `integer` and used `PARAM_INT` in the due-run query. Flags are cast back to `bool` in `jsonSerialize()`, so the API shape is unchanged.

## Prompt / Project
Same `boolean` addType vs `SMALLINT` column mismatch (`PromptMapper` also bound `PARAM_BOOL`). Switched both entities to `integer` and `PromptMapper` to `PARAM_INT` (`ProjectMapper` already used `PARAM_INT`).

## Verification
- 375 unit tests pass (`vendor/bin/phpunit`); updated the affected entity tests to the int contract.
- `php -l` clean on all changed files.
- `generate-spec` produces **no diff** to `openapi*.json` — no signatures changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Bundled security dependency bumps

Resolves the open Dependabot alerts (GitHub code scanning is not enabled on this repo, so these are the security findings). Bumped here rather than via the standalone Dependabot PRs (#368/#369/#370, left open):

- **hono** 4.12.23 → 4.12.26 (mcp-server) — fixes 2 high + 3 moderate: CORS wildcard-with-credentials reflection, serve-static path traversal, body-limit bypass, header/cookie handling.
- **dompurify** override `^3.4.0` → `^3.4.11` (nextcloud-app) — fixes 7 sanitization-bypass alerts.
- **vite** (dev) 7.3.3 → 7.3.5 (nextcloud-app) — fixes 1 high: `server.fs.deny` bypass on Windows.
- **elliptic** (low, dev-only transitive via browserify-sign) — no patched release exists; left as an accepted alert.

Version bumped to **0.3.23** (patch) across all release locations.

Verification: mcp-server `build`/`test` (793 passing) + `lint` (0 errors) + `prettier --check` all pass.
