### PR TITLE
feat(mcp): file recommendations tool (#128)

### DIFF
--- a/mcp-server/src/__tests__/tools-recommendations.test.ts
+++ b/mcp-server/src/__tests__/tools-recommendations.test.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFetchOCS = vi.fn();
+
+vi.mock('../client/ocs.js', () => ({
+  fetchOCS: (...args: unknown[]) => mockFetchOCS(...args),
+}));
+
+const sampleFile = {
+  id: '42',
+  timestamp: 1_700_000_000,
+  name: 'report.pdf',
+  directory: '/Documents',
+  extension: 'pdf',
+  mimeType: 'application/pdf',
+  hasPreview: true,
+  reason: 'recently-commented',
+};
+
+function ok(data: unknown) {
+  return { ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data } };
+}
+
+describe('Recommendation Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXTCLOUD_URL = 'https://cloud.example.com';
+    process.env.NEXTCLOUD_USER = 'admin';
+    process.env.NEXTCLOUD_PASSWORD = 'testpass';
+  });
+
+  describe('list_recommendations', () => {
+    it('should call the recommendations endpoint', async () => {
+      mockFetchOCS.mockResolvedValue(ok({ enabled: true, recommendations: [sampleFile] }));
+
+      const { listRecommendationsTool } = await import('../tools/apps/recommendations.js');
+      await listRecommendationsTool.handler();
+
+      expect(mockFetchOCS).toHaveBeenCalledWith(
+        '/ocs/v2.php/apps/recommendations/api/v1/recommendations'
+      );
+    });
+
+    it('should format recommended files with path, reason and timestamp', async () => {
+      mockFetchOCS.mockResolvedValue(ok({ enabled: true, recommendations: [sampleFile] }));
+
+      const { listRecommendationsTool } = await import('../tools/apps/recommendations.js');
+      const result = await listRecommendationsTool.handler();
+
+      expect(result.content[0].text).toContain('Recommended files (1)');
+      expect(result.content[0].text).toContain('/Documents/report.pdf');
+      expect(result.content[0].text).toContain('reason: recently-commented');
+      expect(result.content[0].text).toContain('2023-11-14T');
+    });
+
+    it('should report when recommendations are disabled', async () => {
+      mockFetchOCS.mockResolvedValue(ok({ enabled: false }));
+
+      const { listRecommendationsTool } = await import('../tools/apps/recommendations.js');
+      const result = await listRecommendationsTool.handler();
+
+      expect(result.content[0].text).toBe('Recommendations are disabled for this user.');
+    });
+
+    it('should handle enabled with no recommendations', async () => {
+      mockFetchOCS.mockResolvedValue(ok({ enabled: true, recommendations: [] }));
+
+      const { listRecommendationsTool } = await import('../tools/apps/recommendations.js');
+      const result = await listRecommendationsTool.handler();
+
+      expect(result.content[0].text).toBe('No recommended files.');
+    });
+
+    it('should report errors', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('boom'));
+
+      const { listRecommendationsTool } = await import('../tools/apps/recommendations.js');
+      const result = await listRecommendationsTool.handler();
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('boom');
+    });
+  });
+});

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -46,6 +46,7 @@ import { projectsTools } from './tools/apps/projects.js';
 import { pollsTools } from './tools/apps/polls.js';
 import { formsTools } from './tools/apps/forms.js';
 import { textTools } from './tools/apps/text.js';
+import { recommendationsTools } from './tools/apps/recommendations.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ToolArray = Array<{
@@ -121,6 +122,7 @@ export const TOOL_REGISTRY: ToolSetEntry[] = [
     appIds: ['terms_of_service'],
     tools: termsOfServiceTools,
   },
+  { category: 'recommendations', appIds: ['recommendations'], tools: recommendationsTools },
 ];
 
 const ALL_CATEGORIES = new Set(TOOL_REGISTRY.map((e) => e.category));

--- a/mcp-server/src/tools/apps/recommendations.ts
+++ b/mcp-server/src/tools/apps/recommendations.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+
+import { z } from 'zod';
+import { fetchOCS } from '../../client/ocs.js';
+
+/**
+ * Nextcloud Recommendations Tools
+ * Surface the files Nextcloud recommends for the configured user via the
+ * Recommendations app OCS API.
+ */
+
+interface RecommendedFile {
+  id: string;
+  timestamp: number;
+  name: string;
+  directory: string;
+  extension: string;
+  mimeType: string;
+  hasPreview: boolean;
+  reason: string;
+}
+
+interface RecommendationsResponse {
+  enabled: boolean;
+  recommendations?: RecommendedFile[];
+}
+
+function formatTime(ts: number): string {
+  if (!ts) return '';
+  return new Date(ts * 1000).toISOString();
+}
+
+function formatRecommendations(items: RecommendedFile[]): string {
+  return items
+    .map((f) => {
+      const dir = f.directory && f.directory !== '/' ? f.directory.replace(/\/$/, '') : '';
+      const path = `${dir}/${f.name}`;
+      const time = f.timestamp ? ` (${formatTime(f.timestamp)})` : '';
+      const reason = f.reason ? `\n  reason: ${f.reason}` : '';
+      return `- ${path}${time}${reason}`;
+    })
+    .join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// list_recommendations
+// ---------------------------------------------------------------------------
+
+export const listRecommendationsTool = {
+  name: 'list_recommendations',
+  description:
+    'List files Nextcloud recommends for the configured user (e.g. recently or frequently ' +
+    'accessed, recently shared, or files in active folders), including the reason each file ' +
+    "is recommended. Respects the user's recommendations setting.",
+  inputSchema: z.object({}),
+  handler: async () => {
+    try {
+      const result = await fetchOCS<RecommendationsResponse>(
+        '/ocs/v2.php/apps/recommendations/api/v1/recommendations'
+      );
+
+      const data = result.ocs.data;
+      const items = data.recommendations ?? [];
+
+      if (!data.enabled && items.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'Recommendations are disabled for this user.',
+            },
+          ],
+        };
+      }
+
+      if (items.length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: 'No recommended files.' }],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Recommended files (${items.length}):\n${formatRecommendations(items)}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error listing recommendations: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export const recommendationsTools = [listRecommendationsTool];


### PR DESCRIPTION
## Summary

Implements #128 — a new MCP tool exposing Nextcloud's recommended-files feature.

- Adds `list_recommendations` wrapping the upstream [Recommendations app](https://github.com/nextcloud/recommendations) OCS endpoint `GET /ocs/v2.php/apps/recommendations/api/v1/recommendations` (the `index` route, which respects the user's enabled setting).
- Returns each recommended file with its path, reason, and timestamp; handles the disabled, empty, and error cases.
- Registered in `tool-registry.ts` gated on the `recommendations` Nextcloud app.

Follows the existing OCS-wrapping tool pattern (`announcements.ts`). Only the `index` route is wrapped; `/always` is intentionally not exposed.

## Test plan

- New `tools-recommendations.test.ts` covers endpoint call, formatting, disabled, empty, and error paths.
- `npm test` (798 passing), `npm run lint` (0 errors), `npx prettier --check src/` clean.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)