### PR TITLE
feat(mcp): Passman integration (metadata only) (#130)

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.23",
+      "version": "0.3.24",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Nextcloud MCP server — files, calendar, contacts, mail, maps, notes, tasks & 120+ more tools",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,7 +18,7 @@
       ]
     }
   ],
-  "version": "0.3.23",
+  "version": "0.3.24",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "remotes": [
     {
@@ -36,7 +36,7 @@
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.23",
+      "version": "0.3.24",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -64,7 +64,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.23",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.24",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/__tests__/tools-passman.test.ts
+++ b/mcp-server/src/__tests__/tools-passman.test.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFetchPassmanAPI = vi.fn();
+vi.mock('../client/passman.js', () => ({
+  fetchPassmanAPI: (...args: unknown[]) => mockFetchPassmanAPI(...args),
+}));
+
+describe('Passman Tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXTCLOUD_URL = 'https://cloud.example.com';
+    process.env.NEXTCLOUD_USER = 'admin';
+    process.env.NEXTCLOUD_PASSWORD = 'testpass';
+  });
+
+  describe('passman_list_vaults', () => {
+    it('lists vaults with metadata', async () => {
+      mockFetchPassmanAPI.mockResolvedValue([
+        { vault_id: 1, guid: 'V1', name: 'Personal', created: 1700000000, last_access: 1700001000 },
+        { vault_id: 2, guid: 'V2', name: 'Work', created: 1700002000, last_access: 0 },
+      ]);
+
+      const { listVaultsTool } = await import('../tools/apps/passman.js');
+      const result = await listVaultsTool.handler();
+
+      expect(result.content[0].text).toContain('Vaults (2)');
+      expect(result.content[0].text).toContain('Personal');
+      expect(result.content[0].text).toContain('Work');
+      expect(result.content[0].text).toContain('end-to-end encrypted');
+    });
+
+    it('handles empty vault list', async () => {
+      mockFetchPassmanAPI.mockResolvedValue([]);
+      const { listVaultsTool } = await import('../tools/apps/passman.js');
+      const result = await listVaultsTool.handler();
+      expect(result.content[0].text).toBe('No vaults found.');
+    });
+  });
+
+  describe('passman_list_credentials', () => {
+    it('lists credential metadata without secret fields', async () => {
+      mockFetchPassmanAPI.mockResolvedValue({
+        guid: 'V1',
+        name: 'Personal',
+        credentials: [
+          {
+            credential_id: 10,
+            guid: 'C10',
+            vault_id: 1,
+            label: 'GitHub',
+            created: 1700000000,
+            changed: 1700000000,
+            url: 'ENCRYPTED_CIPHERTEXT_URL',
+            password: 'ENCRYPTED_CIPHERTEXT_PW',
+            username: 'ENCRYPTED_CIPHERTEXT_USER',
+            tags: ['x'],
+            compromised: true,
+          },
+        ],
+      });
+
+      const { listCredentialsTool } = await import('../tools/apps/passman.js');
+      const result = await listCredentialsTool.handler({ vault_guid: 'V1' });
+
+      expect(result.content[0].text).toContain('GitHub');
+      expect(result.content[0].text).toContain('has url');
+      expect(result.content[0].text).toContain('compromised');
+      // ciphertext / secret values must never leak
+      expect(result.content[0].text).not.toContain('ENCRYPTED_CIPHERTEXT');
+    });
+
+    it('handles empty vault', async () => {
+      mockFetchPassmanAPI.mockResolvedValue({ guid: 'V1', name: 'Personal', credentials: [] });
+      const { listCredentialsTool } = await import('../tools/apps/passman.js');
+      const result = await listCredentialsTool.handler({ vault_guid: 'V1' });
+      expect(result.content[0].text).toBe('No credentials in this vault.');
+    });
+
+    it('handles 404 via status map', async () => {
+      const { ApiError } = await import('../client/aiquila.js');
+      mockFetchPassmanAPI.mockRejectedValue(new ApiError(404, 'Not Found', ''));
+      const { listCredentialsTool } = await import('../tools/apps/passman.js');
+      const result = await listCredentialsTool.handler({ vault_guid: 'nope' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe('Not found.');
+    });
+  });
+
+  describe('passman_get_credential_info', () => {
+    it('returns metadata for a matching credential', async () => {
+      mockFetchPassmanAPI.mockResolvedValue({
+        guid: 'V1',
+        name: 'Personal',
+        credentials: [
+          {
+            credential_id: 10,
+            guid: 'C10',
+            vault_id: 1,
+            label: 'GitHub',
+            created: 1700000000,
+            changed: 1700000500,
+            password: 'ENCRYPTED_CIPHERTEXT_PW',
+          },
+        ],
+      });
+
+      const { getCredentialInfoTool } = await import('../tools/apps/passman.js');
+      const result = await getCredentialInfoTool.handler({
+        vault_guid: 'V1',
+        credential_guid: 'C10',
+      });
+
+      expect(result.content[0].text).toContain('# GitHub');
+      expect(result.content[0].text).toContain('ID: 10');
+      expect(result.content[0].text).not.toContain('ENCRYPTED_CIPHERTEXT');
+    });
+
+    it('errors when credential not in vault', async () => {
+      mockFetchPassmanAPI.mockResolvedValue({ guid: 'V1', name: 'Personal', credentials: [] });
+      const { getCredentialInfoTool } = await import('../tools/apps/passman.js');
+      const result = await getCredentialInfoTool.handler({
+        vault_guid: 'V1',
+        credential_guid: 'missing',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('not found');
+    });
+  });
+});

--- a/mcp-server/src/client/passman.ts
+++ b/mcp-server/src/client/passman.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+
+import { getNextcloudConfig } from '../tools/types.js';
+import { logger } from '../logger.js';
+import { ApiError } from './aiquila.js';
+
+/**
+ * Passman vault metadata.
+ *
+ * Note: the actual credential secrets are end-to-end encrypted client-side
+ * (SJCL AES-256) with a vault password that never reaches the server, so the
+ * server — and therefore this MCP integration — only ever sees ciphertext for
+ * sensitive fields.
+ */
+export interface PassmanVault {
+  vault_id: number;
+  guid: string;
+  name: string;
+  created: number;
+  last_access: number;
+  public_sharing_key?: string;
+  challenge_password?: string;
+  /** Present on GET /vaults/{guid} */
+  credentials?: PassmanCredential[];
+}
+
+/**
+ * Passman credential. Sensitive fields (password, username, url, email,
+ * description, custom_fields, otp, tags, files, icon) are client-side encrypted
+ * ciphertext and are intentionally NOT surfaced by this integration. Only
+ * `label` is plaintext.
+ */
+export interface PassmanCredential {
+  credential_id: number;
+  guid: string;
+  vault_id: number;
+  label: string;
+  created: number;
+  changed: number;
+  tags?: unknown;
+  url?: unknown;
+  renew_interval?: number;
+  expire_time?: number;
+  delete_time?: number;
+  hidden?: number | boolean;
+  shared_key?: string | null;
+  compromised?: boolean;
+}
+
+/**
+ * Make an authenticated request to the Nextcloud Passman REST API v2.
+ *
+ * Base path: /index.php/apps/passman/api/v2
+ */
+export async function fetchPassmanAPI<T = unknown>(
+  endpoint: string,
+  options: {
+    method?: string;
+    body?: unknown;
+    queryParams?: Record<string, string>;
+  } = {}
+): Promise<T> {
+  const config = getNextcloudConfig();
+  const auth = Buffer.from(`${config.user}:${config.password}`).toString('base64');
+
+  let url = `${config.url}/index.php/apps/passman/api/v2${endpoint}`;
+  if (options.queryParams) {
+    const params = new URLSearchParams(options.queryParams);
+    url += `?${params.toString()}`;
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Basic ${auth}`,
+    'OCS-APIRequest': 'true',
+    Accept: 'application/json',
+  };
+
+  let body: string | undefined;
+  if (options.body !== undefined) {
+    body = JSON.stringify(options.body);
+    headers['Content-Type'] = 'application/json';
+  }
+
+  const method = options.method ?? 'GET';
+  const t0 = Date.now();
+  const response = await fetch(url, { method, headers, body });
+  logger.trace({ method, url, status: response.status, ms: Date.now() - t0 }, '[passman] HTTP');
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new ApiError(response.status, response.statusText, text);
+  }
+
+  if (
+    response.status === 200 &&
+    response.headers.get('content-type')?.includes('application/json')
+  ) {
+    return (await response.json()) as T;
+  }
+
+  return undefined as T;
+}

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -48,6 +48,7 @@ import { formsTools } from './tools/apps/forms.js';
 import { textTools } from './tools/apps/text.js';
 import { recommendationsTools } from './tools/apps/recommendations.js';
 import { socialSharingTools } from './tools/apps/social-sharing.js';
+import { passmanTools } from './tools/apps/passman.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ToolArray = Array<{
@@ -102,6 +103,7 @@ export const TOOL_REGISTRY: ToolSetEntry[] = [
   { category: 'news', appIds: ['news'], tools: newsTools },
   { category: 'mail', appIds: ['mail'], tools: mailTools },
   { category: 'deck', appIds: ['deck'], tools: deckTools },
+  { category: 'passman', appIds: ['passman'], tools: passmanTools },
   { category: 'cookbook', appIds: ['cookbook'], tools: cookbookTools },
   { category: 'maps', appIds: ['maps'], tools: mapsTools },
   { category: 'photos', appIds: ['photos'], tools: photosTools },

--- a/mcp-server/src/tools/apps/passman.ts
+++ b/mcp-server/src/tools/apps/passman.ts
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+
+import { z } from 'zod';
+import {
+  fetchPassmanAPI,
+  type PassmanVault,
+  type PassmanCredential,
+} from '../../client/passman.js';
+import { ApiError } from '../../client/aiquila.js';
+import { handleAppError } from '../error-utils.js';
+
+/**
+ * Nextcloud Passman App Tools (password manager)
+ * Uses the Passman REST API v2 (/index.php/apps/passman/api/v2).
+ *
+ * IMPORTANT: Passman is zero-knowledge / end-to-end encrypted. Credential
+ * secrets (password, username, url, email, description, custom fields, OTP,
+ * tags, files) are encrypted client-side (SJCL AES-256) with a vault password
+ * that never reaches the server. This integration therefore exposes vault and
+ * credential *metadata only* (notably the plaintext `label`) and cannot decrypt
+ * or return any secret value.
+ */
+
+const passmanStatusMap: Record<number, string | ((e: ApiError) => string)> = {
+  404: 'Not found.',
+  403: 'Permission denied.',
+  400: (e) => `Bad request: ${e.responseBody}`,
+};
+
+const E2E_NOTE =
+  'Note: secret values (password, username, url, etc.) are end-to-end encrypted and cannot be retrieved by this server.';
+
+function formatVault(vault: PassmanVault): string {
+  const count = vault.credentials?.length ?? undefined;
+  const parts = [`guid: ${vault.guid}`];
+  if (count !== undefined) parts.push(`${count} credentials`);
+  parts.push(`created: ${new Date(vault.created * 1000).toISOString()}`);
+  if (vault.last_access) {
+    parts.push(`last access: ${new Date(vault.last_access * 1000).toISOString()}`);
+  }
+  return `${vault.name} (${parts.join(', ')})`;
+}
+
+function hasValue(v: unknown): boolean {
+  if (v === undefined || v === null || v === '') return false;
+  if (Array.isArray(v)) return v.length > 0;
+  return true;
+}
+
+function formatCredential(cred: PassmanCredential): string {
+  const flags: string[] = [];
+  if (hasValue(cred.url)) flags.push('has url');
+  if (hasValue(cred.tags)) flags.push('tagged');
+  if (cred.hidden) flags.push('hidden');
+  if (cred.compromised) flags.push('compromised');
+  if (cred.expire_time) {
+    flags.push(`expires: ${new Date(cred.expire_time * 1000).toISOString()}`);
+  }
+  const meta = [`guid: ${cred.guid}`, ...flags].join(', ');
+  return `[${cred.credential_id}] ${cred.label} (${meta})`;
+}
+
+export const listVaultsTool = {
+  name: 'passman_list_vaults',
+  description: `List all Passman password vaults. Returns name, guid, creation/last-access time and credential count. ${E2E_NOTE}`,
+  inputSchema: z.object({}),
+  handler: async () => {
+    try {
+      const vaults = await fetchPassmanAPI<PassmanVault[]>('/vaults');
+
+      if (!vaults || vaults.length === 0) {
+        return { content: [{ type: 'text' as const, text: 'No vaults found.' }] };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Vaults (${vaults.length}):\n\n${vaults.map(formatVault).join('\n')}\n\n${E2E_NOTE}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error listing vaults', passmanStatusMap);
+    }
+  },
+};
+
+export const listCredentialsTool = {
+  name: 'passman_list_credentials',
+  description: `List credentials (metadata only) in a Passman vault. Returns each credential's label, id, guid and non-secret flags. ${E2E_NOTE}`,
+  inputSchema: z.object({
+    vault_guid: z.string().describe('Vault GUID (from passman_list_vaults)'),
+  }),
+  handler: async (args: { vault_guid: string }) => {
+    try {
+      const vault = await fetchPassmanAPI<PassmanVault>(
+        `/vaults/${encodeURIComponent(args.vault_guid)}`
+      );
+      const creds = vault.credentials ?? [];
+
+      if (creds.length === 0) {
+        return { content: [{ type: 'text' as const, text: 'No credentials in this vault.' }] };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Credentials in "${vault.name}" (${creds.length}):\n\n${creds
+              .map(formatCredential)
+              .join('\n')}\n\n${E2E_NOTE}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return handleAppError(error, 'Error listing credentials', passmanStatusMap);
+    }
+  },
+};
+
+export const getCredentialInfoTool = {
+  name: 'passman_get_credential_info',
+  description: `Get non-secret metadata for a single Passman credential (label, id, timestamps, flags). ${E2E_NOTE}`,
+  inputSchema: z.object({
+    vault_guid: z.string().describe('Vault GUID (from passman_list_vaults)'),
+    credential_guid: z.string().describe('Credential GUID (from passman_list_credentials)'),
+  }),
+  handler: async (args: { vault_guid: string; credential_guid: string }) => {
+    try {
+      const vault = await fetchPassmanAPI<PassmanVault>(
+        `/vaults/${encodeURIComponent(args.vault_guid)}`
+      );
+      const cred = (vault.credentials ?? []).find((c) => c.guid === args.credential_guid);
+
+      if (!cred) {
+        return {
+          content: [{ type: 'text' as const, text: 'Credential not found in this vault.' }],
+          isError: true as const,
+        };
+      }
+
+      const lines: string[] = [
+        `# ${cred.label}`,
+        '',
+        `ID: ${cred.credential_id}`,
+        `GUID: ${cred.guid}`,
+        `Vault: ${vault.name}`,
+        `Created: ${new Date(cred.created * 1000).toISOString()}`,
+        `Changed: ${new Date(cred.changed * 1000).toISOString()}`,
+        `Has URL: ${hasValue(cred.url)}`,
+        `Tagged: ${hasValue(cred.tags)}`,
+        `Hidden: ${Boolean(cred.hidden)}`,
+        `Compromised: ${Boolean(cred.compromised)}`,
+      ];
+      if (cred.expire_time) {
+        lines.push(`Expires: ${new Date(cred.expire_time * 1000).toISOString()}`);
+      }
+      lines.push('', E2E_NOTE);
+
+      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+    } catch (error) {
+      return handleAppError(error, 'Error getting credential info', passmanStatusMap);
+    }
+  },
+};
+
+export const passmanTools = [listVaultsTool, listCredentialsTool, getCredentialInfoTool];

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.23</version>
+    <version>0.3.24</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
## Summary

Implements the Passman (Nextcloud password manager) MCP integration requested in #130.

**Important constraint — Passman is zero-knowledge / end-to-end encrypted.** Credential secrets (password, username, url, email, description, custom fields, OTP, tags, files) are encrypted client-side with SJCL AES-256 using a vault password that never reaches the server. Unlike a retrievable secret store (.NET user-secrets, Azure Key Vault), the server only ever holds opaque ciphertext.

Per the agreed scope, this is **metadata-only, read-only, no crypto**: it surfaces vault and credential metadata (notably the plaintext `label`) and never returns or attempts to decrypt any secret value.

## Tools added
- `passman_list_vaults` — list vaults (name, guid, created/last-access, credential count)
- `passman_list_credentials` — list credential metadata in a vault (label, id, guid, non-secret flags)
- `passman_get_credential_info` — non-secret metadata for a single credential

Each tool description states plainly that secrets are E2E-encrypted and cannot be retrieved.

## Implementation
- `mcp-server/src/client/passman.ts` — REST v2 client (`/index.php/apps/passman/api/v2`), mirrors the Deck client
- `mcp-server/src/tools/apps/passman.ts` — tool definitions, formatters exclude ciphertext fields
- `mcp-server/src/tool-registry.ts` — registered under app id `passman` (auto-detected when installed)
- `mcp-server/src/__tests__/tools-passman.test.ts` — 7 tests incl. assertion that ciphertext never leaks
- Version bump 0.3.23 → 0.3.24 (both components)

## Future extension (out of scope)
Actual secret retrieval would require an SJCL-compatible AES-CCM decrypt plus a `PASSMAN_VAULT_PASSWORD` env var verified against each vault's `challenge_password`.

## Verification
`npm run build` ✅ · `npm test` ✅ (810 passed) · `npm run lint` ✅ (0 errors) · `prettier --check` ✅

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)