### PR TITLE
fix(mcp): warn loudly when app detection falls back to all tools

### DIFF
--- a/mcp-server/src/__tests__/tool-registry.test.ts
+++ b/mcp-server/src/__tests__/tool-registry.test.ts
@@ -24,7 +24,25 @@ vi.mock('../client/bookmarks.js', () => ({
   fetchBookmarksAPI: vi.fn(),
 }));
 
-import { getFilteredToolSets, _resetCache, TOOL_REGISTRY } from '../tool-registry.js';
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { logger } from '../logger.js';
+import {
+  getFilteredToolSets,
+  _resetCache,
+  TOOL_REGISTRY,
+  HIGH_TOOL_COUNT,
+} from '../tool-registry.js';
+
+/** Concatenated text of every logger.warn call, for message assertions. */
+function warnText(): string {
+  return vi
+    .mocked(logger.warn)
+    .mock.calls.map((call) => call.map((arg) => String(arg)).join(' '))
+    .join('\n');
+}
 
 function flatToolNames(toolSets: Array<Array<{ name: string }>>): string[] {
   return toolSets.flatMap((ts) => ts.map((t) => t.name));
@@ -41,6 +59,8 @@ describe('tool-registry', () => {
     delete process.env.MCP_TOOLS;
     _resetCache();
     mockFetchOCS.mockReset();
+    vi.mocked(logger.warn).mockClear();
+    vi.mocked(logger.info).mockClear();
   });
 
   afterEach(() => {
@@ -130,6 +150,66 @@ describe('tool-registry', () => {
       const names = flatToolNames(result);
       const allToolCount = TOOL_REGISTRY.reduce((sum, e) => sum + e.tools.length, 0);
       expect(names.length).toBe(allToolCount);
+    });
+
+    // /ocs/v2.php/cloud/apps is admin-only, so a non-admin NEXTCLOUD_USER always lands in the
+    // fallback and silently gets every tool. Regression guard for #384 / #385.
+    it.each([
+      ['403', 'OCS request failed: 403 Forbidden'],
+      ['401', 'OCS request failed: 401 Unauthorized'],
+    ])('should fall back to all tools when detection is rejected with %s', async (_label, msg) => {
+      mockFetchOCS.mockRejectedValue(new Error(msg));
+
+      const result = await getFilteredToolSets();
+      const allToolCount = TOOL_REGISTRY.reduce((sum, e) => sum + e.tools.length, 0);
+      expect(flatToolNames(result).length).toBe(allToolCount);
+    });
+
+    it('should warn actionably when detection fails', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('OCS request failed: 403 Forbidden'));
+
+      await getFilteredToolSets();
+
+      const text = warnText();
+      expect(text).toMatch(/admin/i);
+      expect(text).toContain('MCP_TOOLS');
+    });
+
+    it('should warn when the registered tool count is high', async () => {
+      mockFetchOCS.mockRejectedValue(new Error('OCS request failed: 403 Forbidden'));
+
+      await getFilteredToolSets();
+
+      const highCountWarn = vi
+        .mocked(logger.warn)
+        .mock.calls.find((call) => (call[0] as { threshold?: number })?.threshold);
+      expect(highCountWarn).toBeDefined();
+      expect(highCountWarn?.[0]).toMatchObject({
+        threshold: HIGH_TOOL_COUNT,
+        source: 'all (fallback)',
+      });
+    });
+
+    it('should not warn about tool count for a small MCP_TOOLS whitelist', async () => {
+      process.env.MCP_TOOLS = 'files,status';
+
+      const result = await getFilteredToolSets();
+
+      expect(flatToolNames(result).length).toBeLessThanOrEqual(HIGH_TOOL_COUNT);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    // MCP_TOOLS is the documented workaround for non-admin users: it short-circuits detection
+    // entirely, so a failing (or forbidden) /cloud/apps never matters.
+    it('should honour MCP_TOOLS without calling detection even when it would fail', async () => {
+      process.env.MCP_TOOLS = 'calendar';
+      mockFetchOCS.mockRejectedValue(new Error('OCS request failed: 403 Forbidden'));
+
+      const names = flatToolNames(await getFilteredToolSets());
+
+      expect(mockFetchOCS).not.toHaveBeenCalled();
+      expect(names).toContain('list_calendars');
+      expect(names).not.toContain('deck_list_boards');
     });
 
     it('should detect spreed app for talk tools', async () => {

--- a/mcp-server/src/__tests__/transports.test.ts
+++ b/mcp-server/src/__tests__/transports.test.ts
@@ -137,6 +137,24 @@ describe('http transport', () => {
     expect(mockAll).toHaveBeenCalledWith('/mcp', expect.any(Function));
   });
 
+  // Stateless mode makes the SDK answer `GET /mcp` with 405, because it does not offer the
+  // optional server→client SSE stream. That is spec-compliant and the SDK *client* tolerates it
+  // (streamableHttp.js: "405 indicates that the server does not offer an SSE stream at GET
+  // endpoint"). Pinned so a future change doesn't add a session-backed GET stream in response to
+  // a 405 sighting in devtools — see #384, where that 405 was a red herring.
+  it('should construct the transport in stateless mode (no session id generator)', async () => {
+    const { StreamableHTTPServerTransport } =
+      await import('@modelcontextprotocol/sdk/server/streamableHttp.js');
+    const { startHttp } = await import('../transports/http.js');
+    await startHttp();
+
+    const mcpCall = mockAll.mock.calls.find((c) => c[0] === '/mcp');
+    const handler = mcpCall?.[1] as (req: unknown, res: unknown) => Promise<void>;
+    await handler({ body: {} }, { on: vi.fn() });
+
+    expect(StreamableHTTPServerTransport).toHaveBeenCalledWith({ sessionIdGenerator: undefined });
+  });
+
   it('should listen on default port 3339', async () => {
     delete process.env.MCP_PORT;
     const { startHttp } = await import('../transports/http.js');

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -183,7 +183,10 @@ async function detectEnabledApps(): Promise<Set<string> | null> {
   } catch (err) {
     logger.warn(
       { err: err instanceof Error ? err.message : String(err) },
-      '[startup] Could not detect enabled apps — registering all tools'
+      '[startup] Could not detect enabled apps — registering ALL tools as a fallback. ' +
+        '/ocs/v2.php/cloud/apps requires admin credentials; a non-admin NEXTCLOUD_USER always ' +
+        'lands here. Set MCP_TOOLS to an explicit category/tool whitelist, or use an admin app ' +
+        'password, to register only the tools you need.'
     );
     return null;
   }
@@ -228,6 +231,17 @@ function filterByEnabledApps(enabledApps: Set<string> | null): ToolArray[] {
 let cachedToolSets: ToolArray[] | null = null;
 
 /**
+ * Tool count above which we warn. Not a protocol limit — no MCP client documents one —
+ * but very large tool lists are worth flagging, and reaching this number usually means
+ * app-detection fell back to registering everything.
+ */
+export const HIGH_TOOL_COUNT = 100;
+
+function countTools(toolSets: ToolArray[]): number {
+  return toolSets.reduce((sum, ts) => sum + ts.length, 0);
+}
+
+/**
  * Returns filtered tool arrays based on MCP_TOOLS env var or auto-detection.
  * Result is cached after first call.
  */
@@ -235,18 +249,25 @@ export async function getFilteredToolSets(): Promise<ToolArray[]> {
   if (cachedToolSets) return cachedToolSets;
 
   const mcpToolsFilter = parseMcpTools();
+  let source: string;
 
   if (mcpToolsFilter) {
     cachedToolSets = filterByExplicitList(mcpToolsFilter);
-    const toolCount = cachedToolSets.reduce((sum, ts) => sum + ts.length, 0);
-    logger.info({ tools: toolCount, source: 'MCP_TOOLS' }, '[startup] Tool filtering applied');
+    source = 'MCP_TOOLS';
   } else {
     const enabledApps = await detectEnabledApps();
     cachedToolSets = filterByEnabledApps(enabledApps);
-    const toolCount = cachedToolSets.reduce((sum, ts) => sum + ts.length, 0);
-    logger.info(
-      { tools: toolCount, source: enabledApps ? 'app-detection' : 'all (fallback)' },
-      '[startup] Tool filtering applied'
+    source = enabledApps ? 'app-detection' : 'all (fallback)';
+  }
+
+  const toolCount = countTools(cachedToolSets);
+  logger.info({ tools: toolCount, source }, '[startup] Tool filtering applied');
+
+  if (toolCount > HIGH_TOOL_COUNT) {
+    logger.warn(
+      { tools: toolCount, threshold: HIGH_TOOL_COUNT, source },
+      `[startup] Registering ${toolCount} tools. Set MCP_TOOLS to a category/tool whitelist to ` +
+        'narrow this down — some clients degrade on very large tool lists.'
     );
   }
 


### PR DESCRIPTION
## Problem

`detectEnabledApps()` (`mcp-server/src/tool-registry.ts`) calls `/ocs/v2.php/cloud/apps?filter=enabled` to decide which tool categories to register. That OCS endpoint is **admin-only**.

When the configured `NEXTCLOUD_USER` is not an admin, the call 403s, the function returns `null`, and `getFilteredToolSets()` falls back to registering *every* tool in `TOOL_REGISTRY`. The only signal was one bland line:

```
[startup] Could not detect enabled apps — registering all tools
```

The cause (non-admin credentials) is nowhere near the consequence the user perceives. In #384 the reporter explicitly filed this warning under "What I've ruled out" as *"a harmless separate fallback warning, unrelated to this issue"* — while their server was registering the entire registry.

## Change

Logging only — tool-selection behavior is unchanged.

1. The `detectEnabledApps()` catch block now names the likely cause (the endpoint requires admin credentials) and the remedy (`MCP_TOOLS`, or an admin app password). It still returns `null`.
2. `getFilteredToolSets()` emits a `logger.warn` when the registered tool count exceeds the new exported `HIGH_TOOL_COUNT` (100), advising `MCP_TOOLS`. This covers both the auto-detection and `MCP_TOOLS` paths.

A large tool list is **not** confirmed to break any client, and no Anthropic doc states a tool-count limit — the warning is worded accordingly ("some clients degrade on very large tool lists"). This PR addresses the silent, misleading failure mode, not a proven downstream break.

## Tests

- `tool-registry.test.ts`: 401/403 both fall back to the full registry; the warning text mentions `admin` and `MCP_TOOLS`; the high-count warn carries `{ threshold, source: 'all (fallback)' }`; a small `MCP_TOOLS` whitelist produces no warn; `MCP_TOOLS` short-circuits detection entirely (`fetchOCS` never called).
- `transports.test.ts`: pins stateless transport construction (`sessionIdGenerator: undefined`). The `GET /mcp` → 405 seen in #384 is spec-compliant and tolerated by the SDK client — pinned so nobody "fixes" it by adding a session-backed GET stream.

`npm test` (817 passing), `npm run lint` (0 errors), and `npx prettier --check src/` all pass.

Closes #385

Context for #384 — that issue remains open; this does not fix the "no tools available" report, it only removes the misleading noise around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)