### PR TITLE
fix(nextcloud): bump form-data to 4.0.6 (CVE-2026-12143)

### DIFF
--- a/nextcloud-app/package-lock.json
+++ b/nextcloud-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila",
-      "version": "0.3.22",
+      "version": "0.3.23",
       "license": "AGPL-3.0",
       "dependencies": {
         "@nextcloud/axios": "^2.6.0",
@@ -4082,16 +4082,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4290,9 +4290,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"


### PR DESCRIPTION
Resolves Dependabot alert [#103](https://github.com/elgorro/aiquila/security/dependabot/103) (GHSA-hmw2-7cc7-3qxx / CVE-2026-12143, High, CWE-93 CRLF injection).

`form-data` is a transitive runtime dependency in `nextcloud-app/package-lock.json` via `@nextcloud/axios → axios@1.16.0`, pinned at **4.0.5** which is vulnerable to CRLF injection through unescaped multipart field names / filenames. Patched in **4.0.6**.

## Change
- Lock-file-only bump: `form-data` 4.0.5 → 4.0.6. axios's `^4.0.5` range already permits it, so no `package.json` / direct-dependency change.
- Transitive `hasown` 2.0.2 → 2.0.4 pulled in as required by form-data 4.0.6.
- Corrected stale project version in the lock (0.3.22 → 0.3.23, matching `package.json`).

## Verification
- `form-data` resolves to 4.0.6 in the lock; only `package-lock.json` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)