### PR TITLE
feat(mcp): social sharing integration (#129)

### DIFF
--- a/mcp-server/src/__tests__/tools-social-sharing.test.ts
+++ b/mcp-server/src/__tests__/tools-social-sharing.test.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the OCS client module
+const mockFetchOCS = vi.fn();
+vi.mock('../client/ocs.js', () => ({
+  fetchOCS: (...args: unknown[]) => mockFetchOCS(...args),
+}));
+
+const ocsWrap = <T>(data: T) => ({
+  ocs: { meta: { status: 'ok', statuscode: 200, message: 'OK' }, data },
+});
+
+/**
+ * Route mock responses by OCS path: the shares endpoint returns the given share,
+ * the apps endpoint returns the given enabled-app list.
+ */
+function setupMocks(opts: { share?: unknown; sharesList?: unknown[]; enabledApps: string[] }) {
+  mockFetchOCS.mockImplementation((path: string) => {
+    if (path.startsWith('/ocs/v2.php/cloud/apps')) {
+      return Promise.resolve(ocsWrap({ apps: opts.enabledApps }));
+    }
+    if (path.includes('/files_sharing/api/v1/shares')) {
+      if (opts.sharesList !== undefined) return Promise.resolve(ocsWrap(opts.sharesList));
+      return Promise.resolve(ocsWrap([opts.share]));
+    }
+    throw new Error(`Unexpected path ${path}`);
+  });
+}
+
+describe('Social Sharing Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXTCLOUD_URL = 'https://cloud.example.com';
+    process.env.NEXTCLOUD_USER = 'admin';
+    process.env.NEXTCLOUD_PASSWORD = 'testpass';
+  });
+
+  it('resolves a share by id and emits enabled-network URLs with the token', async () => {
+    setupMocks({
+      share: { id: 7, share_type: 3, token: 'tok123', url: 'https://cloud.example.com/s/tok123' },
+      enabledApps: ['files', 'socialsharing_twitter', 'socialsharing_facebook'],
+    });
+
+    const { generateSocialShareLinksTool } = await import('../tools/apps/social-sharing.js');
+    const result = await generateSocialShareLinksTool.handler({ share_id: 7 });
+
+    expect(result.isError).toBeUndefined();
+    const text = result.content[0].text;
+    expect(text).toContain('twitter:');
+    expect(text).toContain('facebook:');
+    expect(text).toContain('tok123');
+    // email app not enabled → not listed
+    expect(text).not.toContain('email:');
+  });
+
+  it('honors the networks filter', async () => {
+    setupMocks({
+      share: { id: 7, share_type: 3, token: 'tok123' },
+      enabledApps: ['socialsharing_twitter', 'socialsharing_facebook'],
+    });
+
+    const { generateSocialShareLinksTool } = await import('../tools/apps/social-sharing.js');
+    const result = await generateSocialShareLinksTool.handler({
+      share_id: 7,
+      networks: ['twitter'],
+    });
+
+    const text = result.content[0].text;
+    expect(text).toContain('twitter:');
+    expect(text).not.toContain('facebook:');
+  });
+
+  it('finds the public-link share by path', async () => {
+    setupMocks({
+      sharesList: [
+        { id: 1, share_type: 0, token: undefined },
+        { id: 2, share_type: 3, token: 'pubtok' },
+      ],
+      enabledApps: ['socialsharing_email'],
+    });
+
+    const { generateSocialShareLinksTool } = await import('../tools/apps/social-sharing.js');
+    const result = await generateSocialShareLinksTool.handler({ path: '/Documents/file.txt' });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain('pubtok');
+  });
+
+  it('errors when the share is not a public link', async () => {
+    setupMocks({
+      share: { id: 9, share_type: 0, token: undefined },
+      enabledApps: ['socialsharing_twitter'],
+    });
+
+    const { generateSocialShareLinksTool } = await import('../tools/apps/social-sharing.js');
+    const result = await generateSocialShareLinksTool.handler({ share_id: 9 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('not a public link');
+  });
+
+  it('errors when neither share_id nor path is provided', async () => {
+    const { generateSocialShareLinksTool } = await import('../tools/apps/social-sharing.js');
+    const result = await generateSocialShareLinksTool.handler({});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('share_id or path');
+  });
+});

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -47,6 +47,7 @@ import { pollsTools } from './tools/apps/polls.js';
 import { formsTools } from './tools/apps/forms.js';
 import { textTools } from './tools/apps/text.js';
 import { recommendationsTools } from './tools/apps/recommendations.js';
+import { socialSharingTools } from './tools/apps/social-sharing.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ToolArray = Array<{
@@ -123,6 +124,19 @@ export const TOOL_REGISTRY: ToolSetEntry[] = [
     tools: termsOfServiceTools,
   },
   { category: 'recommendations', appIds: ['recommendations'], tools: recommendationsTools },
+  {
+    category: 'social_sharing',
+    appIds: [
+      'socialsharing_email',
+      'socialsharing_twitter',
+      'socialsharing_facebook',
+      'socialsharing_telegram',
+      'socialsharing_whatsapp',
+      'socialsharing_bluesky',
+      'socialsharing_diaspora',
+    ],
+    tools: socialSharingTools,
+  },
 ];
 
 const ALL_CATEGORIES = new Set(TOOL_REGISTRY.map((e) => e.category));

--- a/mcp-server/src/tools/apps/social-sharing.ts
+++ b/mcp-server/src/tools/apps/social-sharing.ts
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+
+import { z } from 'zod';
+import { fetchOCS } from '../../client/ocs.js';
+import { getNextcloudConfig } from '../types.js';
+import { handleAppError } from '../error-utils.js';
+
+/**
+ * Social Sharing Integration
+ *
+ * The upstream `nextcloud/socialsharing` apps are frontend-only: each registers a
+ * sidebar action that opens a network's share URL built from a public-link token.
+ * There is no backend API, so this tool replicates those URL templates server-side
+ * for an existing public-link share, exposing only the networks whose
+ * `socialsharing_<network>` app is enabled.
+ */
+
+interface ShareEntry {
+  id: number;
+  share_type: number;
+  token?: string;
+  url?: string;
+}
+
+const SHARE_TYPE_PUBLIC_LINK = 3;
+
+/** Default share message used by the upstream apps. */
+const DEFAULT_MESSAGE = 'I shared a file with you';
+
+interface NetworkDef {
+  /** Short network key used in output and the `networks` filter. */
+  key: string;
+  /** Enabled-app id gating this network. */
+  appId: string;
+  /** Builds the share URL from the public link and an (encoded) message. */
+  build: (link: string, message: string) => string;
+}
+
+const NETWORKS: NetworkDef[] = [
+  {
+    key: 'email',
+    appId: 'socialsharing_email',
+    build: (link, msg) => `mailto:?subject=${msg}&body=${encodeURIComponent(link)}`,
+  },
+  {
+    key: 'twitter',
+    appId: 'socialsharing_twitter',
+    build: (link) => `https://twitter.com/intent/tweet?url=${encodeURIComponent(link)}`,
+  },
+  {
+    key: 'facebook',
+    appId: 'socialsharing_facebook',
+    build: (link) => `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(link)}`,
+  },
+  {
+    key: 'telegram',
+    appId: 'socialsharing_telegram',
+    build: (link, msg) =>
+      `https://telegram.me/share/url?url=${encodeURIComponent(link)}&text=${msg}`,
+  },
+  {
+    key: 'whatsapp',
+    appId: 'socialsharing_whatsapp',
+    build: (link, msg) => `whatsapp://send?text=${msg}:%0A%0A${encodeURIComponent(link)}`,
+  },
+  {
+    key: 'bluesky',
+    appId: 'socialsharing_bluesky',
+    build: (link, msg) =>
+      `https://bsky.app/intent/compose?text=${msg}:%0A%0A${encodeURIComponent(link)}`,
+  },
+  {
+    key: 'diaspora',
+    appId: 'socialsharing_diaspora',
+    build: (link) => `https://share.diasporafoundation.org/?url=${encodeURIComponent(link)}`,
+  },
+];
+
+/** Fetch the set of enabled Nextcloud app ids. */
+async function getEnabledApps(): Promise<Set<string>> {
+  const result = await fetchOCS<{ apps: string[] }>('/ocs/v2.php/cloud/apps', {
+    queryParams: { filter: 'enabled' },
+  });
+  return new Set(result.ocs.data.apps);
+}
+
+/** Resolve a public-link share by id or path. */
+async function resolvePublicShare(args: { share_id?: number; path?: string }): Promise<ShareEntry> {
+  if (args.share_id !== undefined) {
+    const result = await fetchOCS<ShareEntry[] | ShareEntry>(
+      `/ocs/v2.php/apps/files_sharing/api/v1/shares/${args.share_id}`
+    );
+    // The single-share endpoint returns an array with one entry.
+    const data = result.ocs.data;
+    const share = Array.isArray(data) ? data[0] : data;
+    if (!share) throw new Error(`Share ${args.share_id} not found`);
+    return share;
+  }
+
+  const result = await fetchOCS<ShareEntry[]>('/ocs/v2.php/apps/files_sharing/api/v1/shares', {
+    queryParams: { path: args.path as string },
+  });
+  const link = result.ocs.data.find((s) => s.share_type === SHARE_TYPE_PUBLIC_LINK && s.token);
+  if (!link) {
+    throw new Error(`No public link share found for path "${args.path}". Create one first.`);
+  }
+  return link;
+}
+
+export const generateSocialShareLinksTool = {
+  name: 'generate_social_share_links',
+  description:
+    'Generate social-network share URLs (email, X/Twitter, Facebook, Telegram, WhatsApp, ' +
+    'Bluesky, Diaspora) for an existing Nextcloud public-link share. Only networks whose ' +
+    'socialsharing_<network> app is enabled are returned. Provide either share_id or path.',
+  inputSchema: z.object({
+    share_id: z.number().optional().describe('ID of an existing public-link share'),
+    path: z
+      .string()
+      .optional()
+      .describe('File/folder path; its public-link share is used (must already exist)'),
+    networks: z
+      .array(z.string())
+      .optional()
+      .describe('Optional filter, e.g. ["twitter","email"]. Defaults to all enabled networks.'),
+  }),
+  handler: async (args: { share_id?: number; path?: string; networks?: string[] }) => {
+    if (args.share_id === undefined && !args.path) {
+      return {
+        content: [{ type: 'text' as const, text: 'Provide either share_id or path.' }],
+        isError: true as const,
+      };
+    }
+
+    try {
+      const share = await resolvePublicShare(args);
+      if (share.share_type !== SHARE_TYPE_PUBLIC_LINK || !share.token) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'The referenced share is not a public link (no shareable token).',
+            },
+          ],
+          isError: true as const,
+        };
+      }
+
+      const { url } = getNextcloudConfig();
+      const link = share.url || `${url}/s/${share.token}`;
+      const message = encodeURIComponent(DEFAULT_MESSAGE);
+
+      const filter = args.networks ? new Set(args.networks.map((n) => n.toLowerCase())) : null;
+      const enabledApps = await getEnabledApps();
+
+      const lines = NETWORKS.filter((n) => enabledApps.has(n.appId))
+        .filter((n) => !filter || filter.has(n.key))
+        .map((n) => `${n.key}: ${n.build(link, message)}`);
+
+      if (lines.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text:
+                'No matching social sharing networks are available. Install/enable a ' +
+                'socialsharing_<network> app (or adjust the networks filter).',
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Social share links for ${link}:\n${lines.join('\n')}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error generating social share links');
+    }
+  },
+};
+
+export const socialSharingTools = [generateSocialShareLinksTool];


### PR DESCRIPTION
## Summary

Implements #129 — social sharing integration for the MCP server.

Adds a `generate_social_share_links` tool that produces per-network share URLs for an existing Nextcloud public-link share.

**Key finding:** the upstream `nextcloud/socialsharing` apps are frontend-only (each registers a sidebar button that opens a network share URL built from the public-share token) — there is no backend API. The tool therefore replicates those URL templates server-side.

## Details

- New `mcp-server/src/tools/apps/social-sharing.ts` — resolves a public-link share by `share_id` or `path` via the OCS shares API, builds URLs for email, X/Twitter, Facebook, Telegram, WhatsApp, Bluesky, Diaspora, and returns only the networks whose `socialsharing_<network>` app is enabled. Optional `networks` filter. Read-only (no auto-create).
- `tool-registry.ts` — registered under category `social_sharing`, gated (any-of) on the seven `socialsharing_*` app ids, so it appears only when at least one is installed.
- New `tools-social-sharing.test.ts` — 5 tests.

## Verification

- `npm run build` ✓
- `npm test` → 803 passed ✓
- `npm run lint` → 0 errors ✓
- `npx prettier --check src/` ✓

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)