### PR TITLE
feat(mcp): add title + behaviour annotations to all tools

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.28",
+      "version": "0.3.29",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "description": "Nextcloud MCP server — files, calendar, contacts, mail, maps, notes, tasks & 120+ more tools",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,7 +18,7 @@
       ]
     }
   ],
-  "version": "0.3.28",
+  "version": "0.3.29",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "remotes": [
     {
@@ -36,7 +36,7 @@
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.28",
+      "version": "0.3.29",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -64,7 +64,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.28",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.29",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/__tests__/tool-registry.test.ts
+++ b/mcp-server/src/__tests__/tool-registry.test.ts
@@ -272,4 +272,56 @@ describe('tool-registry', () => {
       }
     });
   });
+
+  describe('tool annotations', () => {
+    const allTools = TOOL_REGISTRY.flatMap((e) => e.tools);
+
+    it('should register at least one tool', () => {
+      expect(allTools.length).toBeGreaterThan(0);
+    });
+
+    it('should have globally unique tool names', () => {
+      const names = allTools.map((t) => t.name);
+      const duplicates = names.filter((n, i) => names.indexOf(n) !== i);
+      expect(duplicates).toEqual([]);
+    });
+
+    // Anthropic's connector pre-submission checklist caps tool names at 64 chars.
+    it('should keep every tool name within 64 characters', () => {
+      const tooLong = allTools.filter((t) => t.name.length > 64).map((t) => t.name);
+      expect(tooLong).toEqual([]);
+    });
+
+    it('should give every tool a distinct, non-empty title', () => {
+      const bad = allTools
+        .filter((t) => !t.title || t.title.trim() === '' || t.title === t.name)
+        .map((t) => t.name);
+      expect(bad).toEqual([]);
+    });
+
+    it('should never mark a tool both read-only and destructive', () => {
+      const bad = allTools
+        .filter((t) => t.annotations.readOnlyHint && t.annotations.destructiveHint)
+        .map((t) => t.name);
+      expect(bad).toEqual([]);
+    });
+
+    it('should mark every read-only tool as idempotent', () => {
+      const bad = allTools
+        .filter((t) => t.annotations.readOnlyHint && !t.annotations.idempotentHint)
+        .map((t) => t.name);
+      expect(bad).toEqual([]);
+    });
+
+    it('should mark obvious readers read-only and obvious deleters destructive', () => {
+      const byName = new Map(allTools.map((t) => [t.name, t]));
+      for (const name of ['list_files', 'get_file_info', 'system_status', 'read_file']) {
+        expect(byName.get(name)?.annotations.readOnlyHint, name).toBe(true);
+      }
+      for (const name of ['delete', 'run_occ', 'write_file', 'empty_trash']) {
+        expect(byName.get(name)?.annotations.readOnlyHint, name).toBe(false);
+        expect(byName.get(name)?.annotations.destructiveHint, name).toBe(true);
+      }
+    });
+  });
 });

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -32,7 +32,9 @@ export async function createServer(): Promise<McpServer> {
       server.registerTool(
         name,
         {
+          title: tool.title,
           description: tool.description,
+          annotations: tool.annotations,
           inputSchema: tool.inputSchema as any,
         },
         async (...args: unknown[]) => {

--- a/mcp-server/src/tool-registry.ts
+++ b/mcp-server/src/tool-registry.ts
@@ -2,6 +2,7 @@
 
 import { fetchOCS } from './client/ocs.js';
 import { logger } from './logger.js';
+import type { Tool } from './tools/types.js';
 
 // System tools (always available)
 import { fileSystemTools } from './tools/system/files.js';
@@ -50,13 +51,7 @@ import { recommendationsTools } from './tools/apps/recommendations.js';
 import { socialSharingTools } from './tools/apps/social-sharing.js';
 import { passmanTools } from './tools/apps/passman.js';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ToolArray = Array<{
-  name: string;
-  description: string;
-  inputSchema: any;
-  handler: (...args: any[]) => any;
-}>;
+type ToolArray = Tool[];
 
 interface ToolSetEntry {
   /** Category name, usable in MCP_TOOLS */

--- a/mcp-server/src/tools/apps/absence.ts
+++ b/mcp-server/src/tools/apps/absence.ts
@@ -15,6 +15,13 @@ import { getNextcloudConfig } from '../types.js';
 
 export const getOutOfOfficeTool = {
   name: 'get_out_of_office',
+  title: 'Get Out-of-Office Status',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: "Get a user's current out-of-office / absence status (NC 28+)",
   inputSchema: z.object({
     userId: z
@@ -57,6 +64,13 @@ export const getOutOfOfficeTool = {
 
 export const setOutOfOfficeTool = {
   name: 'set_out_of_office',
+  title: 'Set Out-of-Office Status',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Set an out-of-office / absence period with status message (NC 28+)',
   inputSchema: z.object({
     firstDay: z.string().describe('First day of absence (YYYY-MM-DD)'),
@@ -126,6 +140,13 @@ export const setOutOfOfficeTool = {
 
 export const clearOutOfOfficeTool = {
   name: 'clear_out_of_office',
+  title: 'Clear Out-of-Office Status',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: "Clear a user's out-of-office / absence status (NC 28+)",
   inputSchema: z.object({
     userId: z

--- a/mcp-server/src/tools/apps/activity.ts
+++ b/mcp-server/src/tools/apps/activity.ts
@@ -38,6 +38,13 @@ function formatActivities(activities: Activity[]): string {
 
 export const listActivityTool = {
   name: 'list_activity',
+  title: 'List Activity',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List recent entries from the Nextcloud activity feed (file changes, shares, ' +
     'comments, calendar/contact edits, etc.) for the current user.',
@@ -115,6 +122,13 @@ export const listActivityTool = {
 
 export const getObjectActivityTool = {
   name: 'get_object_activity',
+  title: 'Get Object Activity',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List the activity history for a single object, e.g. one file. Use object_type ' +
     "'files' with a file ID to see what happened to that file.",

--- a/mcp-server/src/tools/apps/aiquila.ts
+++ b/mcp-server/src/tools/apps/aiquila.ts
@@ -27,6 +27,13 @@ async function runOCC(command: string, args: string[] = []): Promise<string> {
  */
 export const showConfigTool = {
   name: 'aiquila_show_config',
+  title: 'Show AIquila Configuration',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Show current AIquila configuration',
   inputSchema: z.object({}),
   handler: async () => {
@@ -58,6 +65,13 @@ export const showConfigTool = {
  */
 export const configureTool = {
   name: 'aiquila_configure',
+  title: 'Configure AIquila',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Configure AIquila settings (API key, model, tokens, timeout)',
   inputSchema: z.object({
     apiKey: z.string().optional().describe('Anthropic API key'),
@@ -119,6 +133,13 @@ export const configureTool = {
  */
 export const testTool = {
   name: 'aiquila_test',
+  title: 'Test AIquila Claude Integration',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
   description: 'Test AIquila Claude API integration with a simple prompt',
   inputSchema: z.object({
     prompt: z.string().default('Hello, Claude!').describe('Test prompt to send to Claude API'),

--- a/mcp-server/src/tools/apps/announcements.ts
+++ b/mcp-server/src/tools/apps/announcements.ts
@@ -43,6 +43,13 @@ function formatAnnouncements(items: Announcement[]): string {
 
 export const listAnnouncementsTool = {
   name: 'list_announcements',
+  title: 'List Announcements',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List announcements from the Nextcloud Announcement Center (org-wide notices such as ' +
     'maintenance windows, events, or news). Returns newest first.',
@@ -101,6 +108,13 @@ export const listAnnouncementsTool = {
 
 export const createAnnouncementTool = {
   name: 'create_announcement',
+  title: 'Create Announcement',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Create a new announcement in the Announcement Center. This is visible to all or ' +
     'selected groups and can trigger notifications/emails — use deliberately. Requires the ' +
@@ -189,6 +203,13 @@ export const createAnnouncementTool = {
 
 export const deleteAnnouncementTool = {
   name: 'delete_announcement',
+  title: 'Delete Announcement',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Delete an announcement by its ID. Requires the configured Nextcloud user to be an admin.',
   inputSchema: z.object({

--- a/mcp-server/src/tools/apps/assistant.ts
+++ b/mcp-server/src/tools/apps/assistant.ts
@@ -52,6 +52,13 @@ const STATUS_LABELS: Record<number, string> = {
 
 export const listTextTasksTool = {
   name: 'list_text_tasks',
+  title: 'List Text Tasks',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "List AI task types available in Nextcloud's TaskProcessing framework (summarize, headline, image-to-text, text-to-image, …). Shows which task types have at least one provider configured.",
   inputSchema: z.object({}),
@@ -97,6 +104,13 @@ export const listTextTasksTool = {
 
 export const processTextTool = {
   name: 'process_text',
+  title: 'Process Text with AI',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
   description:
     "Submit a text-processing task to Nextcloud's AI framework and return the task ID. Use get_task_result to poll until it completes. Common task types: 'core:text2text' (free prompt), 'core:summarize' (summary), 'core:headline' (headline), 'core:extract_topics' (topics).",
   inputSchema: z.object({
@@ -155,6 +169,13 @@ export const processTextTool = {
 
 export const getTaskResultTool = {
   name: 'get_task_result',
+  title: 'Get AI Task Result',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Get the status and result of a Nextcloud AI task previously created by process_text or generate_image. Status: 1=scheduled, 2=running, 3=successful, 4=failed.',
   inputSchema: z.object({
@@ -222,6 +243,13 @@ export const getTaskResultTool = {
 
 export const generateImageTool = {
   name: 'generate_image',
+  title: 'Generate Image',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
   description:
     "Generate an image from a text prompt using Nextcloud's text-to-image AI provider (e.g. Stable Diffusion via LocalAI). Returns the task ID; use get_task_result to check completion.",
   inputSchema: z.object({

--- a/mcp-server/src/tools/apps/bookmarks.ts
+++ b/mcp-server/src/tools/apps/bookmarks.ts
@@ -114,6 +114,13 @@ function formatFolderTree(folder: BookmarkFolder, indent = 0): string {
 
 export const listBookmarksTool = {
   name: 'list_bookmarks',
+  title: 'List Bookmarks',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List bookmarks from Nextcloud Bookmarks app. Supports search, tag filtering, folder filtering, sorting, and pagination.',
   inputSchema: z.object({
@@ -195,6 +202,13 @@ export const listBookmarksTool = {
 
 export const getBookmarkTool = {
   name: 'get_bookmark',
+  title: 'Get Bookmark',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Get full details of a single bookmark by its ID.',
   inputSchema: z.object({
     id: z.number().describe('The bookmark ID'),
@@ -227,6 +241,13 @@ export const getBookmarkTool = {
 
 export const createBookmarkTool = {
   name: 'create_bookmark',
+  title: 'Create Bookmark',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Create a new bookmark in Nextcloud Bookmarks. URL is required; title, description, tags, and folders are optional.',
   inputSchema: z.object({
@@ -279,6 +300,13 @@ export const createBookmarkTool = {
 
 export const updateBookmarkTool = {
   name: 'update_bookmark',
+  title: 'Update Bookmark',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Update an existing bookmark. Only provided fields are changed.',
   inputSchema: z.object({
     id: z.number().describe('The bookmark ID to update'),
@@ -333,6 +361,13 @@ export const updateBookmarkTool = {
 
 export const deleteBookmarkTool = {
   name: 'delete_bookmark',
+  title: 'Delete Bookmark',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete a bookmark by its ID. This action is irreversible.',
   inputSchema: z.object({
     id: z.number().describe('The bookmark ID to delete'),
@@ -367,6 +402,13 @@ export const deleteBookmarkTool = {
 
 export const listBookmarkFoldersTool = {
   name: 'list_bookmark_folders',
+  title: 'List Bookmark Folders',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List the bookmark folder hierarchy. Returns a tree structure of all folders.',
   inputSchema: z.object({
     root: z
@@ -415,6 +457,13 @@ export const listBookmarkFoldersTool = {
 
 export const getBookmarkFolderContentsTool = {
   name: 'get_bookmark_folder_contents',
+  title: 'Get Bookmark Folder Contents',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Get the contents of a bookmark folder (bookmarks and subfolders).',
   inputSchema: z.object({
     id: z.number().describe('The folder ID (-1 for root)'),
@@ -474,6 +523,13 @@ export const getBookmarkFolderContentsTool = {
 
 export const createBookmarkFolderTool = {
   name: 'create_bookmark_folder',
+  title: 'Create Bookmark Folder',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description: 'Create a new bookmark folder.',
   inputSchema: z.object({
     title: z.string().describe('Folder name'),
@@ -513,6 +569,13 @@ export const createBookmarkFolderTool = {
 
 export const updateBookmarkFolderTool = {
   name: 'update_bookmark_folder',
+  title: 'Update Bookmark Folder',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Update a bookmark folder (rename or move to a different parent).',
   inputSchema: z.object({
     id: z.number().describe('The folder ID to update'),
@@ -551,6 +614,13 @@ export const updateBookmarkFolderTool = {
 
 export const deleteBookmarkFolderTool = {
   name: 'delete_bookmark_folder',
+  title: 'Delete Bookmark Folder',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete a bookmark folder and all its contents. This action is irreversible.',
   inputSchema: z.object({
     id: z.number().describe('The folder ID to delete'),
@@ -585,6 +655,13 @@ export const deleteBookmarkFolderTool = {
 
 export const listBookmarkTagsTool = {
   name: 'list_bookmark_tags',
+  title: 'List Bookmark Tags',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List all tags used across bookmarks.',
   inputSchema: z.object({}),
   handler: async () => {
@@ -626,6 +703,13 @@ export const listBookmarkTagsTool = {
 
 export const renameBookmarkTagTool = {
   name: 'rename_bookmark_tag',
+  title: 'Rename Bookmark Tag',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Rename a bookmark tag. All bookmarks with the old tag will be updated.',
   inputSchema: z.object({
     old_name: z.string().describe('Current tag name'),
@@ -662,6 +746,13 @@ export const renameBookmarkTagTool = {
 
 export const deleteBookmarkTagTool = {
   name: 'delete_bookmark_tag',
+  title: 'Delete Bookmark Tag',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete a bookmark tag. The tag will be removed from all bookmarks.',
   inputSchema: z.object({
     name: z.string().describe('Tag name to delete'),

--- a/mcp-server/src/tools/apps/calendar.ts
+++ b/mcp-server/src/tools/apps/calendar.ts
@@ -766,6 +766,13 @@ async function resolveEventByUid(
  */
 export const listCalendarsTool = {
   name: 'list_calendars',
+  title: 'List Calendars',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List all calendars available to the current user, including their supported component types (events, tasks, journals) and metadata.',
   inputSchema: z.object({}),
@@ -835,6 +842,13 @@ export const listCalendarsTool = {
  */
 export const listEventsTool = {
   name: 'list_events',
+  title: 'List Calendar Events',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List events from a Nextcloud calendar within an optional time range. Returns event details including time, location, attendees, recurrence, and UIDs.',
   inputSchema: z.object({
@@ -967,6 +981,13 @@ export const listEventsTool = {
  */
 export const getEventTool = {
   name: 'get_event',
+  title: 'Get Calendar Event',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Get detailed information about a single calendar event by its UID, including full description, attendees, and recurrence rules.',
   inputSchema: z.object({
@@ -1022,6 +1043,13 @@ export const getEventTool = {
  */
 export const createEventTool = {
   name: 'create_event',
+  title: 'Create Calendar Event',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Create a new calendar event in Nextcloud with date/time, location, description, attendees, and optional recurrence.',
   inputSchema: z.object({
@@ -1293,6 +1321,13 @@ export const createEventTool = {
  */
 export const updateEventTool = {
   name: 'update_event',
+  title: 'Update Calendar Event',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "Update an existing calendar event's fields by UID. Uses CalDAV ETag-based optimistic concurrency.",
   inputSchema: z.object({
@@ -1512,6 +1547,13 @@ export const updateEventTool = {
  */
 export const deleteEventTool = {
   name: 'delete_event',
+  title: 'Delete Calendar Event',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete a calendar event from Nextcloud by UID. This action is irreversible.',
   inputSchema: z.object({
     uid: z.string().describe('The UID of the event to delete'),

--- a/mcp-server/src/tools/apps/circles.ts
+++ b/mcp-server/src/tools/apps/circles.ts
@@ -107,6 +107,13 @@ function formatMember(m: CircleMember): string {
 
 export const circlesListTool = {
   name: 'circles_list',
+  title: 'List Circles',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List all circles/teams accessible to the current user. Returns circle IDs, names, owners, and configuration.',
   inputSchema: z.object({
@@ -136,6 +143,13 @@ export const circlesListTool = {
 
 export const circlesGetTool = {
   name: 'circles_get',
+  title: 'Get Circle',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Get detailed information about a specific circle/team, including its description, owner, and configuration flags.',
   inputSchema: z.object({
@@ -173,6 +187,13 @@ export const circlesGetTool = {
 
 export const circlesCreateTool = {
   name: 'circles_create',
+  title: 'Create Circle',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Create a new circle/team. The current user becomes the owner. Set personal=true for a private circle only visible to the owner.',
   inputSchema: z.object({
@@ -207,6 +228,13 @@ export const circlesCreateTool = {
 
 export const circlesDeleteTool = {
   name: 'circles_delete',
+  title: 'Delete Circle',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete a circle/team. Requires owner privileges.',
   inputSchema: z.object({
     circleId: z.string().describe('The circle ID to delete'),
@@ -229,6 +257,13 @@ export const circlesDeleteTool = {
 
 export const circlesListMembersTool = {
   name: 'circles_list_members',
+  title: 'List Circle Members',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List all members of a circle/team. Returns member IDs (needed for removal), user IDs, types, and permission levels.',
   inputSchema: z.object({
@@ -255,6 +290,13 @@ export const circlesListMembersTool = {
 
 export const circlesAddMemberTool = {
   name: 'circles_add_member',
+  title: 'Add Circle Member',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Add a member to a circle/team. Requires moderator privileges or higher. Member type: 1=user (default), 2=group, 4=mail, 16=circle.',
   inputSchema: z.object({
@@ -285,6 +327,13 @@ export const circlesAddMemberTool = {
 
 export const circlesRemoveMemberTool = {
   name: 'circles_remove_member',
+  title: 'Remove Circle Member',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Remove a member from a circle/team. Use circles_list_members to get the memberId. Requires moderator privileges or higher.',
   inputSchema: z.object({
@@ -310,6 +359,13 @@ export const circlesRemoveMemberTool = {
 
 export const circlesSearchTool = {
   name: 'circles_search',
+  title: 'Search Circles',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Search for circles/teams by name.',
   inputSchema: z.object({
     term: z.string().describe('Search term to match against circle names'),

--- a/mcp-server/src/tools/apps/contacts.ts
+++ b/mcp-server/src/tools/apps/contacts.ts
@@ -425,6 +425,13 @@ async function resolveContactByUid(
  */
 export const listAddressBooksTool = {
   name: 'list_address_books',
+  title: 'List Address Books',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List all address books available to the current user, including their display names and metadata.',
   inputSchema: z.object({}),
@@ -490,6 +497,13 @@ export const listAddressBooksTool = {
  */
 export const listContactsTool = {
   name: 'list_contacts',
+  title: 'List Contacts',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List contacts from a Nextcloud address book. Optionally search by name. Returns name, email, phone, organization, and UID for each contact.',
   inputSchema: z.object({
@@ -593,6 +607,13 @@ export const listContactsTool = {
  */
 export const getContactTool = {
   name: 'get_contact',
+  title: 'Get Contact',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Get detailed information about a single contact by its UID, including all properties like name, email, phone, address, organization, birthday, notes, and groups.',
   inputSchema: z.object({
@@ -638,6 +659,13 @@ export const getContactTool = {
  */
 export const createContactTool = {
   name: 'create_contact',
+  title: 'Create Contact',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Create a new contact in a Nextcloud address book with name, email, phone, address, organization, and other properties.',
   inputSchema: z.object({
@@ -820,6 +848,13 @@ export const createContactTool = {
  */
 export const updateContactTool = {
   name: 'update_contact',
+  title: 'Update Contact',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "Update an existing contact's fields by UID. Uses CardDAV ETag-based optimistic concurrency. Only provided fields are changed.",
   inputSchema: z.object({
@@ -1040,6 +1075,13 @@ export const updateContactTool = {
  */
 export const deleteContactTool = {
   name: 'delete_contact',
+  title: 'Delete Contact',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Delete a contact from a Nextcloud address book by UID. This action is irreversible.',
   inputSchema: z.object({

--- a/mcp-server/src/tools/apps/cookbook.ts
+++ b/mcp-server/src/tools/apps/cookbook.ts
@@ -178,6 +178,13 @@ async function readAllRecipes(): Promise<{ folderName: string; recipe: Recipe }[
  */
 export const listRecipesTool = {
   name: 'list_recipes',
+  title: 'List Recipes',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List all recipes in Nextcloud Cookbook. Optionally filter by name, category, or keyword.',
   inputSchema: z.object({
@@ -253,6 +260,13 @@ export const listRecipesTool = {
  */
 export const listRecipeCategoriesTool = {
   name: 'list_recipe_categories',
+  title: 'List Recipe Categories',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List all unique recipe categories found across recipes in Nextcloud Cookbook.',
   inputSchema: z.object({}),
   handler: async () => {
@@ -295,6 +309,13 @@ export const listRecipeCategoriesTool = {
  */
 export const getRecipeTool = {
   name: 'get_recipe',
+  title: 'Get Recipe',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Get full details of a recipe from Nextcloud Cookbook by its folder name.',
   inputSchema: z.object({
     folderName: z.string().describe('The recipe folder name (as shown in list_recipes)'),
@@ -345,6 +366,13 @@ const nutritionSchema = z
  */
 export const createRecipeTool = {
   name: 'create_recipe',
+  title: 'Create Recipe',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description: 'Create a new recipe in Nextcloud Cookbook with schema.org Recipe format.',
   inputSchema: z.object({
     name: z.string().describe('Recipe name'),
@@ -445,6 +473,13 @@ export const createRecipeTool = {
  */
 export const updateRecipeTool = {
   name: 'update_recipe',
+  title: 'Update Recipe',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Update an existing recipe in Nextcloud Cookbook. Only provided fields are changed.',
   inputSchema: z.object({
     folderName: z.string().describe('The recipe folder name'),
@@ -543,6 +578,13 @@ export const updateRecipeTool = {
  */
 export const deleteRecipeTool = {
   name: 'delete_recipe',
+  title: 'Delete Recipe',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Delete a recipe from Nextcloud Cookbook. This removes the entire recipe folder including images. This action is irreversible.',
   inputSchema: z.object({

--- a/mcp-server/src/tools/apps/cowork.ts
+++ b/mcp-server/src/tools/apps/cowork.ts
@@ -2,6 +2,7 @@
 
 import { z } from 'zod';
 import { fetchAiquilaAPI } from '../../client/aiquila.js';
+import type { ToolAnnotations } from '../types.js';
 
 /**
  * AIquila Cowork Tools
@@ -86,6 +87,13 @@ function formatCoworker(c: Coworker): string {
 
 export const listCoworkersTool = {
   name: 'list_coworkers',
+  title: 'List Coworkers',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "List the current user's coworkers (persistent scheduled AI tasks) with their status, provider, schedule and last run.",
   inputSchema: z.object({}),
@@ -106,6 +114,13 @@ export const listCoworkersTool = {
 
 export const listCoworkerTemplatesTool = {
   name: 'list_coworker_templates',
+  title: 'List Coworker Templates',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List built-in coworker templates (e.g. image classification via Claude vision or Mistral Pixtral) and available task types.',
   inputSchema: z.object({}),
@@ -125,6 +140,13 @@ export const listCoworkerTemplatesTool = {
 
 export const getCoworkerTool = {
   name: 'get_coworker',
+  title: 'Get Coworker',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Get a single coworker by ID, including its schedule and last run status.',
   inputSchema: z.object({ id: z.number().describe('Coworker ID') }),
   handler: async (args: { id: number }) => {
@@ -139,6 +161,13 @@ export const getCoworkerTool = {
 
 export const createCoworkerTool = {
   name: 'create_coworker',
+  title: 'Create Coworker',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Create a coworker. Provide templateId to start from a built-in template (e.g. "classify-images-claude" or "classify-images-pixtral"), and/or explicit fields to configure a custom one. Fields override template defaults.',
   inputSchema: z.object({
@@ -198,6 +227,13 @@ export const createCoworkerTool = {
 
 export const updateCoworkerTool = {
   name: 'update_coworker',
+  title: 'Update Coworker',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "Update a coworker's configuration (title, provider, input folder, schedule, options).",
   inputSchema: z.object({
@@ -242,6 +278,13 @@ export const updateCoworkerTool = {
 
 export const deleteCoworkerTool = {
   name: 'delete_coworker',
+  title: 'Delete Coworker',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete a coworker and its run history.',
   inputSchema: z.object({ id: z.number().describe('Coworker ID') }),
   handler: async (args: { id: number }) => {
@@ -256,12 +299,16 @@ export const deleteCoworkerTool = {
 
 function stateTool(
   name: string,
+  title: string,
   description: string,
-  action: 'enable' | 'disable' | 'pause' | 'resume' | 'run'
+  action: 'enable' | 'disable' | 'pause' | 'resume' | 'run',
+  annotations: ToolAnnotations
 ) {
   return {
     name,
+    title,
     description,
+    annotations,
     inputSchema: z.object({ id: z.number().describe('Coworker ID') }),
     handler: async (args: { id: number }) => {
       try {
@@ -286,34 +333,61 @@ function stateTool(
   };
 }
 
+const STATE_CHANGE: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+};
+/** Turning a coworker off removes its scheduled behaviour. */
+const STATE_STOP: ToolAnnotations = { ...STATE_CHANGE, destructiveHint: true };
+
 export const enableCoworkerTool = stateTool(
   'enable_coworker',
+  'Enable Coworker',
   'Enable a coworker so it runs on its schedule.',
-  'enable'
+  'enable',
+  STATE_CHANGE
 );
 export const disableCoworkerTool = stateTool(
   'disable_coworker',
+  'Disable Coworker',
   'Disable a coworker so it stops running on its schedule.',
-  'disable'
+  'disable',
+  STATE_STOP
 );
 export const pauseCoworkerTool = stateTool(
   'pause_coworker',
+  'Pause Coworker',
   'Temporarily pause a coworker without disabling it.',
-  'pause'
+  'pause',
+  STATE_STOP
 );
 export const resumeCoworkerTool = stateTool(
   'resume_coworker',
+  'Resume Coworker',
   'Resume a paused coworker.',
-  'resume'
+  'resume',
+  STATE_CHANGE
 );
 export const runCoworkerTool = stateTool(
   'run_coworker',
+  'Run Coworker',
   'Run a coworker immediately (synchronously) and return the run result.',
-  'run'
+  'run',
+  // executes the coworker's prompt against an AI backend; repeating it does more work
+  { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true }
 );
 
 export const getCoworkerRunsTool = {
   name: 'get_coworker_runs',
+  title: 'Get Coworker Runs',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Get recent run history (progress, status, summary) for a coworker.',
   inputSchema: z.object({
     id: z.number().describe('Coworker ID'),

--- a/mcp-server/src/tools/apps/deck.ts
+++ b/mcp-server/src/tools/apps/deck.ts
@@ -83,6 +83,13 @@ function formatCardDetail(card: DeckCard): string {
 
 export const listBoardsTool = {
   name: 'deck_list_boards',
+  title: 'List Deck Boards',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List all Deck boards. Returns id, title, owner, and label count for each board.',
   inputSchema: z.object({}),
   handler: async () => {
@@ -109,6 +116,13 @@ export const listBoardsTool = {
 
 export const getBoardTool = {
   name: 'deck_get_board',
+  title: 'Get Deck Board',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Get details of a Deck board including its labels and access control list (ACL). Use deck_list_stacks to see the columns and cards.',
   inputSchema: z.object({
@@ -158,6 +172,13 @@ export const getBoardTool = {
 
 export const createBoardTool = {
   name: 'deck_create_board',
+  title: 'Create Deck Board',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description: 'Create a new Deck board.',
   inputSchema: z.object({
     title: z.string().describe('Board title'),
@@ -184,6 +205,13 @@ export const createBoardTool = {
 
 export const listStacksTool = {
   name: 'deck_list_stacks',
+  title: 'List Deck Stacks',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List all stacks (columns) of a Deck board, including the cards in each stack. This gives a full overview of the board layout.',
   inputSchema: z.object({
@@ -227,6 +255,13 @@ export const listStacksTool = {
 
 export const createStackTool = {
   name: 'deck_create_stack',
+  title: 'Create Deck Stack',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description: 'Create a new stack (column) on a Deck board.',
   inputSchema: z.object({
     boardId: z.number().int().describe('Board ID (from deck_list_boards)'),
@@ -251,6 +286,13 @@ export const createStackTool = {
 
 export const getCardTool = {
   name: 'deck_get_card',
+  title: 'Get Deck Card',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Get full details of a Deck card including description, labels, and assigned users.',
   inputSchema: z.object({
     boardId: z.number().int().describe('Board ID'),
@@ -272,6 +314,13 @@ export const getCardTool = {
 
 export const createCardTool = {
   name: 'deck_create_card',
+  title: 'Create Deck Card',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description: 'Create a new card in a Deck stack.',
   inputSchema: z.object({
     boardId: z.number().int().describe('Board ID'),
@@ -312,6 +361,13 @@ export const createCardTool = {
 
 export const updateCardTool = {
   name: 'deck_update_card',
+  title: 'Update Deck Card',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Update an existing Deck card. Provide only the fields you want to change. Fetches the current card first to preserve unchanged fields.',
   inputSchema: z.object({
@@ -360,6 +416,13 @@ export const updateCardTool = {
 
 export const moveCardTool = {
   name: 'deck_move_card',
+  title: 'Move Deck Card',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Move a card to a different stack (column) on the same board. This is the core kanban action for changing card status.',
   inputSchema: z.object({
@@ -405,6 +468,13 @@ export const moveCardTool = {
 
 export const archiveCardTool = {
   name: 'deck_archive_card',
+  title: 'Archive Deck Card',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Archive or unarchive a Deck card.',
   inputSchema: z.object({
     boardId: z.number().int().describe('Board ID'),
@@ -440,6 +510,13 @@ export const archiveCardTool = {
 
 export const assignLabelTool = {
   name: 'deck_assign_label',
+  title: 'Assign Deck Label',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Assign a label to a Deck card. Use deck_get_board to see available labels and their IDs.',
   inputSchema: z.object({
@@ -471,6 +548,13 @@ export const assignLabelTool = {
 
 export const assignUserTool = {
   name: 'deck_assign_user',
+  title: 'Assign Deck User',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Assign a user to a Deck card.',
   inputSchema: z.object({
     boardId: z.number().int().describe('Board ID'),

--- a/mcp-server/src/tools/apps/forms.ts
+++ b/mcp-server/src/tools/apps/forms.ts
@@ -116,6 +116,13 @@ function formatSubmission(s: FormSubmission): string {
 
 export const listFormsTool = {
   name: 'list_forms',
+  title: 'List Forms',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List forms. type="owned" (default) returns forms the current user owns; "shared" returns forms shared with them; "partial" returns forms the user has an unfinished draft on.',
   inputSchema: z.object({
@@ -144,6 +151,13 @@ export const listFormsTool = {
 
 export const getFormTool = {
   name: 'get_form',
+  title: 'Get Form',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Get full details for a form by ID, including questions, options, shares, and metadata.',
   inputSchema: z.object({
@@ -163,6 +177,13 @@ export const getFormTool = {
 
 export const createFormTool = {
   name: 'create_form',
+  title: 'Create Form',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Create a new empty form. Returns the new form ID. Use update_form to set title/description and create_form_question to add questions.',
   inputSchema: z.object({}),
@@ -180,6 +201,13 @@ export const createFormTool = {
 
 export const cloneFormTool = {
   name: 'clone_form',
+  title: 'Clone Form',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description: 'Clone an existing form (its questions, options, and settings) into a new form.',
   inputSchema: z.object({
     formId: z.number().int().describe('Form ID to clone'),
@@ -202,6 +230,13 @@ export const cloneFormTool = {
 
 export const updateFormTool = {
   name: 'update_form',
+  title: 'Update Form',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Update form properties. Only provided fields are changed. state: 0=active, 1=closed, 2=archived. expires=0 disables expiration.',
   inputSchema: z.object({
@@ -255,6 +290,13 @@ export const updateFormTool = {
 
 export const transferFormOwnerTool = {
   name: 'transfer_form_owner',
+  title: 'Transfer Form Ownership',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Transfer ownership of a form to another Nextcloud user. The new owner must have access to the Forms app.',
   inputSchema: z.object({
@@ -278,6 +320,13 @@ export const transferFormOwnerTool = {
 
 export const deleteFormTool = {
   name: 'delete_form',
+  title: 'Delete Form',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Permanently delete a form and all of its submissions. This cannot be undone.',
   inputSchema: z.object({
     formId: z.number().int().describe('Form ID'),
@@ -300,6 +349,13 @@ export const deleteFormTool = {
 
 export const listFormQuestionsTool = {
   name: 'list_form_questions',
+  title: 'List Form Questions',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List all questions for a form, in display order.',
   inputSchema: z.object({
     formId: z.number().int().describe('Form ID'),
@@ -326,6 +382,13 @@ export const listFormQuestionsTool = {
 
 export const createFormQuestionTool = {
   name: 'create_form_question',
+  title: 'Create Form Question',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Add a question to a form. For choice questions use type "multiple" (checkbox), "multiple_unique" (radio), or "dropdown" — then call create_form_options.',
   inputSchema: z.object({
@@ -352,6 +415,13 @@ export const createFormQuestionTool = {
 
 export const updateFormQuestionTool = {
   name: 'update_form_question',
+  title: 'Update Form Question',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Update question properties (text, requirement, type, etc.). Only provided fields are changed.',
   inputSchema: z.object({
@@ -402,6 +472,13 @@ export const updateFormQuestionTool = {
 
 export const reorderFormQuestionsTool = {
   name: 'reorder_form_questions',
+  title: 'Reorder Form Questions',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Reorder all questions in a form. Pass the full list of question IDs in the desired order.',
   inputSchema: z.object({
@@ -428,6 +505,13 @@ export const reorderFormQuestionsTool = {
 
 export const deleteFormQuestionTool = {
   name: 'delete_form_question',
+  title: 'Delete Form Question',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete a question from a form.',
   inputSchema: z.object({
     formId: z.number().int().describe('Form ID'),
@@ -453,6 +537,13 @@ export const deleteFormQuestionTool = {
 
 export const createFormOptionsTool = {
   name: 'create_form_options',
+  title: 'Create Form Options',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Add one or more options to a choice question (multiple/multiple_unique/dropdown). Pass an array of option texts.',
   inputSchema: z.object({
@@ -483,6 +574,13 @@ export const createFormOptionsTool = {
 
 export const updateFormOptionTool = {
   name: 'update_form_option',
+  title: 'Update Form Option',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: "Update a choice option's text (and optionally its order).",
   inputSchema: z.object({
     formId: z.number().int().describe('Form ID'),
@@ -525,6 +623,13 @@ export const updateFormOptionTool = {
 
 export const reorderFormOptionsTool = {
   name: 'reorder_form_options',
+  title: 'Reorder Form Options',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Reorder all options for a choice question. Pass the full list of option IDs in the desired order.',
   inputSchema: z.object({
@@ -549,6 +654,13 @@ export const reorderFormOptionsTool = {
 
 export const deleteFormOptionTool = {
   name: 'delete_form_option',
+  title: 'Delete Form Option',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete an option from a choice question.',
   inputSchema: z.object({
     formId: z.number().int().describe('Form ID'),
@@ -576,6 +688,13 @@ export const deleteFormOptionTool = {
 
 export const createFormShareTool = {
   name: 'create_form_share',
+  title: 'Create Form Share',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Share a form. type="user" shares with a Nextcloud user (shareWith=userId), "group" with a group (shareWith=groupId), "link" creates a public link (shareWith is the generated hash, omit it at creation).',
   inputSchema: z.object({
@@ -634,6 +753,13 @@ export const createFormShareTool = {
 
 export const updateFormShareTool = {
   name: 'update_form_share',
+  title: 'Update Form Share',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Update the permissions on an existing form share.',
   inputSchema: z.object({
     formId: z.number().int().describe('Form ID'),
@@ -657,6 +783,13 @@ export const updateFormShareTool = {
 
 export const deleteFormShareTool = {
   name: 'delete_form_share',
+  title: 'Delete Form Share',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Revoke a form share.',
   inputSchema: z.object({
     formId: z.number().int().describe('Form ID'),
@@ -682,6 +815,13 @@ export const deleteFormShareTool = {
 
 export const listFormSubmissionsTool = {
   name: 'list_form_submissions',
+  title: 'List Form Submissions',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List submissions for a form. Supports free-text search (query) and pagination (limit/offset). Only form owners/admins see all submissions.',
   inputSchema: z.object({
@@ -722,6 +862,13 @@ export const listFormSubmissionsTool = {
 
 export const getFormSubmissionTool = {
   name: 'get_form_submission',
+  title: 'Get Form Submission',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Get a single submission with all of its answers.',
   inputSchema: z.object({
     formId: z.number().int().describe('Form ID'),
@@ -743,6 +890,13 @@ export const getFormSubmissionTool = {
 
 export const createFormSubmissionTool = {
   name: 'create_form_submission',
+  title: 'Create Form Submission',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Submit answers to a form. `answers` is an object keyed by question ID; values are always arrays. For text questions: ["My answer"]. For choice questions: [optionId1, optionId2] (numeric IDs). Public links require `shareHash`.',
   inputSchema: z.object({
@@ -778,6 +932,13 @@ export const createFormSubmissionTool = {
 
 export const deleteFormSubmissionTool = {
   name: 'delete_form_submission',
+  title: 'Delete Form Submission',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete a single submission by ID.',
   inputSchema: z.object({
     formId: z.number().int().describe('Form ID'),
@@ -799,6 +960,13 @@ export const deleteFormSubmissionTool = {
 
 export const deleteAllFormSubmissionsTool = {
   name: 'delete_all_form_submissions',
+  title: 'Delete All Form Submissions',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Delete every submission for a form. The form itself is kept. This cannot be undone.',
   inputSchema: z.object({
@@ -823,6 +991,13 @@ export const deleteAllFormSubmissionsTool = {
 
 export const exportFormSubmissionsTool = {
   name: 'export_form_submissions',
+  title: 'Export Form Submissions',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "Export a form's submissions as a spreadsheet into the user's Nextcloud storage. Returns the destination path. Use read_file / get_file_info afterwards to work with the export.",
   inputSchema: z.object({

--- a/mcp-server/src/tools/apps/groups.ts
+++ b/mcp-server/src/tools/apps/groups.ts
@@ -13,6 +13,13 @@ import { fetchOCS } from '../../client/ocs.js';
  */
 export const listGroupsTool = {
   name: 'list_groups',
+  title: 'List Groups',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List all groups in the Nextcloud instance. Requires admin or sub-admin privileges',
   inputSchema: z.object({
     search: z.string().optional().describe('Search/filter string for group names'),
@@ -59,6 +66,13 @@ export const listGroupsTool = {
  */
 export const getGroupInfoTool = {
   name: 'get_group_info',
+  title: 'Get Group Info',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Get detailed information about a specific Nextcloud group. Requires admin or sub-admin privileges',
   inputSchema: z.object({
@@ -99,6 +113,13 @@ export const getGroupInfoTool = {
  */
 export const addUserToGroupTool = {
   name: 'add_user_to_group',
+  title: 'Add User to Group',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Add a Nextcloud user to a group. Requires admin privileges',
   inputSchema: z.object({
     userId: z.string().describe('The user ID (login name) to add to the group'),
@@ -138,6 +159,13 @@ export const addUserToGroupTool = {
  */
 export const removeUserFromGroupTool = {
   name: 'remove_user_from_group',
+  title: 'Remove User from Group',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Remove a Nextcloud user from a group. Requires admin privileges',
   inputSchema: z.object({
     userId: z.string().describe('The user ID (login name) to remove from the group'),

--- a/mcp-server/src/tools/apps/mail.ts
+++ b/mcp-server/src/tools/apps/mail.ts
@@ -118,6 +118,13 @@ function formatRecipients(recipients: MailRecipient[]): string {
 
 const listMailAccountsTool = {
   name: 'list_mail_accounts',
+  title: 'List Mail Accounts',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List all configured email accounts in Nextcloud Mail. Returns account IDs, names, and email addresses.',
   inputSchema: z.object({}),
@@ -153,6 +160,13 @@ const listMailAccountsTool = {
 
 const listMailboxesTool = {
   name: 'list_mailboxes',
+  title: 'List Mailboxes',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List all mailboxes (folders) for a Nextcloud Mail account. Returns mailbox names, IDs, and unread counts.',
   inputSchema: z.object({
@@ -196,6 +210,13 @@ const listMailboxesTool = {
 
 const listMessagesTool = {
   name: 'mail_list_messages',
+  title: 'List Mail Messages',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List email messages in a Nextcloud Mail mailbox. Supports pagination via cursor. Returns subject, sender, date, and message IDs.',
   inputSchema: z.object({
@@ -273,6 +294,13 @@ const listMessagesTool = {
 
 const readMessageTool = {
   name: 'mail_read_message',
+  title: 'Read Mail Message',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Read the full content of an email message by ID. Returns headers, body text, and attachment list.',
   inputSchema: z.object({
@@ -331,6 +359,13 @@ const readMessageTool = {
 
 const getAttachmentTool = {
   name: 'mail_get_attachment',
+  title: 'Get Mail Attachment',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Download an email attachment by message ID and attachment ID. ' +
     'Returns text for text files and calendar invites (ICS), image data for images, ' +
@@ -430,6 +465,13 @@ const getAttachmentTool = {
 
 const searchMessagesTool = {
   name: 'mail_search_messages',
+  title: 'Search Mail Messages',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Search email messages across all mailboxes by subject or sender. ' +
     'Returns matches with message IDs usable in mail_read_message. ' +
@@ -507,6 +549,13 @@ const searchMessagesTool = {
 
 const sendMessageTool = {
   name: 'mail_send_message',
+  title: 'Send Mail Message',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
   description:
     'Send an email message through Nextcloud Mail. Requires an account ID and recipient addresses.',
   inputSchema: z.object({
@@ -583,6 +632,13 @@ const sendMessageTool = {
 
 const deleteMessageTool = {
   name: 'mail_delete_message',
+  title: 'Delete Mail Message',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete an email message by ID. This typically moves it to trash.',
   inputSchema: z.object({
     messageId: z.number().describe('The message ID to delete'),
@@ -616,6 +672,13 @@ const deleteMessageTool = {
 
 const moveMessageTool = {
   name: 'mail_move_message',
+  title: 'Move Mail Message',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Move an email message to a different mailbox/folder.',
   inputSchema: z.object({
     messageId: z.number().describe('The message ID to move'),
@@ -656,6 +719,13 @@ const moveMessageTool = {
 
 const setMessageFlagsTool = {
   name: 'mail_set_message_flags',
+  title: 'Set Mail Message Flags',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Set flags on an email message (mark as read/unread, star/unstar, mark as important or junk).',
   inputSchema: z.object({

--- a/mcp-server/src/tools/apps/maps.ts
+++ b/mcp-server/src/tools/apps/maps.ts
@@ -135,6 +135,13 @@ function formatMyMap(m: MyMap): string {
 
 export const listMapFavoritesTool = {
   name: 'list_map_favorites',
+  title: 'List Map Favorites',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List map favorites (saved locations/pins) from Nextcloud Maps. Optionally filter by modification time.',
   inputSchema: z.object({
@@ -176,6 +183,13 @@ export const listMapFavoritesTool = {
 
 export const createMapFavoriteTool = {
   name: 'create_map_favorite',
+  title: 'Create Map Favorite',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Create a new map favorite (saved location/pin) in Nextcloud Maps. Latitude and longitude are required.',
   inputSchema: z.object({
@@ -230,6 +244,13 @@ export const createMapFavoriteTool = {
 
 export const updateMapFavoriteTool = {
   name: 'update_map_favorite',
+  title: 'Update Map Favorite',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Update an existing map favorite. Only provided fields are changed.',
   inputSchema: z.object({
     id: z.number().describe('Favorite ID'),
@@ -287,6 +308,13 @@ export const updateMapFavoriteTool = {
 
 export const deleteMapFavoriteTool = {
   name: 'delete_map_favorite',
+  title: 'Delete Map Favorite',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete a map favorite by its ID. This action is irreversible.',
   inputSchema: z.object({
     id: z.number().describe('Favorite ID to delete'),
@@ -315,6 +343,13 @@ export const deleteMapFavoriteTool = {
 
 export const listMapDevicesTool = {
   name: 'list_map_devices',
+  title: 'List Map Devices',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List GPS tracking devices registered in Nextcloud Maps.',
   inputSchema: z.object({}),
   handler: async () => {
@@ -347,6 +382,13 @@ export const listMapDevicesTool = {
 
 export const getMapDevicePointsTool = {
   name: 'get_map_device_points',
+  title: 'Get Map Device Points',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Get GPS location points for a specific device. Supports time filtering and pagination.',
   inputSchema: z.object({
@@ -396,6 +438,13 @@ export const getMapDevicePointsTool = {
 
 export const addMapDevicePointTool = {
   name: 'add_map_device_point',
+  title: 'Add Map Device Point',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     "Log a GPS location point for a device. The device is auto-created by user_agent if it doesn't exist.",
   inputSchema: z.object({
@@ -453,6 +502,13 @@ export const addMapDevicePointTool = {
 
 export const updateMapDeviceTool = {
   name: 'update_map_device',
+  title: 'Update Map Device',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: "Update a device's display color.",
   inputSchema: z.object({
     id: z.number().describe('Device ID'),
@@ -486,6 +542,13 @@ export const updateMapDeviceTool = {
 
 export const deleteMapDeviceTool = {
   name: 'delete_map_device',
+  title: 'Delete Map Device',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Delete a GPS tracking device and all its location points. This action is irreversible.',
   inputSchema: z.object({
@@ -515,6 +578,13 @@ export const deleteMapDeviceTool = {
 
 export const listMapTracksTool = {
   name: 'list_map_tracks',
+  title: 'List Map Tracks',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List GPS tracks (GPX/KML files) from Nextcloud Maps.',
   inputSchema: z.object({
     myMapId: z.number().optional().describe('Custom map ID to scope to'),
@@ -550,6 +620,13 @@ export const listMapTracksTool = {
 
 export const getMapTrackTool = {
   name: 'get_map_track',
+  title: 'Get Map Track',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Get full details and content of a track by its ID. Returns metadata and the raw GPX/KML file content.',
   inputSchema: z.object({
@@ -589,6 +666,13 @@ export const getMapTrackTool = {
 
 export const updateMapTrackTool = {
   name: 'update_map_track',
+  title: 'Update Map Track',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: "Update a track's color or metadata.",
   inputSchema: z.object({
     id: z.number().describe('Track ID'),
@@ -626,6 +710,13 @@ export const updateMapTrackTool = {
 
 export const listMapPhotosTool = {
   name: 'list_map_photos',
+  title: 'List Map Photos',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List geolocated photos (photos with GPS coordinates) from Nextcloud Maps.',
   inputSchema: z.object({
     myMapId: z.number().optional().describe('Custom map ID to scope to'),
@@ -663,6 +754,13 @@ export const listMapPhotosTool = {
 
 export const listMapPhotosNonlocalizedTool = {
   name: 'list_map_photos_nonlocalized',
+  title: 'List Non-Localized Map Photos',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "List photos that don't have GPS coordinates. Useful for finding photos that can be placed on the map.",
   inputSchema: z.object({
@@ -717,6 +815,13 @@ export const listMapPhotosNonlocalizedTool = {
 
 export const placeMapPhotosTool = {
   name: 'place_map_photos',
+  title: 'Place Map Photos',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Set GPS coordinates on one or more photos. Each photo path is paired with a lat/lng.',
   inputSchema: z.object({
@@ -757,6 +862,13 @@ export const placeMapPhotosTool = {
 
 export const resetMapPhotoCoordsTool = {
   name: 'reset_map_photo_coords',
+  title: 'Reset Map Photo Coordinates',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Remove GPS coordinates from one or more photos.',
   inputSchema: z.object({
     paths: z.array(z.string()).describe('File paths in Nextcloud storage'),
@@ -795,6 +907,13 @@ export const resetMapPhotoCoordsTool = {
 
 export const listMapsTool = {
   name: 'list_maps',
+  title: 'List Maps',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List all custom maps created by the user in Nextcloud Maps.',
   inputSchema: z.object({}),
   handler: async () => {
@@ -827,6 +946,13 @@ export const listMapsTool = {
 
 export const createMapTool = {
   name: 'create_map',
+  title: 'Create Map',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description: 'Create a new custom map in Nextcloud Maps.',
   inputSchema: z.object({
     name: z.string().optional().describe("Map name (default: 'New Map')"),
@@ -861,6 +987,13 @@ export const createMapTool = {
 
 export const updateMapTool = {
   name: 'update_map',
+  title: 'Update Map',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: "Update a custom map's properties (e.g. rename).",
   inputSchema: z.object({
     id: z.number().describe('Map ID'),
@@ -896,6 +1029,13 @@ export const updateMapTool = {
 
 export const deleteMapTool = {
   name: 'delete_map',
+  title: 'Delete Map',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete a custom map. This action is irreversible.',
   inputSchema: z.object({
     id: z.number().describe('Map ID to delete'),
@@ -924,6 +1064,13 @@ export const deleteMapTool = {
 
 export const exportMapRouteTool = {
   name: 'export_map_route',
+  title: 'Export Map Route',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: "Export a route or track as a GPX file to the user's Nextcloud /Maps folder.",
   inputSchema: z.object({
     name: z.string().describe('Route name (used as filename)'),
@@ -991,6 +1138,13 @@ export const exportMapRouteTool = {
 
 export const exportMapFavoritesTool = {
   name: 'export_map_favorites',
+  title: 'Export Map Favorites',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "Export favorites as a GPX file to the user's Nextcloud /Maps folder. Filter by categories and time range.",
   inputSchema: z.object({
@@ -1037,6 +1191,13 @@ export const exportMapFavoritesTool = {
 
 export const importMapFavoritesTool = {
   name: 'import_map_favorites',
+  title: 'Import Map Favorites',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Import favorites from a file in Nextcloud storage. Supports GPX, KML, KMZ, JSON, and GeoJSON.',
   inputSchema: z.object({
@@ -1075,6 +1236,13 @@ export const importMapFavoritesTool = {
 
 export const exportMapDevicesTool = {
   name: 'export_map_devices',
+  title: 'Export Map Devices',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: "Export device location data as a GPX file to the user's Nextcloud /Maps folder.",
   inputSchema: z.object({
     deviceIdList: z.array(z.number()).describe('Device IDs to export'),
@@ -1118,6 +1286,13 @@ export const exportMapDevicesTool = {
 
 export const importMapDevicesTool = {
   name: 'import_map_devices',
+  title: 'Import Map Devices',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Import device location data from a file in Nextcloud storage. Supports GPX, KML, and KMZ.',
   inputSchema: z.object({

--- a/mcp-server/src/tools/apps/news.ts
+++ b/mcp-server/src/tools/apps/news.ts
@@ -75,6 +75,13 @@ function formatItem(i: Item): string {
 
 export const listFeedsTool = {
   name: 'list_feeds',
+  title: 'List News Feeds',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List all RSS feeds subscribed in the Nextcloud News app, with unread counts.',
   inputSchema: z.object({}),
   handler: async () => {
@@ -93,6 +100,13 @@ export const listFeedsTool = {
 
 export const addFeedTool = {
   name: 'add_feed',
+  title: 'Add News Feed',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
   description: 'Subscribe to a new RSS feed by URL, optionally placing it in a folder.',
   inputSchema: z.object({
     url: z.string().describe('The RSS/Atom feed URL to subscribe to'),
@@ -117,6 +131,13 @@ export const addFeedTool = {
 
 export const deleteFeedTool = {
   name: 'delete_feed',
+  title: 'Delete News Feed',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete (unsubscribe from) a feed and all its items.',
   inputSchema: z.object({
     feedId: z.number().describe('The feed ID to delete'),
@@ -133,6 +154,13 @@ export const deleteFeedTool = {
 
 export const moveFeedTool = {
   name: 'move_feed',
+  title: 'Move News Feed',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Move a feed into a different folder.',
   inputSchema: z.object({
     feedId: z.number().describe('The feed ID to move'),
@@ -153,6 +181,13 @@ export const moveFeedTool = {
 
 export const renameFeedTool = {
   name: 'rename_feed',
+  title: 'Rename News Feed',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Rename a feed.',
   inputSchema: z.object({
     feedId: z.number().describe('The feed ID to rename'),
@@ -173,6 +208,13 @@ export const renameFeedTool = {
 
 export const markFeedReadTool = {
   name: 'mark_feed_read',
+  title: 'Mark Feed as Read',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Mark all items in a feed as read up to (and including) the given newest item ID.',
   inputSchema: z.object({
     feedId: z.number().describe('The feed ID'),
@@ -195,6 +237,13 @@ export const markFeedReadTool = {
 
 export const listNewsFoldersTool = {
   name: 'list_news_folders',
+  title: 'List News Folders',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List all folders used to organize feeds in the Nextcloud News app.',
   inputSchema: z.object({}),
   handler: async () => {
@@ -213,6 +262,13 @@ export const listNewsFoldersTool = {
 
 export const createNewsFolderTool = {
   name: 'create_news_folder',
+  title: 'Create News Folder',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description: 'Create a new folder for organizing feeds in the News app.',
   inputSchema: z.object({
     name: z.string().describe('The folder name'),
@@ -237,6 +293,13 @@ export const createNewsFolderTool = {
 
 export const renameNewsFolderTool = {
   name: 'rename_news_folder',
+  title: 'Rename News Folder',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Rename a News folder.',
   inputSchema: z.object({
     folderId: z.number().describe('The folder ID to rename'),
@@ -257,6 +320,13 @@ export const renameNewsFolderTool = {
 
 export const deleteNewsFolderTool = {
   name: 'delete_news_folder',
+  title: 'Delete News Folder',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete a News folder and all feeds it contains.',
   inputSchema: z.object({
     folderId: z.number().describe('The folder ID to delete'),
@@ -273,6 +343,13 @@ export const deleteNewsFolderTool = {
 
 export const markNewsFolderReadTool = {
   name: 'mark_news_folder_read',
+  title: 'Mark News Folder as Read',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Mark all items in a folder as read up to (and including) the given newest item ID.',
   inputSchema: z.object({
     folderId: z.number().describe('The folder ID'),
@@ -295,6 +372,13 @@ export const markNewsFolderReadTool = {
 
 export const listNewsItemsTool = {
   name: 'list_news_items',
+  title: 'List News Items',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List news articles (items). Filter by feed, folder, starred, or all; supports pagination and read/unread filtering.',
   inputSchema: z.object({
@@ -347,6 +431,13 @@ export const listNewsItemsTool = {
 
 export const markItemReadTool = {
   name: 'mark_item_read',
+  title: 'Mark News Item as Read',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Mark a single news item as read.',
   inputSchema: z.object({
     itemId: z.number().describe('The item ID'),
@@ -363,6 +454,13 @@ export const markItemReadTool = {
 
 export const markItemUnreadTool = {
   name: 'mark_item_unread',
+  title: 'Mark News Item as Unread',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Mark a single news item as unread.',
   inputSchema: z.object({
     itemId: z.number().describe('The item ID'),
@@ -379,6 +477,13 @@ export const markItemUnreadTool = {
 
 export const starItemTool = {
   name: 'star_item',
+  title: 'Star News Item',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Star (favorite) a single news item.',
   inputSchema: z.object({
     itemId: z.number().describe('The item ID'),
@@ -395,6 +500,13 @@ export const starItemTool = {
 
 export const unstarItemTool = {
   name: 'unstar_item',
+  title: 'Unstar News Item',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Remove the star from a single news item.',
   inputSchema: z.object({
     itemId: z.number().describe('The item ID'),
@@ -411,6 +523,13 @@ export const unstarItemTool = {
 
 export const markItemsReadTool = {
   name: 'mark_items_read',
+  title: 'Mark News Items as Read',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Mark multiple news items as read in one call.',
   inputSchema: z.object({
     itemIds: z.array(z.number()).describe('The item IDs to mark as read'),

--- a/mcp-server/src/tools/apps/notes.ts
+++ b/mcp-server/src/tools/apps/notes.ts
@@ -28,6 +28,13 @@ function formatNote(note: Note): string {
 
 export const listNotesTool = {
   name: 'list_notes',
+  title: 'List Notes',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List all notes in Nextcloud Notes. Returns id, title, category, favorite flag, and modification date.',
   inputSchema: z.object({
@@ -66,6 +73,13 @@ export const listNotesTool = {
 
 export const getNoteTool = {
   name: 'get_note',
+  title: 'Get Note',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Get the full content of a note by its ID.',
   inputSchema: z.object({
     id: z.number().int().describe('Note ID (from list_notes)'),
@@ -89,6 +103,13 @@ export const getNoteTool = {
 
 export const createNoteTool = {
   name: 'create_note',
+  title: 'Create Note',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description: 'Create a new note in Nextcloud Notes.',
   inputSchema: z.object({
     title: z.string().describe('Title of the note'),
@@ -128,6 +149,13 @@ export const createNoteTool = {
 
 export const updateNoteTool = {
   name: 'update_note',
+  title: 'Update Note',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Update an existing note. Provide only the fields you want to change.',
   inputSchema: z.object({
     id: z.number().int().describe('Note ID (from list_notes)'),
@@ -172,6 +200,13 @@ export const updateNoteTool = {
 
 export const deleteNoteTool = {
   name: 'delete_note',
+  title: 'Delete Note',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete a note by its ID.',
   inputSchema: z.object({
     id: z.number().int().describe('Note ID (from list_notes)'),

--- a/mcp-server/src/tools/apps/notifications.ts
+++ b/mcp-server/src/tools/apps/notifications.ts
@@ -27,6 +27,13 @@ interface Notification {
 
 export const listNotificationsTool = {
   name: 'list_notifications',
+  title: 'List Notifications',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List all notifications for the current user',
   inputSchema: z.object({}),
   handler: async () => {
@@ -76,6 +83,13 @@ export const listNotificationsTool = {
 
 export const getNotificationTool = {
   name: 'get_notification',
+  title: 'Get Notification',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Get details of a specific notification by ID',
   inputSchema: z.object({
     id: z.number().describe('The notification ID'),
@@ -109,6 +123,13 @@ export const getNotificationTool = {
 
 export const markNotificationReadTool = {
   name: 'mark_notification_read',
+  title: 'Mark Notification as Read',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Mark a notification as read (deletes it)',
   inputSchema: z.object({
     id: z.number().describe('The notification ID to mark as read'),
@@ -142,6 +163,13 @@ export const markNotificationReadTool = {
 
 export const deleteAllNotificationsTool = {
   name: 'delete_all_notifications',
+  title: 'Delete All Notifications',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete all notifications for the current user',
   inputSchema: z.object({}),
   handler: async () => {

--- a/mcp-server/src/tools/apps/passman.ts
+++ b/mcp-server/src/tools/apps/passman.ts
@@ -62,6 +62,13 @@ function formatCredential(cred: PassmanCredential): string {
 
 export const listVaultsTool = {
   name: 'passman_list_vaults',
+  title: 'List Password Vaults',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: `List all Passman password vaults. Returns name, guid, creation/last-access time and credential count. ${E2E_NOTE}`,
   inputSchema: z.object({}),
   handler: async () => {
@@ -88,6 +95,13 @@ export const listVaultsTool = {
 
 export const listCredentialsTool = {
   name: 'passman_list_credentials',
+  title: 'List Vault Credentials',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: `List credentials (metadata only) in a Passman vault. Returns each credential's label, id, guid and non-secret flags. ${E2E_NOTE}`,
   inputSchema: z.object({
     vault_guid: z.string().describe('Vault GUID (from passman_list_vaults)'),
@@ -121,6 +135,13 @@ export const listCredentialsTool = {
 
 export const getCredentialInfoTool = {
   name: 'passman_get_credential_info',
+  title: 'Get Credential Info',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: `Get non-secret metadata for a single Passman credential (label, id, timestamps, flags). ${E2E_NOTE}`,
   inputSchema: z.object({
     vault_guid: z.string().describe('Vault GUID (from passman_list_vaults)'),

--- a/mcp-server/src/tools/apps/photos.ts
+++ b/mcp-server/src/tools/apps/photos.ts
@@ -114,6 +114,13 @@ const METADATA_PROPFIND = `<?xml version="1.0"?>
 
 export const photosListAlbumsTool = {
   name: 'photos_list_albums',
+  title: 'List Photo Albums',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List all photo albums owned by the current user. Returns album names, item counts, locations, and date ranges.',
   inputSchema: z.object({}),
@@ -173,6 +180,13 @@ export const photosListAlbumsTool = {
 
 export const photosGetAlbumTool = {
   name: 'photos_get_album',
+  title: 'Get Photo Album',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Get details of a photo album including its files. Returns file IDs (needed for photos_remove_from_album), names, types, and sizes.',
   inputSchema: z.object({
@@ -232,6 +246,13 @@ export const photosGetAlbumTool = {
 
 export const photosCreateAlbumTool = {
   name: 'photos_create_album',
+  title: 'Create Photo Album',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description: 'Create a new photo album.',
   inputSchema: z.object({
     name: z.string().describe('Name for the new album'),
@@ -263,6 +284,13 @@ export const photosCreateAlbumTool = {
 
 export const photosDeleteAlbumTool = {
   name: 'photos_delete_album',
+  title: 'Delete Photo Album',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Delete a photo album. This only removes the album — the underlying files are not deleted.',
   inputSchema: z.object({
@@ -295,6 +323,13 @@ export const photosDeleteAlbumTool = {
 
 export const photosRenameAlbumTool = {
   name: 'photos_rename_album',
+  title: 'Rename Photo Album',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Rename a photo album.',
   inputSchema: z.object({
     name: z.string().describe('Current album name'),
@@ -334,6 +369,13 @@ export const photosRenameAlbumTool = {
 
 export const photosAddToAlbumTool = {
   name: 'photos_add_to_album',
+  title: 'Add Photos to Album',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Add one or more files to a photo album. Files are referenced by their Nextcloud path. The files themselves are not moved — only an album association is created.',
   inputSchema: z.object({
@@ -408,6 +450,13 @@ export const photosAddToAlbumTool = {
 
 export const photosRemoveFromAlbumTool = {
   name: 'photos_remove_from_album',
+  title: 'Remove Photos from Album',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Remove one or more files from a photo album by file ID (use photos_get_album to find IDs). This only removes the album association — the files are not deleted.',
   inputSchema: z.object({
@@ -478,6 +527,13 @@ export const photosRemoveFromAlbumTool = {
 
 export const photosGetMetadataTool = {
   name: 'photos_get_metadata',
+  title: 'Get Photo Metadata',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Get photo/video metadata (EXIF) for a file. Returns camera, lens, ISO, aperture, shutter speed, focal length, GPS coordinates, dimensions, and date taken when available.',
   inputSchema: z.object({
@@ -602,6 +658,13 @@ export const photosGetMetadataTool = {
 
 export const photosSetFavoriteTool = {
   name: 'photos_set_favorite',
+  title: 'Set Photo Favorite',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Mark or unmark a file as favorite.',
   inputSchema: z.object({
     path: z.string().describe('File path in Nextcloud (e.g., "/Photos/sunset.jpg")'),
@@ -650,6 +713,13 @@ export const photosSetFavoriteTool = {
 
 export const photosSetAlbumLocationTool = {
   name: 'photos_set_album_location',
+  title: 'Set Photo Album Location',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Set or update the location metadata on a photo album.',
   inputSchema: z.object({
     name: z.string().describe('Album name'),
@@ -696,6 +766,13 @@ export const photosSetAlbumLocationTool = {
 
 export const photosAddCollaboratorsTool = {
   name: 'photos_add_collaborators',
+  title: 'Add Photo Album Collaborators',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Add collaborators (users or groups) to a photo album. Collaborators can view and add photos to the album.',
   inputSchema: z.object({

--- a/mcp-server/src/tools/apps/polls.ts
+++ b/mcp-server/src/tools/apps/polls.ts
@@ -101,6 +101,13 @@ function formatShare(s: PollShare): string {
 
 export const listPollsTool = {
   name: 'list_polls',
+  title: 'List Polls',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List all polls the current user can access (own, shared, or public). Returns id, title, type, owner, and status.',
   inputSchema: z.object({}),
@@ -126,6 +133,13 @@ export const listPollsTool = {
 
 export const getPollTool = {
   name: 'get_poll',
+  title: 'Get Poll',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Get full details of a poll by ID: configuration, owner, status, and current user state.',
   inputSchema: z.object({
@@ -145,6 +159,13 @@ export const getPollTool = {
 
 export const createPollTool = {
   name: 'create_poll',
+  title: 'Create Poll',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Create a new poll. Type "textPoll" for text options (e.g. lunch choices), "datePoll" for date/time options (e.g. meeting scheduling).',
   inputSchema: z.object({
@@ -168,6 +189,13 @@ export const createPollTool = {
 
 export const updatePollTool = {
   name: 'update_poll',
+  title: 'Update Poll',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Update a poll configuration. Only provided fields are changed. Set expire to 0 for no expiration, or a unix timestamp to auto-close on that date.',
   inputSchema: z.object({
@@ -235,6 +263,13 @@ export const updatePollTool = {
 
 export const deletePollTool = {
   name: 'delete_poll',
+  title: 'Delete Poll',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Permanently delete a poll. This cannot be undone.',
   inputSchema: z.object({
     pollId: z.number().int().describe('Poll ID'),
@@ -253,6 +288,13 @@ export const deletePollTool = {
 
 export const closePollTool = {
   name: 'close_poll',
+  title: 'Close Poll',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Close a poll immediately so no further votes are accepted.',
   inputSchema: z.object({
     pollId: z.number().int().describe('Poll ID'),
@@ -273,6 +315,13 @@ export const closePollTool = {
 
 export const reopenPollTool = {
   name: 'reopen_poll',
+  title: 'Reopen Poll',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Reopen a previously closed poll so voting can resume.',
   inputSchema: z.object({
     pollId: z.number().int().describe('Poll ID'),
@@ -293,6 +342,13 @@ export const reopenPollTool = {
 
 export const clonePollTool = {
   name: 'clone_poll',
+  title: 'Clone Poll',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description: 'Clone an existing poll, copying its configuration and options into a new poll.',
   inputSchema: z.object({
     pollId: z.number().int().describe('Poll ID to clone'),
@@ -317,6 +373,13 @@ export const clonePollTool = {
 
 export const listPollOptionsTool = {
   name: 'list_poll_options',
+  title: 'List Poll Options',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List all options for a poll, with vote tallies per option.',
   inputSchema: z.object({
     pollId: z.number().int().describe('Poll ID'),
@@ -345,6 +408,13 @@ export const listPollOptionsTool = {
 
 export const addTextPollOptionTool = {
   name: 'add_text_poll_option',
+  title: 'Add Text Poll Option',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Add a text option to a textPoll (e.g. "Pizza", "Sushi"). Use add_date_poll_option for datePolls.',
   inputSchema: z.object({
@@ -371,6 +441,13 @@ export const addTextPollOptionTool = {
 
 export const addDatePollOptionTool = {
   name: 'add_date_poll_option',
+  title: 'Add Date Poll Option',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Add a date/time option to a datePoll. Provide startAt as ISO-8601 (e.g. "2026-05-12T14:00:00Z") and durationSeconds (e.g. 3600 for 1 hour).',
   inputSchema: z.object({
@@ -421,6 +498,13 @@ export const addDatePollOptionTool = {
 
 export const deletePollOptionTool = {
   name: 'delete_poll_option',
+  title: 'Delete Poll Option',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete an option from a poll by option ID.',
   inputSchema: z.object({
     optionId: z.number().int().describe('Option ID (from list_poll_options)'),
@@ -443,6 +527,13 @@ export const deletePollOptionTool = {
 
 export const listPollVotesTool = {
   name: 'list_poll_votes',
+  title: 'List Poll Votes',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: "List all votes for a poll. Anonymous polls redact voters' identities.",
   inputSchema: z.object({
     pollId: z.number().int().describe('Poll ID'),
@@ -469,6 +560,13 @@ export const listPollVotesTool = {
 
 export const voteOnPollTool = {
   name: 'vote_on_poll',
+  title: 'Vote on Poll',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Cast or change your vote on a poll option. setTo: "yes" to vote yes, "no" to vote no, "maybe" for a tentative yes (only if allowed).',
   inputSchema: z.object({
@@ -501,6 +599,13 @@ export const voteOnPollTool = {
 
 export const listPollCommentsTool = {
   name: 'list_poll_comments',
+  title: 'List Poll Comments',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List all comments on a poll.',
   inputSchema: z.object({
     pollId: z.number().int().describe('Poll ID'),
@@ -529,6 +634,13 @@ export const listPollCommentsTool = {
 
 export const addPollCommentTool = {
   name: 'add_poll_comment',
+  title: 'Add Poll Comment',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description: 'Post a comment on a poll (requires comments to be enabled).',
   inputSchema: z.object({
     pollId: z.number().int().describe('Poll ID'),
@@ -551,6 +663,13 @@ export const addPollCommentTool = {
 
 export const deletePollCommentTool = {
   name: 'delete_poll_comment',
+  title: 'Delete Poll Comment',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete one of your poll comments by comment ID.',
   inputSchema: z.object({
     commentId: z.number().int().describe('Comment ID (from list_poll_comments)'),
@@ -573,6 +692,13 @@ export const deletePollCommentTool = {
 
 export const listPollSharesTool = {
   name: 'list_poll_shares',
+  title: 'List Poll Shares',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List all shares (public link, user invitations, email invitations) for a poll.',
   inputSchema: z.object({
     pollId: z.number().int().describe('Poll ID'),
@@ -601,6 +727,13 @@ export const listPollSharesTool = {
 
 export const addPollShareTool = {
   name: 'add_poll_share',
+  title: 'Add Poll Share',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Share a poll. type="public" creates a public link (no extra fields). type="user" invites a Nextcloud user (requires userId). type="email" invites by email (requires userId=email address, displayName).',
   inputSchema: z.object({
@@ -664,6 +797,13 @@ export const addPollShareTool = {
 
 export const deletePollShareTool = {
   name: 'delete_poll_share',
+  title: 'Delete Poll Share',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Revoke a poll share by its token (obtained from list_poll_shares or add_poll_share).',
   inputSchema: z.object({
@@ -687,6 +827,13 @@ export const deletePollShareTool = {
 
 export const setPollSubscriptionTool = {
   name: 'set_poll_subscription',
+  title: 'Set Poll Subscription',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Subscribe or unsubscribe the current user to poll notifications (new votes, comments). Use subscribe=true to subscribe, false to unsubscribe.',
   inputSchema: z.object({

--- a/mcp-server/src/tools/apps/projects.ts
+++ b/mcp-server/src/tools/apps/projects.ts
@@ -44,6 +44,13 @@ function formatProject(p: Project): string {
 
 export const listProjectsTool = {
   name: 'list_projects',
+  title: 'List Projects',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List all AIquila projects for the current user. Projects bundle files/directories with an optional system prompt.',
   inputSchema: z.object({}),
@@ -77,6 +84,13 @@ export const listProjectsTool = {
 
 export const createProjectTool = {
   name: 'create_project',
+  title: 'Create Project',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Create a new AIquila project. Projects bundle files/directories with an optional system prompt that gets injected into conversations.',
   inputSchema: z.object({
@@ -117,6 +131,13 @@ export const createProjectTool = {
 
 export const getProjectTool = {
   name: 'get_project',
+  title: 'Get Project',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Get details of an AIquila project including its file/directory paths.',
   inputSchema: z.object({
     id: z.number().describe('Project ID'),
@@ -144,6 +165,13 @@ export const getProjectTool = {
 
 export const updateProjectTool = {
   name: 'update_project',
+  title: 'Update Project',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Update an AIquila project. Only provided fields are updated.',
   inputSchema: z.object({
     id: z.number().describe('Project ID'),
@@ -190,6 +218,13 @@ export const updateProjectTool = {
 
 export const deleteProjectTool = {
   name: 'delete_project',
+  title: 'Delete Project',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Delete an AIquila project. Associated paths are removed and conversations referencing it are unlinked.',
   inputSchema: z.object({
@@ -218,6 +253,13 @@ export const deleteProjectTool = {
 
 export const addProjectPathTool = {
   name: 'add_project_path',
+  title: 'Add Project Path',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Add a file or directory path to an AIquila project.',
   inputSchema: z.object({
     id: z.number().describe('Project ID'),
@@ -258,6 +300,13 @@ export const addProjectPathTool = {
 
 export const removeProjectPathTool = {
   name: 'remove_project_path',
+  title: 'Remove Project Path',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Remove a file or directory path from an AIquila project.',
   inputSchema: z.object({
     id: z.number().describe('Project ID'),

--- a/mcp-server/src/tools/apps/recommendations.ts
+++ b/mcp-server/src/tools/apps/recommendations.ts
@@ -48,6 +48,13 @@ function formatRecommendations(items: RecommendedFile[]): string {
 
 export const listRecommendationsTool = {
   name: 'list_recommendations',
+  title: 'List Recommendations',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List files Nextcloud recommends for the configured user (e.g. recently or frequently ' +
     'accessed, recently shared, or files in active folders), including the reason each file ' +

--- a/mcp-server/src/tools/apps/registration.ts
+++ b/mcp-server/src/tools/apps/registration.ts
@@ -47,6 +47,13 @@ const KNOWN_KEYS = Object.keys(REGISTRATION_KEYS);
 
 export const getRegistrationSettingsTool = {
   name: 'get_registration_settings',
+  title: 'Get Registration Settings',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Read the Nextcloud Registration app settings (self-service signup configuration), such as ' +
     'allowed email domains, whether admin approval is required, and the default group for new ' +
@@ -88,6 +95,13 @@ export const getRegistrationSettingsTool = {
 
 export const updateRegistrationSettingsTool = {
   name: 'update_registration_settings',
+  title: 'Update Registration Settings',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Update one or more Nextcloud Registration app settings. Boolean settings use the strings ' +
     "'yes'/'no'; allowed_domains takes a JSON array string (e.g. '[\"example.com\"]'). Requires " +
@@ -144,6 +158,13 @@ export const updateRegistrationSettingsTool = {
 
 export const resetRegistrationSettingTool = {
   name: 'reset_registration_setting',
+  title: 'Reset Registration Setting',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Reset a Nextcloud Registration app setting to its default by deleting the stored value. ' +
     'Requires the configured Nextcloud user to be an admin.',

--- a/mcp-server/src/tools/apps/shares.ts
+++ b/mcp-server/src/tools/apps/shares.ts
@@ -39,6 +39,13 @@ const SHARE_TYPE_LABELS: Record<number, string> = {
  */
 export const listSharesTool = {
   name: 'list_shares',
+  title: 'List Shares',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List file shares in Nextcloud (for diagnostics and security auditing)',
   inputSchema: z.object({
     path: z.string().optional().describe('Filter shares for a specific file/folder path'),
@@ -106,6 +113,13 @@ export const listSharesTool = {
  */
 export const createShareTool = {
   name: 'create_share',
+  title: 'Create Share',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description: 'Create a file or folder share in Nextcloud',
   inputSchema: z.object({
     path: z.string().describe('File or folder path to share'),
@@ -183,6 +197,13 @@ export const createShareTool = {
  */
 export const updateShareTool = {
   name: 'update_share',
+  title: 'Update Share',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Update an existing share in Nextcloud',
   inputSchema: z.object({
     shareId: z.number().describe('The share ID to update'),
@@ -248,6 +269,13 @@ export const updateShareTool = {
  */
 export const deleteShareTool = {
   name: 'delete_share',
+  title: 'Delete Share',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete a share in Nextcloud',
   inputSchema: z.object({
     shareId: z.number().describe('The share ID to delete'),
@@ -285,6 +313,13 @@ export const deleteShareTool = {
  */
 export const getShareTool = {
   name: 'get_share',
+  title: 'Get Share',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Get detailed information about a specific share by its ID',
   inputSchema: z.object({
     shareId: z.number().describe('The share ID to retrieve'),
@@ -317,6 +352,13 @@ export const getShareTool = {
  */
 export const listSharesWithMeTool = {
   name: 'list_shares_with_me',
+  title: 'List Shares With Me',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List all files and folders shared with the current user',
   inputSchema: z.object({}),
   handler: async () => {
@@ -364,6 +406,13 @@ export const listSharesWithMeTool = {
  */
 export const searchShareesTool = {
   name: 'search_sharees',
+  title: 'Search Share Recipients',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Search for valid share recipients (users, groups, emails, federated users, circles, rooms)',
   inputSchema: z.object({
@@ -412,6 +461,13 @@ export const searchShareesTool = {
  */
 export const listPendingSharesTool = {
   name: 'list_pending_shares',
+  title: 'List Pending Shares',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List pending federated/remote shares waiting to be accepted or declined',
   inputSchema: z.object({}),
   handler: async () => {
@@ -449,6 +505,13 @@ export const listPendingSharesTool = {
  */
 export const acceptPendingShareTool = {
   name: 'accept_pending_share',
+  title: 'Accept Pending Share',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Accept a pending federated/remote share',
   inputSchema: z.object({
     shareId: z.number().describe('The pending share ID to accept'),
@@ -482,6 +545,13 @@ export const acceptPendingShareTool = {
  */
 export const declinePendingShareTool = {
   name: 'decline_pending_share',
+  title: 'Decline Pending Share',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Decline a pending federated/remote share',
   inputSchema: z.object({
     shareId: z.number().describe('The pending share ID to decline'),

--- a/mcp-server/src/tools/apps/social-sharing.ts
+++ b/mcp-server/src/tools/apps/social-sharing.ts
@@ -109,6 +109,13 @@ async function resolvePublicShare(args: { share_id?: number; path?: string }): P
 
 export const generateSocialShareLinksTool = {
   name: 'generate_social_share_links',
+  title: 'Generate Social Share Links',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Generate social-network share URLs (email, X/Twitter, Facebook, Telegram, WhatsApp, ' +
     'Bluesky, Diaspora) for an existing Nextcloud public-link share. Only networks whose ' +

--- a/mcp-server/src/tools/apps/talk.ts
+++ b/mcp-server/src/tools/apps/talk.ts
@@ -112,6 +112,13 @@ function wrapError(action: string, err: unknown) {
 
 export const listConversationsTool = {
   name: 'talk_list_conversations',
+  title: 'List Talk Conversations',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List all Talk conversations the user has access to. Returns conversation tokens, names, types, and unread message counts.',
   inputSchema: z.object({
@@ -152,6 +159,13 @@ export const listConversationsTool = {
 
 export const listMessagesTool = {
   name: 'talk_list_messages',
+  title: 'List Talk Messages',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List recent messages in a Talk conversation. Returns message content with timestamps and authors.',
   inputSchema: z.object({
@@ -208,6 +222,13 @@ export const listMessagesTool = {
 
 export const sendMessageTool = {
   name: 'talk_send_message',
+  title: 'Send Talk Message',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Send a message to a Talk conversation. Supports replies and silent messages that do not trigger notifications.',
   inputSchema: z.object({
@@ -245,6 +266,13 @@ export const sendMessageTool = {
 
 export const createConversationTool = {
   name: 'talk_create_conversation',
+  title: 'Create Talk Conversation',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Create a new Talk conversation. One-on-one requires an invite user, group/public require a name.',
   inputSchema: z.object({
@@ -295,6 +323,13 @@ export const createConversationTool = {
 
 export const listParticipantsTool = {
   name: 'talk_list_participants',
+  title: 'List Talk Participants',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List all participants in a Talk conversation with their roles.',
   inputSchema: z.object({
     token: z.string().describe('Conversation token'),
@@ -323,6 +358,13 @@ export const listParticipantsTool = {
 
 export const addParticipantTool = {
   name: 'talk_add_participant',
+  title: 'Add Talk Participant',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Add a user, group, or email participant to a Talk conversation.',
   inputSchema: z.object({
     token: z.string().describe('Conversation token'),
@@ -354,6 +396,13 @@ export const addParticipantTool = {
 
 export const removeParticipantTool = {
   name: 'talk_remove_participant',
+  title: 'Remove Talk Participant',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Remove a participant from a Talk conversation by their attendee ID (from list_participants).',
   inputSchema: z.object({
@@ -381,6 +430,13 @@ export const removeParticipantTool = {
 
 export const deleteMessageTool = {
   name: 'talk_delete_message',
+  title: 'Delete Talk Message',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete a message from a Talk conversation.',
   inputSchema: z.object({
     token: z.string().describe('Conversation token'),
@@ -404,6 +460,13 @@ export const deleteMessageTool = {
 
 export const createPollTool = {
   name: 'talk_create_poll',
+  title: 'Create Talk Poll',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description: 'Create a poll in a Talk conversation. Requires at least 2 options.',
   inputSchema: z.object({
     token: z.string().describe('Conversation token'),
@@ -456,6 +519,13 @@ export const createPollTool = {
 
 export const reactToMessageTool = {
   name: 'talk_react_to_message',
+  title: 'React to Talk Message',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Add an emoji reaction to a message in a Talk conversation.',
   inputSchema: z.object({
     token: z.string().describe('Conversation token'),

--- a/mcp-server/src/tools/apps/tasks.ts
+++ b/mcp-server/src/tools/apps/tasks.ts
@@ -350,6 +350,13 @@ async function resolveTaskByUid(
  */
 export const listTaskListsTool = {
   name: 'list_task_lists',
+  title: 'List Task Lists',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List all task lists in Nextcloud Tasks',
   inputSchema: z.object({}),
   handler: async () => {
@@ -391,6 +398,13 @@ export const listTaskListsTool = {
  */
 export const listTasksTool = {
   name: 'list_tasks',
+  title: 'List Tasks',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List tasks from a Nextcloud Tasks calendar. Returns task details including status, priority, dates, tags, and UIDs.',
   inputSchema: z.object({
@@ -482,6 +496,13 @@ export const listTasksTool = {
  */
 export const createTaskTool = {
   name: 'create_task',
+  title: 'Create Task',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Create a new task in Nextcloud Tasks with optional due date, start date, tags, location, and subtask relationships.',
   inputSchema: z.object({
@@ -609,6 +630,13 @@ export const createTaskTool = {
  */
 export const updateTaskTool = {
   name: 'update_task',
+  title: 'Update Task',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "Update an existing task's fields by UID. Uses CalDAV ETag-based optimistic concurrency.",
   inputSchema: z.object({
@@ -786,6 +814,13 @@ export const updateTaskTool = {
  */
 export const deleteTaskTool = {
   name: 'delete_task',
+  title: 'Delete Task',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete a task from Nextcloud Tasks by UID. This action is irreversible.',
   inputSchema: z.object({
     uid: z.string().describe('The UID of the task to delete'),
@@ -838,6 +873,13 @@ export const deleteTaskTool = {
  */
 export const completeTaskTool = {
   name: 'complete_task',
+  title: 'Complete Task',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Mark a task as completed or reopen it. Sets STATUS, PERCENT-COMPLETE, and COMPLETED date atomically.',
   inputSchema: z.object({

--- a/mcp-server/src/tools/apps/terms-of-service.ts
+++ b/mcp-server/src/tools/apps/terms-of-service.ts
@@ -45,6 +45,13 @@ function preview(body: string): string {
 
 export const getTermsOfServiceTool = {
   name: 'get_terms_of_service',
+  title: 'Get Terms of Service',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Read the Nextcloud Terms of Service admin configuration: all published terms (by ' +
     'country/language), the enforcement settings (tos_for_users, tos_on_public_shares), and ' +
@@ -100,6 +107,13 @@ export const getTermsOfServiceTool = {
 
 export const setTermsOfServiceTool = {
   name: 'set_terms_of_service',
+  title: 'Set Terms of Service',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Create or update the terms of service for a given country/language pair. If terms ' +
     'already exist for that pair they are replaced, otherwise new terms are created. Use ' +
@@ -154,6 +168,13 @@ export const setTermsOfServiceTool = {
 
 export const deleteTermsOfServiceTool = {
   name: 'delete_terms_of_service',
+  title: 'Delete Terms of Service',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Delete a single terms of service entry by its id (see get_terms_of_service). Requires ' +
     'the configured Nextcloud user to be an admin.',
@@ -187,6 +208,13 @@ export const deleteTermsOfServiceTool = {
 
 export const resetTermsSignaturesTool = {
   name: 'reset_terms_signatures',
+  title: 'Reset Terms Signatures',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "Reset ALL users' terms of service signatures org-wide, forcing every user to accept " +
     'the terms again on next login. This is destructive and cannot be undone. Requires the ' +
@@ -224,6 +252,13 @@ export const resetTermsSignaturesTool = {
 
 export const updateTermsSettingsTool = {
   name: 'update_terms_settings',
+  title: 'Update Terms Settings',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Update the Terms of Service enforcement settings: whether logged-in users must accept ' +
     'the terms (tos_for_users) and whether the terms apply to public shares ' +

--- a/mcp-server/src/tools/apps/text.ts
+++ b/mcp-server/src/tools/apps/text.ts
@@ -59,6 +59,13 @@ async function resolveWorkspaceFile(folder: string): Promise<TextWorkspaceFile |
 
 export const getTextWorkspaceTool = {
   name: 'get_text_workspace',
+  title: 'Get Text Workspace',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "Get metadata of the Text workspace file (Readme.md) for a folder. Returns the file's id, name, mimetype and path, or reports that no workspace exists yet.",
   inputSchema: z.object({ path: FolderPathArg }),
@@ -86,6 +93,13 @@ export const getTextWorkspaceTool = {
 
 export const readTextWorkspaceTool = {
   name: 'read_text_workspace',
+  title: 'Read Text Workspace',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "Read the content of a folder's Text workspace file (Readme.md). Returns markdown text, or a 'no workspace' message if none exists.",
   inputSchema: z.object({ path: FolderPathArg }),
@@ -113,6 +127,13 @@ export const readTextWorkspaceTool = {
 
 export const writeTextWorkspaceTool = {
   name: 'write_text_workspace',
+  title: 'Write Text Workspace',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "Create or overwrite a folder's Text workspace file. If a workspace already exists, its existing filename is reused; otherwise Readme.md is created at the folder root.",
   inputSchema: z.object({
@@ -143,6 +164,13 @@ export const writeTextWorkspaceTool = {
 
 export const deleteTextWorkspaceTool = {
   name: 'delete_text_workspace',
+  title: 'Delete Text Workspace',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Delete the Text workspace file (Readme.md) for a folder. The folder itself is kept. No-op if the folder has no workspace.',
   inputSchema: z.object({ path: FolderPathArg }),
@@ -172,6 +200,13 @@ export const deleteTextWorkspaceTool = {
 
 export const getTextWorkspaceEditUrlTool = {
   name: 'get_text_workspace_edit_url',
+  title: 'Get Text Workspace Edit URL',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "Get a one-shot direct-edit URL for a folder's Text workspace. Opens the live collaborative editor in a browser. The Readme.md is created automatically if it does not exist yet. Hand the URL to a human collaborator — the MCP server does not participate in the editing session.",
   inputSchema: z.object({ path: FolderPathArg }),

--- a/mcp-server/src/tools/apps/translate.ts
+++ b/mcp-server/src/tools/apps/translate.ts
@@ -26,6 +26,13 @@ interface LanguagePair {
 
 export const translateTextTool = {
   name: 'translate_text',
+  title: 'Translate Text',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
   description:
     "Translate text between languages using Nextcloud's configured translation provider. If called without text, returns available language pairs.",
   inputSchema: z.object({

--- a/mcp-server/src/tools/apps/trash.ts
+++ b/mcp-server/src/tools/apps/trash.ts
@@ -15,6 +15,13 @@ import { getNextcloudConfig } from '../types.js';
 
 export const listTrashTool = {
   name: 'list_trash',
+  title: 'List Trash',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List files in the trash / recycle bin',
   inputSchema: z.object({}),
   handler: async () => {
@@ -113,6 +120,13 @@ export const listTrashTool = {
 
 export const restoreFromTrashTool = {
   name: 'restore_from_trash',
+  title: 'Restore from Trash',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Restore a file from the trash to its original location (use the Key from list_trash)',
   inputSchema: z.object({
@@ -173,6 +187,13 @@ export const restoreFromTrashTool = {
 
 export const emptyTrashTool = {
   name: 'empty_trash',
+  title: 'Empty Trash',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Permanently delete all files in the trash (cannot be undone)',
   inputSchema: z.object({}),
   handler: async () => {

--- a/mcp-server/src/tools/apps/user-status.ts
+++ b/mcp-server/src/tools/apps/user-status.ts
@@ -27,6 +27,13 @@ const STATUS_TYPES = ['online', 'away', 'dnd', 'invisible', 'offline'] as const;
 
 export const getUserStatusTool = {
   name: 'get_user_status',
+  title: 'Get User Status',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "Get the current user's presence status (online, away, DND, invisible, custom message)",
   inputSchema: z.object({
@@ -65,6 +72,13 @@ export const getUserStatusTool = {
 
 export const setUserStatusTool = {
   name: 'set_user_status',
+  title: 'Set User Status',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: "Set the current user's status type (online, away, dnd, invisible, offline)",
   inputSchema: z.object({
     statusType: z.enum(STATUS_TYPES).describe('Status type to set'),
@@ -99,6 +113,13 @@ export const setUserStatusTool = {
 
 export const setUserStatusMessageTool = {
   name: 'set_user_status_message',
+  title: 'Set User Status Message',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Set a custom status message with optional emoji icon and auto-clear time',
   inputSchema: z.object({
     message: z.string().describe('Custom status message text'),
@@ -147,6 +168,13 @@ export const setUserStatusMessageTool = {
 
 export const clearUserStatusMessageTool = {
   name: 'clear_user_status_message',
+  title: 'Clear User Status Message',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: "Clear the current user's custom status message",
   inputSchema: z.object({}),
   handler: async () => {
@@ -178,6 +206,13 @@ export const clearUserStatusMessageTool = {
 
 export const listUserStatusesTool = {
   name: 'list_user_statuses',
+  title: 'List User Statuses',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: "List all users' statuses for team presence visibility",
   inputSchema: z.object({
     limit: z.number().optional().describe('Maximum number of statuses to return'),

--- a/mcp-server/src/tools/apps/users.ts
+++ b/mcp-server/src/tools/apps/users.ts
@@ -13,6 +13,13 @@ import { fetchOCS } from '../../client/ocs.js';
  */
 export const listUsersTool = {
   name: 'list_users',
+  title: 'List Users',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List all users in the Nextcloud instance. Requires admin or sub-admin privileges',
   inputSchema: z.object({
     search: z.string().optional().describe('Search/filter string for user IDs'),
@@ -59,6 +66,13 @@ export const listUsersTool = {
  */
 export const getUserInfoTool = {
   name: 'get_user_info',
+  title: 'Get User Info',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Get detailed information about a specific Nextcloud user. Non-admin users can only query their own user ID',
   inputSchema: z.object({
@@ -97,6 +111,13 @@ export const getUserInfoTool = {
  */
 export const enableUserTool = {
   name: 'enable_user',
+  title: 'Enable User',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Enable a disabled Nextcloud user account. Requires admin privileges',
   inputSchema: z.object({
     userId: z.string().describe('The user ID (login name) to enable'),
@@ -134,6 +155,13 @@ export const enableUserTool = {
  */
 export const disableUserTool = {
   name: 'disable_user',
+  title: 'Disable User',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Disable a Nextcloud user account (prevents login but preserves data). Requires admin privileges',
   inputSchema: z.object({

--- a/mcp-server/src/tools/apps/versions.ts
+++ b/mcp-server/src/tools/apps/versions.ts
@@ -15,6 +15,13 @@ import { getNextcloudConfig } from '../types.js';
 
 export const listFileVersionsTool = {
   name: 'list_file_versions',
+  title: 'List File Versions',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List previous versions of a file (use get_file_info to find the fileId)',
   inputSchema: z.object({
     fileId: z.number().describe('The Nextcloud internal file ID (from get_file_info)'),
@@ -106,6 +113,13 @@ export const listFileVersionsTool = {
 
 export const restoreFileVersionTool = {
   name: 'restore_file_version',
+  title: 'Restore File Version',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Restore a previous version of a file (creates a new current version from the old one)',
   inputSchema: z.object({

--- a/mcp-server/src/tools/system/apps.ts
+++ b/mcp-server/src/tools/system/apps.ts
@@ -14,6 +14,13 @@ import { executeOCC } from '../../client/aiquila.js';
  */
 export const listAppsTool = {
   name: 'list_apps',
+  title: 'List Apps',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List all installed Nextcloud apps with their enabled/disabled status. Requires admin privileges',
   inputSchema: z.object({
@@ -63,6 +70,13 @@ export const listAppsTool = {
  */
 export const getAppInfoTool = {
   name: 'get_app_info',
+  title: 'Get App Info',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Get detailed information about a specific Nextcloud app. Requires admin privileges',
   inputSchema: z.object({
     appId: z.string().describe('The app ID (e.g., "tasks", "deck", "photos")'),
@@ -100,6 +114,13 @@ export const getAppInfoTool = {
  */
 export const enableAppTool = {
   name: 'enable_app',
+  title: 'Enable App',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Enable a disabled Nextcloud app. Requires admin privileges',
   inputSchema: z.object({
     appId: z.string().describe('The app ID to enable (e.g., "tasks", "deck", "photos")'),
@@ -137,6 +158,13 @@ export const enableAppTool = {
  */
 export const disableAppTool = {
   name: 'disable_app',
+  title: 'Disable App',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Disable an enabled Nextcloud app (preserves data but removes functionality). Requires admin privileges',
   inputSchema: z.object({
@@ -175,6 +203,13 @@ export const disableAppTool = {
  */
 export const installAppTool = {
   name: 'install_app',
+  title: 'Install App',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
   description: 'Install a Nextcloud app from the App Store via occ app:install',
   inputSchema: z.object({
     appId: z.string().describe('App ID to install (e.g. "tasks", "calendar", "mail")'),
@@ -197,6 +232,13 @@ export const installAppTool = {
  */
 export const uninstallAppTool = {
   name: 'uninstall_app',
+  title: 'Uninstall App',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Remove a Nextcloud app via occ app:remove',
   inputSchema: z.object({
     appId: z.string().describe('App ID to remove (e.g. "tasks")'),

--- a/mcp-server/src/tools/system/files.ts
+++ b/mcp-server/src/tools/system/files.ts
@@ -15,6 +15,13 @@ import { PathSchema, FilePathSchema, FileContentSchema, FolderPathSchema } from 
  */
 export const listFilesTool = {
   name: 'list_files',
+  title: 'List Files',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List files and folders in a Nextcloud directory',
   inputSchema: z.object({
     path: z.string().default('/').describe("The directory path to list (default: '/')"),
@@ -38,6 +45,13 @@ export const listFilesTool = {
  */
 export const readFileTool = {
   name: 'read_file',
+  title: 'Read File',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Read the contents of a file from Nextcloud',
   inputSchema: FilePathSchema,
   handler: async (args: { path: string }) => {
@@ -61,6 +75,13 @@ export const readFileTool = {
  */
 export const writeFileTool = {
   name: 'write_file',
+  title: 'Write File',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Create or update a file in Nextcloud. File size is limited (default 1 GB, configurable via MCP_MAX_FILE_SIZE).',
   inputSchema: FileContentSchema,
@@ -85,6 +106,13 @@ export const writeFileTool = {
  */
 export const createFolderTool = {
   name: 'create_folder',
+  title: 'Create Folder',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Create a folder in Nextcloud',
   inputSchema: FolderPathSchema,
   handler: async (args: { path: string }) => {
@@ -106,6 +134,13 @@ export const createFolderTool = {
  */
 export const deleteTool = {
   name: 'delete',
+  title: 'Delete File or Folder',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Delete a file or folder from Nextcloud',
   inputSchema: PathSchema,
   handler: async (args: { path: string }) => {
@@ -127,6 +162,13 @@ export const deleteTool = {
  */
 export const getFileInfoTool = {
   name: 'get_file_info',
+  title: 'Get File Info',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Get detailed file metadata from Nextcloud (name, size, mime type, modified date, permissions, etc.)',
   inputSchema: z.object({
@@ -161,6 +203,13 @@ export const getFileInfoTool = {
  */
 export const searchFilesTool = {
   name: 'search_files',
+  title: 'Search Files',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Search for files in Nextcloud by name pattern and/or mime type',
   inputSchema: z.object({
     query: z.string().describe('Search query (file name pattern)'),
@@ -201,6 +250,13 @@ export const searchFilesTool = {
  */
 export const getFileContentTool = {
   name: 'get_file_content',
+  title: 'Get File Content',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Read file content from Nextcloud with mime type info. Returns text for text files, base64 for binary files (images, PDFs, etc.). Images are returned as MCP image content for Claude vision.',
   inputSchema: z.object({
@@ -276,6 +332,13 @@ export const getFileContentTool = {
  */
 export const analyzeImageTool = {
   name: 'analyze_image',
+  title: 'Analyze Image',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
   description:
     'Analyze one or more images stored in Nextcloud using Claude vision. Ask questions about image content, extract text (OCR), describe visuals, compare images, or analyse documents. Supports up to 20 images for multi-image comparison.',
   inputSchema: z.object({
@@ -386,6 +449,13 @@ export const analyzeImageTool = {
  */
 export const moveFileTool = {
   name: 'move_file',
+  title: 'Move File',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Move or rename a file or folder in Nextcloud',
   inputSchema: z.object({
     source: z.string().describe('The source path of the file or folder to move'),
@@ -427,6 +497,13 @@ export const moveFileTool = {
  */
 export const copyFileTool = {
   name: 'copy_file',
+  title: 'Copy File',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Copy a file or folder in Nextcloud',
   inputSchema: z.object({
     source: z.string().describe('The source path of the file or folder to copy'),
@@ -468,6 +545,13 @@ export const copyFileTool = {
  */
 export const bulkFileOperationsTool = {
   name: 'bulk_file_operations',
+  title: 'Bulk File Operations',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Execute multiple file operations (move, copy, delete) sequentially in a single call. Returns per-item results.',
   inputSchema: z.object({
@@ -537,6 +621,13 @@ export const bulkFileOperationsTool = {
  */
 export const createArchiveTool = {
   name: 'create_archive',
+  title: 'Create Archive',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Create a zip archive in Nextcloud from one or more files and/or folders. Runs server-side; not bound by MCP file-size limits.',
   inputSchema: z.object({
@@ -585,6 +676,13 @@ export const createArchiveTool = {
  */
 export const extractArchiveTool = {
   name: 'extract_archive',
+  title: 'Extract Archive',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Extract a zip archive in Nextcloud into a destination folder. Runs server-side.',
   inputSchema: z.object({
     archive: z.string().describe("Path to the .zip file (e.g., '/Documents/backup.zip')"),
@@ -627,6 +725,13 @@ export const extractArchiveTool = {
  */
 export const listArchiveTool = {
   name: 'list_archive',
+  title: 'List Archive Contents',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'List the contents of a zip archive in Nextcloud without extracting it.',
   inputSchema: z.object({
     archive: z.string().describe("Path to the .zip file (e.g., '/Documents/backup.zip')"),

--- a/mcp-server/src/tools/system/occ.ts
+++ b/mcp-server/src/tools/system/occ.ts
@@ -47,6 +47,13 @@ export function getOccAllowlist(): string[] {
 
 export const runOccTool = {
   name: 'run_occ',
+  title: 'Run OCC Command',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description:
     'Execute an allowlisted Nextcloud OCC command on the server and return the output. ' +
     'Only commands in the allowlist may be run (configurable via MCP_OCC_ALLOWLIST env var). ' +

--- a/mcp-server/src/tools/system/search.ts
+++ b/mcp-server/src/tools/system/search.ts
@@ -67,6 +67,13 @@ async function searchProvider(
  */
 export const unifiedSearchTool = {
   name: 'unified_search',
+  title: 'Unified Search',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Search across all Nextcloud apps (files, calendar, contacts, mail, notes, etc.) using Unified Search. ' +
     'Optionally filter by a specific provider ID. Without a provider, searches the top providers in parallel.',
@@ -196,6 +203,13 @@ export const unifiedSearchTool = {
  */
 export const listSearchProvidersTool = {
   name: 'list_search_providers',
+  title: 'List Search Providers',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List all available Unified Search providers in Nextcloud. ' +
     'Use this to discover provider IDs for targeted searches with unified_search.',

--- a/mcp-server/src/tools/system/security.ts
+++ b/mcp-server/src/tools/system/security.ts
@@ -13,6 +13,13 @@ import { executeOCC, formatOccError } from '../../client/aiquila.js';
  */
 export const checkCoreIntegrityTool = {
   name: 'check_core_integrity',
+  title: 'Check Core Integrity',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Verify Nextcloud core system integrity by checking file signatures against the official release',
   inputSchema: z.object({}),
@@ -62,6 +69,13 @@ export const checkCoreIntegrityTool = {
  */
 export const checkAppIntegrityTool = {
   name: 'check_app_integrity',
+  title: 'Check App Integrity',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Verify integrity of a specific Nextcloud app by checking file signatures against its official release',
   inputSchema: z.object({

--- a/mcp-server/src/tools/system/status.ts
+++ b/mcp-server/src/tools/system/status.ts
@@ -14,6 +14,13 @@ import { executeOCC, formatOccError } from '../../client/aiquila.js';
  */
 export const systemStatusTool = {
   name: 'system_status',
+  title: 'System Status',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Get Nextcloud system status including version, installation path, and configuration',
   inputSchema: z.object({}),
@@ -56,6 +63,13 @@ export const systemStatusTool = {
  */
 export const setupChecksTool = {
   name: 'run_setup_checks',
+  title: 'Run Setup Checks',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Run Nextcloud setup checks to verify system configuration (security, performance, PHP modules, etc.). Requires admin privileges',
   inputSchema: z.object({}),
@@ -105,6 +119,13 @@ export const setupChecksTool = {
  */
 export const getLocalTimeTool = {
   name: 'get_local_time',
+  title: 'Get Local Time',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Get the current local time and timezone of the MCP server. ' +
     'Call this to establish a time reference before creating or listing calendar events, ' +

--- a/mcp-server/src/tools/system/tags.ts
+++ b/mcp-server/src/tools/system/tags.ts
@@ -15,6 +15,13 @@ import { getNextcloudConfig } from '../types.js';
  */
 export const getFileTagsTool = {
   name: 'get_file_tags',
+  title: 'Get File Tags',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Get the personal tags assigned to a file or folder in Nextcloud',
   inputSchema: z.object({
     path: z.string().describe("The file or folder path in Nextcloud (e.g., '/Photos/test.png')"),
@@ -85,6 +92,13 @@ export const getFileTagsTool = {
  */
 export const setFileTagsTool = {
   name: 'set_file_tags',
+  title: 'Set File Tags',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Set personal tags on a file or folder in Nextcloud. Replaces all existing personal tags. Use an empty array to clear all tags.',
   inputSchema: z.object({
@@ -162,6 +176,13 @@ export const setFileTagsTool = {
  */
 export const assignSystemTagTool = {
   name: 'assign_system_tag',
+  title: 'Assign System Tag',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'Assign a system tag to a file by file ID and tag ID. Use get_file_info to obtain the file ID.',
   inputSchema: z.object({
@@ -220,6 +241,13 @@ export const assignSystemTagTool = {
  */
 export const removeSystemTagTool = {
   name: 'remove_system_tag',
+  title: 'Remove System Tag',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: 'Remove a system tag from a file by file ID and tag ID',
   inputSchema: z.object({
     fileId: z.number().describe('The Nextcloud file ID'),
@@ -277,6 +305,13 @@ export const removeSystemTagTool = {
  */
 export const listSystemTagsTool = {
   name: 'list_system_tags',
+  title: 'List System Tags',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     'List all available system tags in Nextcloud with their IDs, names, and properties. Use this to find tag IDs before assigning them to files.',
   inputSchema: z.object({}),
@@ -382,6 +417,13 @@ export const listSystemTagsTool = {
  */
 export const createSystemTagTool = {
   name: 'create_system_tag',
+  title: 'Create System Tag',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
   description: 'Create a new system tag in Nextcloud. Returns the created tag info.',
   inputSchema: z.object({
     name: z.string().describe('The name for the new system tag'),

--- a/mcp-server/src/tools/types.ts
+++ b/mcp-server/src/tools/types.ts
@@ -7,6 +7,41 @@ import { z } from 'zod';
  */
 
 /**
+ * MCP tool behaviour hints, surfaced to clients via `tools/list`.
+ *
+ * All four are required here (the MCP spec makes them optional) so that
+ * `tsc` rejects any tool that forgets to classify itself. Claude uses
+ * `readOnlyHint` and `destructiveHint` to decide whether a call needs
+ * per-invocation confirmation.
+ */
+export interface ToolAnnotations {
+  /** Tool only reads data; it never mutates Nextcloud state. */
+  readOnlyHint: boolean;
+  /** Tool overwrites or removes existing data (as opposed to purely additive). */
+  destructiveHint: boolean;
+  /** Repeating the call with identical arguments has no further effect. */
+  idempotentHint: boolean;
+  /** Tool reaches an unbounded external world rather than just this Nextcloud. */
+  openWorldHint: boolean;
+}
+
+/**
+ * The shape every entry in a `*Tools` array must satisfy. Enforced structurally
+ * where the arrays are placed into `TOOL_REGISTRY` in `../tool-registry.ts`.
+ */
+export interface Tool {
+  name: string;
+  /** Human-readable display name, e.g. 'Get Out-of-Office Status'. */
+  title: string;
+  description: string;
+  annotations: ToolAnnotations;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  inputSchema: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handler: (...args: any[]) => any;
+}
+
+/**
  * Zod schemas for common parameters
  */
 

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.28</version>
+    <version>0.3.29</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
## Problem

None of our 301 MCP tools declared `title` or `annotations`. Two consequences:

1. **UX** — without `readOnlyHint`, harmless reads (`list_files`, `get_file_info`, `system_status`) prompt for confirmation on every call.
2. **Directory submission** — annotations are a hard requirement in Anthropic's [pre-submission checklist](https://claude.com/docs/connectors/building/review-criteria): *"Every tool must include a `title` and the applicable hint … These determine auto-permissions in Claude."*

## Approach

`title` and all four hints are now **required** on the tool contract (`Tool` / `ToolAnnotations` in `src/tools/types.ts`), replacing the inline anonymous type in `tool-registry.ts`. `tsc` therefore rejects any tool that forgets to classify itself — a stronger guarantee than a lint rule, and it needs no new tooling.

That gate immediately earned its keep: it caught the **five tools generated by the `stateTool()` factory** in `cowork.ts` (`enable_coworker`, `disable_coworker`, `pause_coworker`, `resume_coworker`, `run_coworker`), which have no literal `name:` line and which a purely textual sweep of the tool files would have silently skipped.

`src/server.ts` now forwards `title` and `annotations` into the SDK's `registerTool`.

### One correction to the issue

The issue proposed a third bucket — *"neither / write-only — `write_file`, `create_folder`, `*_create_*`, `*_update_*`"*. That would have been unsafe: per the MCP spec `destructiveHint` **defaults to `true`** whenever `readOnlyHint` is false, so omitting it leaves every write tool implicitly marked destructive. Every write tool now sets it explicitly.

### Classification rules

| Hint | Rule |
|---|---|
| `readOnlyHint` | Tool only reads. Note `export_map_*` and `export_form_submissions` are **not** read-only despite the prefix — they write a GPX/spreadsheet file into Nextcloud. |
| `destructiveHint` | Overwrites or removes *existing* data (`delete`, `update_*`, `set_*`, `write_file`, `run_occ`, `mark_*_read`), as opposed to purely additive (`create_*`, `add_*`, `copy_file`). |
| `idempotentHint` | Repeating the call with identical args has no further effect. |
| `openWorldHint` | Nextcloud is a closed domain, so `false` almost everywhere. `true` only for the 9 tools that reach an unbounded external world: AI backends (`process_text`, `generate_image`, `translate_text`, `analyze_image`, `aiquila_test`, `run_coworker`), `add_feed` (arbitrary URL), `mail_send_message`, `install_app` (app store). |

Descriptions, input schemas, and handlers are untouched.

## Result

```
total tools: 301
readOnly: 118 | destructive: 118 | additive: 65 | openWorld: 9
missing title/annotations: 0
readOnly+destructive conflict: 0
names >64 chars: 0
```

The 118 read-only tools will now run without per-call confirmation in Claude.

## Verification

- `npm test` — 824 passing (52 files), including new `tool-registry.test.ts` invariants: unique names, names ≤ 64 chars, non-empty titles distinct from `name`, no read-only+destructive conflict, read-only ⇒ idempotent, and spot-checks that `list_files` is read-only and `delete`/`run_occ`/`write_file` are destructive.
- `npx tsc --noEmit` — no new errors (the pre-existing `express` typings and `z.record` arity errors in `maps.ts` are untouched and present on `main`).
- `npm run lint` — 0 errors; `npx prettier --check src/` — clean.
- **End-to-end**: drove a real `initialize` → `tools/list` over the stdio transport and asserted every one of the 301 tools comes back with `title` + `annotations`, e.g. `list_files` → `readOnlyHint: true`, `delete` → `destructiveHint: true`.

Closes #386

Related to #384 — annotations govern permission prompting, not tool visibility, so this does **not** fix the "connector has no tools available" symptom. It was found while investigating that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)