### PR TITLE
feat(nextcloud): OpenMetrics exporter for usage and task stats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,10 @@ Commit messages follow **Conventional Commits** with scope:
 - `feat(nextcloud):` / `fix(nextcloud):` — Nextcloud app changes
 - `docs:` / `chore:` — cross-cutting changes
 
+To auto-close the issue a PR resolves, put a **closing keyword** in the PR description —
+`Closes #184` (or `Fixes #184` / `Resolves #184`). A bare mention like `(#184)` or
+`Implements GH #184` links the issue but does **not** close it on merge.
+
 ## Version Bumps
 
 All locations that must be updated on each release:

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ Complete documentation for the AIquila Nextcloud app and MCP server.
 - **[AIquila App Setup](installation/aiquila-setup.md)** — installation, configuration, and troubleshooting
 - **[Internal API Guide](internal-api.md)** — integrate AIquila AI (ask/summarize/analyze) into your own Nextcloud apps
 - **[Cowork Management API](cowork-api.md)** — register, steer and verify scheduled cowork jobs from your own Nextcloud app
+- **[Monitoring](monitoring.md)** — OpenMetrics / Prometheus export for usage and task metrics
 
 ## Deployment
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,79 @@
+# Monitoring — OpenMetrics / Prometheus
+
+The AIquila Nextcloud app exports usage and task-processing metrics in the
+[OpenMetrics](https://openmetrics.io/) format, so admins can monitor AI adoption,
+token spend and system health with Prometheus and Grafana.
+
+The metrics are served through Nextcloud's built-in `/metrics` endpoint
+(**Nextcloud 33+**). AIquila registers its exporters via `appinfo/info.xml`; no extra
+configuration is required once the app is installed.
+
+## Exported metrics
+
+All series are emitted by Nextcloud with a `nextcloud_` prefix. Values are aggregated
+**globally across all users** — there are no per-user labels (this keeps cardinality
+bounded and avoids exposing individual usage to anyone scraping the endpoint).
+
+| Series | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `nextcloud_aiquila_tokens_used_total` | counter | `model`, `request_type`, `direction` (`input`/`output`) | Total tokens consumed |
+| `nextcloud_aiquila_tasks_total` | counter | `status` | Coworker task runs processed |
+| `nextcloud_aiquila_conversations_total` | counter | — | Conversations created |
+| `nextcloud_aiquila_mcp_server_status` | gauge | `server_id`, `server` | Per MCP server: `1` = enabled and last connection healthy, `0` = disabled or failing |
+
+> The `aiquila_task_duration_seconds` histogram from the original proposal is tracked
+> as a follow-up.
+
+## Enabling the endpoint
+
+Nextcloud's `/metrics` endpoint is gated by an **IP allowlist**, not a token. Only the
+client ranges listed in the `openmetrics_allowed_clients` system config may scrape it
+(default: `127.0.0.0/16` and `::1/128`). Add the address range of your Prometheus host
+in `config.php`:
+
+```php
+'openmetrics_allowed_clients' => ['127.0.0.0/16', '::1/128', '10.0.0.0/24'],
+```
+
+or via OCC:
+
+```bash
+php occ config:system:set openmetrics_allowed_clients 0 --value='127.0.0.0/16'
+php occ config:system:set openmetrics_allowed_clients 1 --value='10.0.0.0/24'
+```
+
+The endpoint is then reachable at:
+
+```
+https://<your-nextcloud>/metrics
+```
+
+Verify AIquila series are present (run from an allowlisted host):
+
+```bash
+curl -s https://<your-nextcloud>/metrics | grep nextcloud_aiquila_
+```
+
+## Prometheus scrape config
+
+```yaml
+scrape_configs:
+  - job_name: nextcloud-aiquila
+    metrics_path: /metrics
+    scheme: https
+    static_configs:
+      - targets: ['your-nextcloud:443']
+```
+
+(Ensure the Prometheus host's source IP is covered by `openmetrics_allowed_clients`.)
+
+## Grafana
+
+Point Grafana at the Prometheus data source and build panels from the series above.
+Useful starting queries:
+
+- **Token spend rate** — `sum by (model) (rate(nextcloud_aiquila_tokens_used_total[1h]))`
+- **Task success ratio** —
+  `sum(nextcloud_aiquila_tasks_total{status="success"}) / sum(nextcloud_aiquila_tasks_total)`
+- **MCP server health** — `nextcloud_aiquila_mcp_server_status` (stat panel, mapped 1→up / 0→down)
+- **Conversations created** — `nextcloud_aiquila_conversations_total`

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.25</version>
+    <version>0.3.26</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>
@@ -73,6 +73,12 @@ Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](htt
         <command>OCA\AIquila\Command\McpAddCommand</command>
         <command>OCA\AIquila\Command\DoctorCommand</command>
     </commands>
+    <openmetrics>
+        <exporter>OCA\AIquila\OpenMetrics\TokensUsedExporter</exporter>
+        <exporter>OCA\AIquila\OpenMetrics\TasksExporter</exporter>
+        <exporter>OCA\AIquila\OpenMetrics\ConversationsExporter</exporter>
+        <exporter>OCA\AIquila\OpenMetrics\McpServerStatusExporter</exporter>
+    </openmetrics>
     <background-jobs>
         <job>OCA\AIquila\BackgroundJob\CleanupAnthropicFilesJob</job>
         <job>OCA\AIquila\BackgroundJob\CoworkerRunJob</job>

--- a/nextcloud-app/lib/Db/ConversationMapper.php
+++ b/nextcloud-app/lib/Db/ConversationMapper.php
@@ -50,4 +50,20 @@ class ConversationMapper extends QBMapper {
             ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)));
         $qb->executeStatement();
     }
+
+    /**
+     * Count all conversations across all users.
+     * Used for the server-global OpenMetrics export.
+     */
+    public function countAll(): int {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select($qb->func()->count('*', 'conversation_count'))
+            ->from($this->getTableName());
+
+        $result = $qb->executeQuery();
+        $row = $result->fetch();
+        $result->closeCursor();
+
+        return (int)($row['conversation_count'] ?? 0);
+    }
 }

--- a/nextcloud-app/lib/Db/CoworkerRunMapper.php
+++ b/nextcloud-app/lib/Db/CoworkerRunMapper.php
@@ -49,6 +49,29 @@ class CoworkerRunMapper extends QBMapper {
     }
 
     /**
+     * Count all coworker runs grouped by status, across all users.
+     * Used for the server-global OpenMetrics export.
+     *
+     * @return array<string, int> status => count
+     */
+    public function countByStatus(): array {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('status')
+            ->selectAlias($qb->func()->count('*'), 'run_count')
+            ->from($this->getTableName())
+            ->groupBy('status');
+
+        $result = $qb->executeQuery();
+        $counts = [];
+        while ($row = $result->fetch()) {
+            $counts[(string)($row['status'] ?? '')] = (int)($row['run_count'] ?? 0);
+        }
+        $result->closeCursor();
+
+        return $counts;
+    }
+
+    /**
      * Delete all run history for a coworker (used when the coworker is removed).
      */
     public function deleteByCoworker(int $coworkerId): void {

--- a/nextcloud-app/lib/Db/UsageStatMapper.php
+++ b/nextcloud-app/lib/Db/UsageStatMapper.php
@@ -82,4 +82,33 @@ class UsageStatMapper extends QBMapper {
             'output_tokens' => (int)($row['total_output'] ?? 0),
         ];
     }
+
+    /**
+     * Aggregate token usage across all users, grouped by model and request type.
+     * Used for the server-global OpenMetrics export (no per-user breakdown).
+     *
+     * @return list<array{model: string, request_type: string, input_tokens: int, output_tokens: int}>
+     */
+    public function sumTokensByModelAndType(): array {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('model', 'request_type')
+            ->selectAlias($qb->func()->sum('input_tokens'), 'total_input')
+            ->selectAlias($qb->func()->sum('output_tokens'), 'total_output')
+            ->from($this->getTableName())
+            ->groupBy('model', 'request_type');
+
+        $result = $qb->executeQuery();
+        $rows = [];
+        while ($row = $result->fetch()) {
+            $rows[] = [
+                'model' => (string)($row['model'] ?? ''),
+                'request_type' => (string)($row['request_type'] ?? ''),
+                'input_tokens' => (int)($row['total_input'] ?? 0),
+                'output_tokens' => (int)($row['total_output'] ?? 0),
+            ];
+        }
+        $result->closeCursor();
+
+        return $rows;
+    }
 }

--- a/nextcloud-app/lib/OpenMetrics/ConversationsExporter.php
+++ b/nextcloud-app/lib/OpenMetrics/ConversationsExporter.php
@@ -1,0 +1,48 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\OpenMetrics;
+
+use Generator;
+use OCA\AIquila\Db\ConversationMapper;
+use OCP\OpenMetrics\IMetricFamily;
+use OCP\OpenMetrics\Metric;
+use OCP\OpenMetrics\MetricType;
+use Override;
+
+/**
+ * Exports the total number of conversations created across all users.
+ */
+class ConversationsExporter implements IMetricFamily {
+    public function __construct(
+        private ConversationMapper $conversationMapper,
+    ) {
+    }
+
+    #[Override]
+    public function name(): string {
+        return 'aiquila_conversations_total';
+    }
+
+    #[Override]
+    public function type(): MetricType {
+        return MetricType::counter;
+    }
+
+    #[Override]
+    public function unit(): string {
+        return '';
+    }
+
+    #[Override]
+    public function help(): string {
+        return 'Total AIquila conversations created.';
+    }
+
+    #[Override]
+    public function metrics(): Generator {
+        yield new Metric($this->conversationMapper->countAll());
+    }
+}

--- a/nextcloud-app/lib/OpenMetrics/McpServerStatusExporter.php
+++ b/nextcloud-app/lib/OpenMetrics/McpServerStatusExporter.php
@@ -1,0 +1,55 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\OpenMetrics;
+
+use Generator;
+use OCA\AIquila\Db\McpServerMapper;
+use OCP\OpenMetrics\IMetricFamily;
+use OCP\OpenMetrics\Metric;
+use OCP\OpenMetrics\MetricType;
+use Override;
+
+/**
+ * Exports the connectivity status of each configured MCP server as a gauge
+ * (1 = enabled and last connection healthy, 0 = disabled or last connection failed).
+ */
+class McpServerStatusExporter implements IMetricFamily {
+    public function __construct(
+        private McpServerMapper $mcpServerMapper,
+    ) {
+    }
+
+    #[Override]
+    public function name(): string {
+        return 'aiquila_mcp_server_status';
+    }
+
+    #[Override]
+    public function type(): MetricType {
+        return MetricType::gauge;
+    }
+
+    #[Override]
+    public function unit(): string {
+        return '';
+    }
+
+    #[Override]
+    public function help(): string {
+        return 'AIquila MCP server connectivity (1 = enabled and healthy, 0 = disabled or failing).';
+    }
+
+    #[Override]
+    public function metrics(): Generator {
+        foreach ($this->mcpServerMapper->findAll() as $server) {
+            $up = $server->getIsEnabled() && $server->getLastStatus() === 'ok';
+            yield new Metric($up ? 1 : 0, [
+                'server_id' => (string)$server->getId(),
+                'server' => $server->getDisplayName(),
+            ]);
+        }
+    }
+}

--- a/nextcloud-app/lib/OpenMetrics/TasksExporter.php
+++ b/nextcloud-app/lib/OpenMetrics/TasksExporter.php
@@ -1,0 +1,51 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\OpenMetrics;
+
+use Generator;
+use OCA\AIquila\Db\CoworkerRunMapper;
+use OCP\OpenMetrics\IMetricFamily;
+use OCP\OpenMetrics\Metric;
+use OCP\OpenMetrics\MetricType;
+use Override;
+
+/**
+ * Exports the total number of coworker (task) runs processed, labelled by status,
+ * aggregated across all users.
+ */
+class TasksExporter implements IMetricFamily {
+    public function __construct(
+        private CoworkerRunMapper $coworkerRunMapper,
+    ) {
+    }
+
+    #[Override]
+    public function name(): string {
+        return 'aiquila_tasks_total';
+    }
+
+    #[Override]
+    public function type(): MetricType {
+        return MetricType::counter;
+    }
+
+    #[Override]
+    public function unit(): string {
+        return '';
+    }
+
+    #[Override]
+    public function help(): string {
+        return 'Total AIquila coworker task runs processed, by status.';
+    }
+
+    #[Override]
+    public function metrics(): Generator {
+        foreach ($this->coworkerRunMapper->countByStatus() as $status => $count) {
+            yield new Metric($count, ['status' => $status]);
+        }
+    }
+}

--- a/nextcloud-app/lib/OpenMetrics/TokensUsedExporter.php
+++ b/nextcloud-app/lib/OpenMetrics/TokensUsedExporter.php
@@ -1,0 +1,61 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\OpenMetrics;
+
+use Generator;
+use OCA\AIquila\Db\UsageStatMapper;
+use OCP\OpenMetrics\IMetricFamily;
+use OCP\OpenMetrics\Metric;
+use OCP\OpenMetrics\MetricType;
+use Override;
+
+/**
+ * Exports total token consumption across all users, broken down by model,
+ * request type and direction (input/output). Aggregated globally — no per-user
+ * labels — to keep cardinality bounded and avoid exposing per-user usage.
+ */
+class TokensUsedExporter implements IMetricFamily {
+    public function __construct(
+        private UsageStatMapper $usageStatMapper,
+    ) {
+    }
+
+    #[Override]
+    public function name(): string {
+        return 'aiquila_tokens_used_total';
+    }
+
+    #[Override]
+    public function type(): MetricType {
+        return MetricType::counter;
+    }
+
+    #[Override]
+    public function unit(): string {
+        return '';
+    }
+
+    #[Override]
+    public function help(): string {
+        return 'Total AIquila tokens consumed, by model, request type and direction.';
+    }
+
+    #[Override]
+    public function metrics(): Generator {
+        foreach ($this->usageStatMapper->sumTokensByModelAndType() as $row) {
+            yield new Metric($row['input_tokens'], [
+                'model' => $row['model'],
+                'request_type' => $row['request_type'],
+                'direction' => 'input',
+            ]);
+            yield new Metric($row['output_tokens'], [
+                'model' => $row['model'],
+                'request_type' => $row['request_type'],
+                'direction' => 'output',
+            ]);
+        }
+    }
+}

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",

--- a/nextcloud-app/tests/Unit/Db/ConversationMapperTest.php
+++ b/nextcloud-app/tests/Unit/Db/ConversationMapperTest.php
@@ -74,4 +74,22 @@ class ConversationMapperTest extends MapperTestCase {
         $mapper->method('findEntities')->willReturn([]);
         $mapper->findAllByUser('alice');
     }
+
+    public function testCountAllReturnsCount(): void {
+        $this->qb->method('executeQuery')->willReturn($this->result);
+        $this->result->method('fetch')->willReturn(['conversation_count' => '42']);
+        $this->result->method('closeCursor')->willReturn(true);
+
+        $mapper = new ConversationMapper($this->db);
+        $this->assertSame(42, $mapper->countAll());
+    }
+
+    public function testCountAllReturnsZeroWhenNoRow(): void {
+        $this->qb->method('executeQuery')->willReturn($this->result);
+        $this->result->method('fetch')->willReturn(false);
+        $this->result->method('closeCursor')->willReturn(true);
+
+        $mapper = new ConversationMapper($this->db);
+        $this->assertSame(0, $mapper->countAll());
+    }
 }

--- a/nextcloud-app/tests/Unit/Db/CoworkerRunMapperTest.php
+++ b/nextcloud-app/tests/Unit/Db/CoworkerRunMapperTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Tests\Unit\Db;
+
+use OCA\AIquila\Db\CoworkerRunMapper;
+
+class CoworkerRunMapperTest extends MapperTestCase {
+
+    public function testTableName(): void {
+        $this->qb->expects($this->once())
+            ->method('from')
+            ->with('aiquila_coworker_runs')
+            ->willReturnSelf();
+
+        $this->qb->method('executeQuery')->willReturn($this->result);
+        $this->result->method('fetch')->willReturn(false);
+        $this->result->method('closeCursor')->willReturn(true);
+
+        $mapper = new CoworkerRunMapper($this->db);
+        $mapper->countByStatus();
+    }
+
+    public function testCountByStatusGroupsRows(): void {
+        $this->qb->method('executeQuery')->willReturn($this->result);
+        $this->result->method('fetch')->willReturnOnConsecutiveCalls(
+            ['status' => 'success', 'run_count' => '7'],
+            ['status' => 'error', 'run_count' => '2'],
+            false,
+        );
+        $this->result->method('closeCursor')->willReturn(true);
+
+        $mapper = new CoworkerRunMapper($this->db);
+        $this->assertSame(['success' => 7, 'error' => 2], $mapper->countByStatus());
+    }
+
+    public function testCountByStatusEmpty(): void {
+        $this->qb->method('executeQuery')->willReturn($this->result);
+        $this->result->method('fetch')->willReturn(false);
+        $this->result->method('closeCursor')->willReturn(true);
+
+        $mapper = new CoworkerRunMapper($this->db);
+        $this->assertSame([], $mapper->countByStatus());
+    }
+}

--- a/nextcloud-app/tests/Unit/Db/MapperTestCase.php
+++ b/nextcloud-app/tests/Unit/Db/MapperTestCase.php
@@ -35,8 +35,8 @@ abstract class MapperTestCase extends TestCase {
         $this->db->method('getQueryBuilder')->willReturn($this->qb);
 
         // Stub the entire fluent IQueryBuilder chain
-        foreach (['select', 'from', 'where', 'andWhere', 'orderBy',
-                  'setMaxResults', 'setFirstResult', 'delete'] as $method) {
+        foreach (['select', 'selectAlias', 'from', 'where', 'andWhere', 'orderBy',
+                  'groupBy', 'setMaxResults', 'setFirstResult', 'delete'] as $method) {
             $this->qb->method($method)->willReturnSelf();
         }
 
@@ -47,6 +47,8 @@ abstract class MapperTestCase extends TestCase {
 
         $this->expr->method('eq')->willReturn('1=1');
         $this->expr->method('lte')->willReturn('1<=1');
-        $this->func->method('sum')->willReturnArgument(1); // returns alias
+        $this->expr->method('gte')->willReturn('1>=1');
+        $this->func->method('sum')->willReturnArgument(0); // returns expression
+        $this->func->method('count')->willReturnArgument(0); // returns expression
     }
 }

--- a/nextcloud-app/tests/Unit/Db/UsageStatMapperTest.php
+++ b/nextcloud-app/tests/Unit/Db/UsageStatMapperTest.php
@@ -97,6 +97,33 @@ class UsageStatMapperTest extends MapperTestCase {
         $this->assertEquals(['input_tokens' => 0, 'output_tokens' => 0, 'cache_creation_tokens' => 0, 'cache_read_tokens' => 0], $totals);
     }
 
+    public function testSumTokensByModelAndTypeAggregatesRows(): void {
+        $this->qb->method('executeQuery')->willReturn($this->result);
+        $this->result->method('fetch')->willReturnOnConsecutiveCalls(
+            ['model' => 'claude-opus-4-8', 'request_type' => 'chat', 'total_input' => '1000', 'total_output' => '500'],
+            ['model' => 'claude-haiku-4-5', 'request_type' => 'summary', 'total_input' => '20', 'total_output' => '10'],
+            false,
+        );
+        $this->result->method('closeCursor')->willReturn(true);
+
+        $mapper = new UsageStatMapper($this->db);
+        $rows = $mapper->sumTokensByModelAndType();
+
+        $this->assertSame([
+            ['model' => 'claude-opus-4-8', 'request_type' => 'chat', 'input_tokens' => 1000, 'output_tokens' => 500],
+            ['model' => 'claude-haiku-4-5', 'request_type' => 'summary', 'input_tokens' => 20, 'output_tokens' => 10],
+        ], $rows);
+    }
+
+    public function testSumTokensByModelAndTypeEmpty(): void {
+        $this->qb->method('executeQuery')->willReturn($this->result);
+        $this->result->method('fetch')->willReturn(false);
+        $this->result->method('closeCursor')->willReturn(true);
+
+        $mapper = new UsageStatMapper($this->db);
+        $this->assertSame([], $mapper->sumTokensByModelAndType());
+    }
+
     public function testTableName(): void {
         $this->qb->expects($this->once())
             ->method('from')

--- a/nextcloud-app/tests/Unit/OpenMetrics/ExportersTest.php
+++ b/nextcloud-app/tests/Unit/OpenMetrics/ExportersTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Tests\Unit\OpenMetrics;
+
+use OCA\AIquila\Db\Conversation;
+use OCA\AIquila\Db\ConversationMapper;
+use OCA\AIquila\Db\CoworkerRunMapper;
+use OCA\AIquila\Db\McpServer;
+use OCA\AIquila\Db\McpServerMapper;
+use OCA\AIquila\Db\UsageStatMapper;
+use OCA\AIquila\OpenMetrics\ConversationsExporter;
+use OCA\AIquila\OpenMetrics\McpServerStatusExporter;
+use OCA\AIquila\OpenMetrics\TasksExporter;
+use OCA\AIquila\OpenMetrics\TokensUsedExporter;
+use OCP\OpenMetrics\Metric;
+use OCP\OpenMetrics\MetricType;
+use PHPUnit\Framework\TestCase;
+
+class ExportersTest extends TestCase {
+
+    /**
+     * @param iterable<Metric> $metrics
+     * @return Metric[]
+     */
+    private function collect(iterable $metrics): array {
+        return iterator_to_array($metrics, false);
+    }
+
+    public function testTokensUsedExporter(): void {
+        $mapper = $this->createMock(UsageStatMapper::class);
+        $mapper->method('sumTokensByModelAndType')->willReturn([
+            ['model' => 'claude-opus-4-8', 'request_type' => 'chat', 'input_tokens' => 1000, 'output_tokens' => 500],
+        ]);
+
+        $exporter = new TokensUsedExporter($mapper);
+        $this->assertSame('aiquila_tokens_used_total', $exporter->name());
+        $this->assertSame(MetricType::counter, $exporter->type());
+
+        $metrics = $this->collect($exporter->metrics());
+        $this->assertCount(2, $metrics);
+        $this->assertSame(1000, $metrics[0]->value);
+        $this->assertSame('input', $metrics[0]->label('direction'));
+        $this->assertSame('claude-opus-4-8', $metrics[0]->label('model'));
+        $this->assertSame(500, $metrics[1]->value);
+        $this->assertSame('output', $metrics[1]->label('direction'));
+    }
+
+    public function testTasksExporter(): void {
+        $mapper = $this->createMock(CoworkerRunMapper::class);
+        $mapper->method('countByStatus')->willReturn(['success' => 7, 'error' => 2]);
+
+        $exporter = new TasksExporter($mapper);
+        $this->assertSame('aiquila_tasks_total', $exporter->name());
+        $this->assertSame(MetricType::counter, $exporter->type());
+
+        $metrics = $this->collect($exporter->metrics());
+        $this->assertCount(2, $metrics);
+        $this->assertSame(7, $metrics[0]->value);
+        $this->assertSame('success', $metrics[0]->label('status'));
+    }
+
+    public function testConversationsExporter(): void {
+        $mapper = $this->createMock(ConversationMapper::class);
+        $mapper->method('countAll')->willReturn(42);
+
+        $exporter = new ConversationsExporter($mapper);
+        $this->assertSame('aiquila_conversations_total', $exporter->name());
+
+        $metrics = $this->collect($exporter->metrics());
+        $this->assertCount(1, $metrics);
+        $this->assertSame(42, $metrics[0]->value);
+    }
+
+    public function testMcpServerStatusExporter(): void {
+        $up = $this->makeServer(1, 'Calendars', true, 'ok');
+        $down = $this->makeServer(2, 'Mail', true, 'error');
+        $disabled = $this->makeServer(3, 'Notes', false, 'ok');
+
+        $mapper = $this->createMock(McpServerMapper::class);
+        $mapper->method('findAll')->willReturn([$up, $down, $disabled]);
+
+        $exporter = new McpServerStatusExporter($mapper);
+        $this->assertSame('aiquila_mcp_server_status', $exporter->name());
+        $this->assertSame(MetricType::gauge, $exporter->type());
+
+        $metrics = $this->collect($exporter->metrics());
+        $this->assertCount(3, $metrics);
+        $this->assertSame(1, $metrics[0]->value);
+        $this->assertSame('Calendars', $metrics[0]->label('server'));
+        $this->assertSame(0, $metrics[1]->value); // enabled but failing
+        $this->assertSame(0, $metrics[2]->value); // disabled
+    }
+
+    private function makeServer(int $id, string $name, bool $enabled, string $status): McpServer {
+        $server = new McpServer();
+        $server->setId($id);
+        $server->setDisplayName($name);
+        $server->setIsEnabled($enabled);
+        $server->setLastStatus($status);
+        return $server;
+    }
+}

--- a/nextcloud-app/tests/bootstrap.php
+++ b/nextcloud-app/tests/bootstrap.php
@@ -179,6 +179,8 @@ if (!class_exists('OCP\AppFramework\Db\Entity')) {
 
         public function getFieldTypes(): array { return $this->_types; }
 
+        protected function markFieldUpdated(string $attribute): void {}
+
         public function jsonSerialize(): array {
             $out = ['id' => $this->id];
             foreach (array_keys($this->_types) as $field) {
@@ -217,7 +219,8 @@ if (!interface_exists('OCP\DB\QueryBuilder\IExpressionBuilder')) {
 
 if (!interface_exists('OCP\DB\QueryBuilder\IFunctionBuilder')) {
     interface OCP_DB_QueryBuilder_IFunctionBuilder {
-        public function sum(string $column, string $alias): string;
+        public function sum(string $column, ?string $alias = null): string;
+        public function count(string $column, ?string $alias = null): string;
     }
     class_alias('OCP_DB_QueryBuilder_IFunctionBuilder', 'OCP\DB\QueryBuilder\IFunctionBuilder');
 }
@@ -238,6 +241,8 @@ if (!interface_exists('OCP\DB\QueryBuilder\IQueryBuilder')) {
         const PARAM_BOOL = 5;
 
         public function select(mixed ...$selects): static;
+        public function selectAlias(mixed $select, string $alias): static;
+        public function groupBy(mixed ...$groupBy): static;
         public function from(string $from, ?string $alias = null): static;
         public function where(mixed $predicate): static;
         public function andWhere(mixed $predicate): static;
@@ -711,4 +716,61 @@ if (!interface_exists('OCP\Dashboard\IButtonWidget')) {
         public function getWidgetButtons(string $userId): array;
     }
     class_alias('OCP_Dashboard_IButtonWidget', 'OCP\Dashboard\IButtonWidget');
+}
+
+// ── OCP\OpenMetrics (Nextcloud 33+) ───────────────────────────────────────
+
+if (!enum_exists('OCP\OpenMetrics\MetricType')) {
+    enum OCP_OpenMetrics_MetricType {
+        case counter;
+        case gauge;
+        case histogram;
+        case gaugehistogram;
+        case stateset;
+        case info;
+        case summary;
+        case unknown;
+    }
+    class_alias('OCP_OpenMetrics_MetricType', 'OCP\OpenMetrics\MetricType');
+}
+
+if (!enum_exists('OCP\OpenMetrics\MetricValue')) {
+    enum OCP_OpenMetrics_MetricValue: string {
+        case NOT_A_NUMBER = 'NaN';
+        case POSITIVE_INFINITY = '+Inf';
+        case NEGATIVE_INFINITY = '-Inf';
+    }
+    class_alias('OCP_OpenMetrics_MetricValue', 'OCP\OpenMetrics\MetricValue');
+}
+
+if (!class_exists('OCP\OpenMetrics\Metric')) {
+    final readonly class OCP_OpenMetrics_Metric {
+        public function __construct(
+            public int|float|bool|\OCP\OpenMetrics\MetricValue $value = false,
+            public array $labels = [],
+            public int|float|null $timestamp = null,
+        ) {
+            foreach (array_keys($this->labels) as $label) {
+                if (preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', (string)$label) !== 1) {
+                    throw new \InvalidArgumentException('Invalid OpenMetrics label name: "' . $label . '"');
+                }
+            }
+        }
+
+        public function label(string $name): ?string {
+            return $this->labels[$name] ?? null;
+        }
+    }
+    class_alias('OCP_OpenMetrics_Metric', 'OCP\OpenMetrics\Metric');
+}
+
+if (!interface_exists('OCP\OpenMetrics\IMetricFamily')) {
+    interface OCP_OpenMetrics_IMetricFamily {
+        public function name(): string;
+        public function type(): \OCP\OpenMetrics\MetricType;
+        public function unit(): string;
+        public function help(): string;
+        public function metrics(): \Generator;
+    }
+    class_alias('OCP_OpenMetrics_IMetricFamily', 'OCP\OpenMetrics\IMetricFamily');
 }


### PR DESCRIPTION
## Summary

Exposes AIquila usage and task-processing metrics in OpenMetrics format via Nextcloud 33's built-in `/metrics` endpoint, so admins can monitor AI adoption, token spend and system health with Prometheus/Grafana.

Implements four `OCP\OpenMetrics\IMetricFamily` exporters registered in `appinfo/info.xml`:

| Series | Type | Labels |
|--------|------|--------|
| `nextcloud_aiquila_tokens_used_total` | counter | `model`, `request_type`, `direction` |
| `nextcloud_aiquila_tasks_total` | counter | `status` |
| `nextcloud_aiquila_conversations_total` | counter | — |
| `nextcloud_aiquila_mcp_server_status` | gauge | `server_id`, `server` |

Backed by new **global aggregate** mapper queries (`sumTokensByModelAndType`, `countByStatus`, `countAll`). Metrics are aggregated across all users — **no per-user labels** — to bound cardinality and avoid exposing individual usage to scrapers.

### Notes
- NC 33's real API is `<openmetrics>` exporters in `info.xml` implementing `IMetricFamily` — not the `IMetricsProvider` the issue text guessed. No `Application.php` change is needed.
- The `/metrics` endpoint is gated by an **IP allowlist** (`openmetrics_allowed_clients`), not a token — documented in `docs/monitoring.md`.
- `mcp_server_status` reflects each server's last stored `lastStatus`, not a live probe at scrape time (a live check per scrape would be too expensive).
- The `aiquila_task_duration_seconds` histogram from the original proposal is deferred to a follow-up.

## Testing

- `vendor/bin/phpunit` — full suite green (397 tests). Added exporter tests + new mapper-method tests, plus OCP OpenMetrics stubs in `tests/bootstrap.php`.
- Verified end-to-end on the dev stack (`docker/installation`): app upgraded to 0.3.26, `/metrics` returns HTTP 200 with all four `# TYPE`/`# HELP` blocks and live `nextcloud_aiquila_conversations_total 3`. No exporter errors in the NC log.

## Version

Bumped Nextcloud app + frontend to **0.3.26** (patch).

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)