### PR TITLE
feat(mcp): lazy authentication, discovery-bearing 401, and expired-token 401 fix (v0.3.30)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ See `docs/dev/mcp-server-architecture.md` for full architecture details.
 | `MCP_AUTH_SECRET` | If auth | `openssl rand -hex 32` |
 | `MCP_AUTH_ISSUER` | If auth | public HTTPS URL of this server |
 | `MCP_AUTH_STATE_DIR` | No | Directory for persisted OAuth state (default `/app/state`) |
+| `MCP_LAZY_AUTH` | No | `false` requires a bearer token on every JSON-RPC method. Default `true`: `initialize`, `tools/list` and `get_local_time` are served without one |
 | `MCP_LOCALE` | No | BCP 47 locale tag for `localTime` in `get_local_time` (e.g. `sv-SE`); defaults to system locale |
 | `MCP_MAX_FILE_SIZE` | No | Max `write_file` content length in bytes (default `1073741824` = 1 GB) |
 | `MCP_ALLOWED_HOSTS` | No | Comma-separated extra hostnames for DNS rebinding protection (e.g. `mcp` for Docker service name) |

--- a/docs/mcp/oauth.md
+++ b/docs/mcp/oauth.md
@@ -33,8 +33,8 @@ header, which is the signal that makes a client pause, run the OAuth flow, and r
 same call. A JSON-RPC batch is a single HTTP request, so one protected message in a batch
 gates the whole batch.
 
-> **Behaviour change.** Previously *every* `/mcp` request required a token.
-> Anyone who can reach your `/mcp` endpoint can now enumerate tool names,
+> **Behaviour change (v0.3.30).** Before this release, *every* `/mcp` request required a
+> token. Anyone who can reach your `/mcp` endpoint can now enumerate tool names,
 > descriptions and input schemas, and read the server's timezone. No Nextcloud data is
 > reachable without a token. If you deliberately treat `/mcp` as a fully closed endpoint,
 > set `MCP_LAZY_AUTH=false` to restore the old behaviour.

--- a/docs/mcp/oauth.md
+++ b/docs/mcp/oauth.md
@@ -14,6 +14,41 @@ When OAuth is enabled, the standard flow looks like this:
 
 Your Nextcloud credentials are only used during login and are never stored by the MCP server.
 
+## Lazy authentication
+
+MCP clients need to inspect a connector before you sign in — they must complete the
+handshake and read the tool list to show you what the connector can do. So AIquila does
+not demand a token for every request. It serves a small set of methods anonymously and
+challenges only when a request would actually touch your Nextcloud instance.
+
+**Readable without a token:**
+
+- `initialize`, `notifications/initialized`, `ping`
+- `tools/list`, `resources/list`, `resources/templates/list`, `prompts/list`
+- the `get_local_time` tool, which reports the server's clock and timezone
+
+**Everything else requires a Bearer token** — every tool that reaches Nextcloud (files,
+calendar, contacts, Talk, …). Refusals are an HTTP `401` carrying a `WWW-Authenticate`
+header, which is the signal that makes a client pause, run the OAuth flow, and retry the
+same call. A JSON-RPC batch is a single HTTP request, so one protected message in a batch
+gates the whole batch.
+
+> **Behaviour change.** Previously *every* `/mcp` request required a token.
+> Anyone who can reach your `/mcp` endpoint can now enumerate tool names,
+> descriptions and input schemas, and read the server's timezone. No Nextcloud data is
+> reachable without a token. If you deliberately treat `/mcp` as a fully closed endpoint,
+> set `MCP_LAZY_AUTH=false` to restore the old behaviour.
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `MCP_LAZY_AUTH` | `true` | `false` requires a Bearer token on every JSON-RPC method, including `initialize` and `tools/list`. Clients that cannot pre-authenticate will not be able to inspect the connector. |
+
+The startup log tells you which mode you are in:
+
+```
+Lazy auth enabled — tools/list and public tools are readable without a token (set MCP_LAZY_AUTH=false to require one)
+```
+
 ## Prerequisites
 
 - AIquila MCP server running in HTTP transport mode (e.g. via [Standalone Docker](standalone-docker.md))
@@ -122,13 +157,37 @@ You should receive a JSON document similar to:
 }
 ```
 
-### 7. Confirm unauthenticated requests are rejected
+### 7. Confirm protected requests are rejected
+
+Listing the server's tools works without a token — see [Lazy authentication](#lazy-authentication):
 
 ```bash
-curl -i https://mcp.example.com/mcp
+curl -s -o /dev/null -w '%{http_code}\n' https://mcp.example.com/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+# 200
 ```
 
-You should get `401 Unauthorized`. Without a valid Bearer token, all `/mcp` requests are blocked.
+Calling a tool that touches Nextcloud does not:
+
+```bash
+curl -i https://mcp.example.com/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_files","arguments":{"path":"/"}}}'
+```
+
+You should get `401 Unauthorized` with a challenge header pointing at the protected
+resource metadata:
+
+```http
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer error="invalid_token", error_description="Missing Authorization header", resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource/mcp", scope="mcp:tools"
+```
+
+That header is what makes an MCP client prompt you to sign in and then retry the same
+call. If you set `MCP_LAZY_AUTH=false`, the first request returns `401` too.
 
 ## Client-Specific Setup
 
@@ -183,12 +242,21 @@ Tokens are stored in memory only — restarting the container invalidates all ac
 - The MCP server validates Nextcloud credentials on every login by calling your Nextcloud instance's OCS API. If Nextcloud is unreachable, logins will fail.
 - Use a Nextcloud **app password** (not your main password) for the MCP login. This limits the blast radius if the credential is ever exposed. See [Security Best Practice: App Passwords](setup.md#security-best-practice-app-passwords).
 - The login form is served over HTTPS (enforced by your reverse proxy). Never run the auth-enabled server without TLS.
+- **Tool names, descriptions and input schemas are readable without a token** by default, along with the server's timezone. This is [lazy authentication](#lazy-authentication); no Nextcloud data is exposed. Set `MCP_LAZY_AUTH=false` if your threat model treats the tool inventory as sensitive.
 
 ## Troubleshooting
 
 ### `/.well-known/oauth-authorization-server` returns 404
 
 The OAuth router only mounts when `MCP_AUTH_ENABLED=true`. Check the container logs for the "OAuth 2.0 authentication enabled" line. If it's absent, the env var is not being read — verify your `.env` file and restart.
+
+### `/mcp` returns 500 instead of 401 for an expired token
+
+Fixed. Older versions raised a generic error when an access token was invalid or expired,
+which the MCP SDK turned into `500 Internal Server Error`. Clients read that as a server
+fault rather than a cue to re-authenticate, so the session appeared to hang after a token
+aged out. The server now answers `401` with a `WWW-Authenticate` challenge and the client
+silently refreshes. Upgrade if you see 500s correlated with the one-hour token lifetime.
 
 ### Client shows "unable to connect" or "invalid issuer"
 

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.29",
+      "version": "0.3.30",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "description": "Nextcloud MCP server — files, calendar, contacts, mail, maps, notes, tasks & 120+ more tools",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,7 +18,7 @@
       ]
     }
   ],
-  "version": "0.3.29",
+  "version": "0.3.30",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "remotes": [
     {
@@ -36,7 +36,7 @@
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.29",
+      "version": "0.3.30",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -64,7 +64,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.29",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.30",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/__tests__/auth/provider.test.ts
+++ b/mcp-server/src/__tests__/auth/provider.test.ts
@@ -329,6 +329,16 @@ describe('NextcloudOAuthProvider', () => {
       );
     });
 
+    // A bare Error would surface as a 500, which clients read as a server fault
+    // rather than a cue to re-authenticate. It must be an InvalidTokenError so
+    // the SDK answers 401 with a WWW-Authenticate challenge.
+    it('rejects an invalid token with InvalidTokenError (→ 401, not 500)', async () => {
+      const { InvalidTokenError } = await import('@modelcontextprotocol/sdk/server/auth/errors.js');
+      await expect(provider.verifyAccessToken('not-a-jwt')).rejects.toBeInstanceOf(
+        InvalidTokenError
+      );
+    });
+
     it('embeds correct aud claim (resource server URL)', async () => {
       const token = await issueToken();
       const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString());

--- a/mcp-server/src/__tests__/lazy-auth.test.ts
+++ b/mcp-server/src/__tests__/lazy-auth.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect } from 'vitest';
+import { isPublicRequest } from '../transports/lazy-auth.js';
+
+const call = (name: string) => ({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'tools/call',
+  params: { name, arguments: {} },
+});
+
+describe('isPublicRequest', () => {
+  it('allows the handshake and capability listings', () => {
+    for (const method of ['initialize', 'notifications/initialized', 'ping', 'tools/list']) {
+      expect(isPublicRequest({ jsonrpc: '2.0', id: 1, method })).toBe(true);
+    }
+  });
+
+  it('allows a public tool', () => {
+    expect(isPublicRequest(call('get_local_time'))).toBe(true);
+  });
+
+  it('gates a Nextcloud-backed tool', () => {
+    expect(isPublicRequest(call('list_files'))).toBe(false);
+  });
+
+  it('gates unknown methods', () => {
+    expect(isPublicRequest({ jsonrpc: '2.0', id: 1, method: 'resources/read' })).toBe(false);
+  });
+
+  it('allows a batch of public messages', () => {
+    expect(
+      isPublicRequest([{ jsonrpc: '2.0', id: 1, method: 'tools/list' }, call('get_local_time')])
+    ).toBe(true);
+  });
+
+  it('gates a batch where any message is protected', () => {
+    expect(
+      isPublicRequest([{ jsonrpc: '2.0', id: 1, method: 'tools/list' }, call('list_files')])
+    ).toBe(false);
+  });
+
+  it('gates bodyless requests (GET stream, DELETE session)', () => {
+    expect(isPublicRequest(undefined)).toBe(false);
+    expect(isPublicRequest([])).toBe(false);
+  });
+
+  it('gates malformed bodies', () => {
+    expect(isPublicRequest(null)).toBe(false);
+    expect(isPublicRequest('tools/list')).toBe(false);
+    expect(isPublicRequest({ method: 'tools/call' })).toBe(false);
+    expect(isPublicRequest({ method: 'tools/call', params: { name: 42 } })).toBe(false);
+  });
+});

--- a/mcp-server/src/__tests__/transports.test.ts
+++ b/mcp-server/src/__tests__/transports.test.ts
@@ -259,15 +259,66 @@ describe('http transport with auth enabled', () => {
     expect(mockPost).toHaveBeenCalledWith('/auth/login', expect.any(Function), mockLoginHandlerFn);
   });
 
-  it('mounts /mcp with bearer middleware and handler', async () => {
+  it('mounts /mcp with the lazy-auth gate ahead of the bearer middleware', async () => {
     const { startHttp } = await import('../transports/http.js');
     await startHttp();
     expect(mockAll).toHaveBeenCalledWith(
       '/mcp',
-      expect.any(Function),
+      expect.any(Function), // logging + challenge-scope decoration
+      expect.any(Function), // lazy-auth gate
       mockBearerMiddleware,
-      expect.any(Function)
+      expect.any(Function) // authenticated handler
     );
+  });
+
+  it('points the 401 challenge at the protected resource metadata', async () => {
+    const { requireBearerAuth } =
+      await import('@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js');
+    const { startHttp } = await import('../transports/http.js');
+    await startHttp();
+
+    expect(requireBearerAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceMetadataUrl: expect.stringContaining(
+          '/.well-known/oauth-protected-resource/mcp'
+        ) as unknown as string,
+      })
+    );
+
+    // Scopes must not be enforced: tokens issued without them (and the internal
+    // service token) would otherwise start getting 403 insufficient_scope.
+    const opts = (requireBearerAuth as unknown as { mock: { calls: [Record<string, unknown>][] } })
+      .mock.calls[0][0];
+    expect(opts.requiredScopes).toBeUndefined();
+  });
+
+  it('serves public requests without a bearer token', async () => {
+    const { startHttp } = await import('../transports/http.js');
+    await startHttp();
+
+    const mcpCall = mockAll.mock.calls.find((c) => c[0] === '/mcp');
+    const gate = mcpCall?.[2] as (req: any, res: any, next: any) => Promise<void>;
+
+    const next = vi.fn();
+    const res = { on: vi.fn(), setHeader: vi.fn() };
+    await gate(
+      { headers: {}, body: { jsonrpc: '2.0', id: 1, method: 'tools/list' } },
+      res as any,
+      next
+    );
+    expect(next).not.toHaveBeenCalled();
+
+    // ...but a protected tool falls through to the bearer middleware.
+    const next2 = vi.fn();
+    await gate(
+      {
+        headers: {},
+        body: { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'list_files' } },
+      },
+      res as any,
+      next2
+    );
+    expect(next2).toHaveBeenCalled();
   });
 
   it('still connects the MCP server to the transport', async () => {

--- a/mcp-server/src/__tests__/transports.test.ts
+++ b/mcp-server/src/__tests__/transports.test.ts
@@ -271,6 +271,24 @@ describe('http transport with auth enabled', () => {
     );
   });
 
+  it('omits the lazy-auth gate when MCP_LAZY_AUTH=false', async () => {
+    process.env.MCP_LAZY_AUTH = 'false';
+    const { startHttp } = await import('../transports/http.js');
+    await startHttp();
+
+    // Chain collapses to logging + bearer + handler: every method needs a token.
+    expect(mockAll).toHaveBeenCalledWith(
+      '/mcp',
+      expect.any(Function),
+      mockBearerMiddleware,
+      expect.any(Function)
+    );
+
+    const mcpCall = mockAll.mock.calls.find((c) => c[0] === '/mcp');
+    expect(mcpCall).toHaveLength(4);
+    expect(mcpCall?.[2]).toBe(mockBearerMiddleware);
+  });
+
   it('points the 401 challenge at the protected resource metadata', async () => {
     const { requireBearerAuth } =
       await import('@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js');

--- a/mcp-server/src/auth/provider.ts
+++ b/mcp-server/src/auth/provider.ts
@@ -13,7 +13,10 @@ import type {
   OAuthTokens,
   OAuthTokenRevocationRequest,
 } from '@modelcontextprotocol/sdk/shared/auth.js';
-import { InvalidGrantError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
+import {
+  InvalidGrantError,
+  InvalidTokenError,
+} from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import { ClientsStore, CodeStore, RefreshStore } from './store.js';
 import { logger } from '../logger.js';
 
@@ -290,7 +293,10 @@ export class NextcloudOAuthProvider implements OAuthServerProvider {
     );
     if (!claims) {
       logger.warn('[auth] Access token verification failed: invalid or expired token');
-      throw new Error('Invalid or expired access token');
+      // InvalidTokenError (not a bare Error) so the SDK answers 401 with a
+      // WWW-Authenticate challenge. A bare Error becomes a 500, and clients
+      // treat that as a server fault rather than a cue to re-authenticate.
+      throw new InvalidTokenError('Invalid or expired access token');
     }
     return {
       token,

--- a/mcp-server/src/transports/http.ts
+++ b/mcp-server/src/transports/http.ts
@@ -15,11 +15,18 @@ import {
   markStateUnwritableWarned,
 } from '../auth/store.js';
 import { loginHandler } from '../auth/login.js';
+import { isPublicRequest } from './lazy-auth.js';
 import { logger } from '../logger.js';
 import { fetchStatus } from '../client/ocs.js';
 
 const DEFAULT_PORT = 3339;
 const MCP_PATH = '/mcp';
+const SCOPES_SUPPORTED = ['mcp:tools', 'mcp:resources', 'mcp:prompts'];
+
+// Scope advertised in the WWW-Authenticate challenge. Clients request exactly
+// this on authorisation; omitting it makes them fall back to the full
+// `scopes_supported` union, which produces an over-broad consent prompt.
+const CHALLENGE_SCOPE = 'mcp:tools';
 
 // TLS error codes that indicate a self-signed or untrusted certificate.
 // Network errors (ECONNREFUSED, ETIMEDOUT) are not included — they mean the
@@ -261,7 +268,7 @@ export async function startHttp(): Promise<void> {
         issuerUrl: new URL(issuerUrl),
         resourceServerUrl: new URL(MCP_PATH, issuerUrl),
         serviceDocumentationUrl: new URL('https://github.com/elgorro/aiquila'),
-        scopesSupported: ['mcp:tools', 'mcp:resources', 'mcp:prompts'],
+        scopesSupported: SCOPES_SUPPORTED,
       })
     );
 
@@ -272,7 +279,7 @@ export async function startHttp(): Promise<void> {
       res.json({
         resource: new URL(MCP_PATH, issuerUrl).href,
         authorization_servers: [issuerUrl],
-        scopes_supported: ['mcp:tools', 'mcp:resources', 'mcp:prompts'],
+        scopes_supported: SCOPES_SUPPORTED,
         resource_documentation: 'https://github.com/elgorro/aiquila',
       });
     });
@@ -315,9 +322,43 @@ export async function startHttp(): Promise<void> {
             );
           }
         });
+
+        // The SDK appends `scope="..."` to the challenge only when
+        // `requiredScopes` is set — but setting that would also *enforce* the
+        // scope, and 403 every token issued before scopes were requested (plus
+        // the internal service token, which carries none). Advertise the scope
+        // without enforcing it by decorating the header on its way out.
+        const setHeader = res.setHeader.bind(res);
+        res.setHeader = (name: string, value: any) => {
+          if (
+            typeof name === 'string' &&
+            name.toLowerCase() === 'www-authenticate' &&
+            typeof value === 'string' &&
+            !value.includes('scope=')
+          ) {
+            value = `${value}, scope="${CHALLENGE_SCOPE}"`;
+          }
+          return setHeader(name, value);
+        };
         next();
       },
-      requireBearerAuth({ verifier: provider }),
+
+      // Lazy-auth gate: the handshake, capability listings, and public tools are
+      // served anonymously so clients can inspect the connector before sign-in.
+      // Everything else falls through to requireBearerAuth below.
+      async (req: any, res: any, next: any) => {
+        if (!req.headers.authorization && isPublicRequest(req.body)) {
+          logger.debug({ rpcMethod: req.body?.method }, '[mcp] Public request (unauthenticated)');
+          await handleMcpRequest(req, res);
+          return;
+        }
+        next();
+      },
+
+      requireBearerAuth({
+        verifier: provider,
+        resourceMetadataUrl: new URL('/.well-known/oauth-protected-resource/mcp', issuerUrl).href,
+      }),
       async (req: any, res: any) => {
         logger.debug({ method: req.method, rpcMethod: req.body?.method }, '[mcp] Request received');
         await handleMcpRequest(req, res);

--- a/mcp-server/src/transports/http.ts
+++ b/mcp-server/src/transports/http.ts
@@ -116,6 +116,11 @@ export async function startHttp(): Promise<void> {
   const host = process.env.MCP_HOST || '0.0.0.0';
   const authEnabled = process.env.MCP_AUTH_ENABLED === 'true';
 
+  // Lazy authentication is on by default: clients need to inspect a connector
+  // before signing in. Operators who treat /mcp as a fully closed endpoint can
+  // set MCP_LAZY_AUTH=false to require a bearer token on every JSON-RPC method.
+  const lazyAuthEnabled = process.env.MCP_LAZY_AUTH !== 'false';
+
   if (!authEnabled) {
     if (process.env.MCP_ALLOW_UNAUTHENTICATED !== 'true') {
       throw new Error(
@@ -346,14 +351,23 @@ export async function startHttp(): Promise<void> {
       // Lazy-auth gate: the handshake, capability listings, and public tools are
       // served anonymously so clients can inspect the connector before sign-in.
       // Everything else falls through to requireBearerAuth below.
-      async (req: any, res: any, next: any) => {
-        if (!req.headers.authorization && isPublicRequest(req.body)) {
-          logger.debug({ rpcMethod: req.body?.method }, '[mcp] Public request (unauthenticated)');
-          await handleMcpRequest(req, res);
-          return;
-        }
-        next();
-      },
+      // Omitted entirely when MCP_LAZY_AUTH=false, restoring a chain in which
+      // every JSON-RPC method requires a bearer token.
+      ...(lazyAuthEnabled
+        ? [
+            async (req: any, res: any, next: any) => {
+              if (!req.headers.authorization && isPublicRequest(req.body)) {
+                logger.debug(
+                  { rpcMethod: req.body?.method },
+                  '[mcp] Public request (unauthenticated)'
+                );
+                await handleMcpRequest(req, res);
+                return;
+              }
+              next();
+            },
+          ]
+        : []),
 
       requireBearerAuth({
         verifier: provider,
@@ -382,6 +396,12 @@ export async function startHttp(): Promise<void> {
     if (authEnabled) {
       const tp = process.env.MCP_TRUST_PROXY;
       logger.info({ issuer: process.env.MCP_AUTH_ISSUER }, 'OAuth 2.0 authentication enabled');
+      logger.info(
+        { lazyAuth: lazyAuthEnabled },
+        lazyAuthEnabled
+          ? 'Lazy auth enabled — tools/list and public tools are readable without a token (set MCP_LAZY_AUTH=false to require one)'
+          : 'Lazy auth disabled — every JSON-RPC method requires a bearer token'
+      );
       logger.info(
         { trustProxy: tp && tp !== 'false' ? tp : 'disabled' },
         'Trust proxy setting (set MCP_TRUST_PROXY=1 if behind a reverse proxy)'

--- a/mcp-server/src/transports/lazy-auth.ts
+++ b/mcp-server/src/transports/lazy-auth.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+
+/**
+ * Lazy authentication (mixed auth) for the Streamable HTTP transport.
+ *
+ * Unauthenticated clients may complete the MCP handshake, enumerate the server's
+ * capabilities, and call the tools listed in PUBLIC_TOOLS.  Anything else is
+ * refused at the HTTP layer with a 401 + WWW-Authenticate challenge, which is
+ * what makes clients render an inline "Connect" card and retry the same call
+ * once the user has authorised.
+ *
+ * The refusal has to be an HTTP status, so the check must run *before* the
+ * JSON-RPC message reaches the MCP SDK: once a tool handler is executing, its
+ * return value is already destined to be wrapped in a 200 response, and a 200
+ * carrying `isError: true` reads as an application-level failure, not an auth
+ * challenge.
+ *
+ * @see https://claude.com/docs/connectors/building/lazy-authentication
+ */
+
+/**
+ * JSON-RPC methods reachable without a token.  These describe the server rather
+ * than touching the Nextcloud instance behind it, so they leak nothing.
+ */
+const PUBLIC_METHODS: ReadonlySet<string> = new Set([
+  'initialize',
+  'notifications/initialized',
+  'notifications/cancelled',
+  'ping',
+  'tools/list',
+  'resources/list',
+  'resources/templates/list',
+  'prompts/list',
+]);
+
+/**
+ * Tools reachable without a token.  Every other AIquila tool proxies to
+ * Nextcloud, so this set is deliberately tiny.
+ */
+const PUBLIC_TOOLS: ReadonlySet<string> = new Set(['get_local_time']);
+
+function isPublicMessage(msg: unknown): boolean {
+  if (!msg || typeof msg !== 'object') return false;
+
+  const method = (msg as { method?: unknown }).method;
+  if (typeof method !== 'string') return false;
+
+  if (method === 'tools/call') {
+    const name = (msg as { params?: { name?: unknown } }).params?.name;
+    return typeof name === 'string' && PUBLIC_TOOLS.has(name);
+  }
+
+  return PUBLIC_METHODS.has(method);
+}
+
+/**
+ * True when every message in the request body is safe to serve anonymously.
+ *
+ * A JSON-RPC batch is a single HTTP request and therefore gets a single status
+ * code, so one protected message taints the whole batch.  An empty or
+ * non-JSON-RPC body (a GET for the SSE stream, a DELETE to end a session) is
+ * never public — those still require a bearer token.
+ */
+export function isPublicRequest(body: unknown): boolean {
+  const messages = Array.isArray(body) ? body : [body];
+  if (messages.length === 0) return false;
+  return messages.every(isPublicMessage);
+}

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.29</version>
+    <version>0.3.30</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
> ## ⚠️ Behaviour change
>
> Previously **every** `/mcp` request required a bearer token. After this release, anyone who can reach the `/mcp` endpoint can enumerate tool names, descriptions and input schemas (`tools/list`) and read the server's timezone (`get_local_time`).
>
> **No Nextcloud data is reachable without a token** — every tool that touches the instance still returns `401`.
>
> This is the point of lazy authentication: clients must be able to inspect a connector before sign-in. Operators who deliberately treat `/mcp` as a fully closed endpoint can set **`MCP_LAZY_AUTH=false`** to restore the old behaviour. Announced in #391.

Implements [lazy authentication](https://claude.com/docs/connectors/building/lazy-authentication) for the Streamable HTTP transport, and fixes two auth bugs found while building it.

Closes #389

## What's in here

**Lazy auth gate.** New `transports/lazy-auth.ts` exports `isPublicRequest(body)`. Public methods are the handshake and capability listings (`initialize`, `notifications/initialized`, `ping`, `tools/list`, `resources/list`, `resources/templates/list`, `prompts/list`); `PUBLIC_TOOLS` holds only `get_local_time`, since every other AIquila tool proxies to Nextcloud. A JSON-RPC batch is a single HTTP request and gets a single status code, so one protected message gates the whole batch. Bodyless requests (the `GET` SSE stream, a `DELETE` session teardown) are never public.

**`MCP_LAZY_AUTH` opt-out.** Default `true`. When `false`, the gate middleware is omitted from the chain entirely, so the disabled path is exactly the pre-existing middleware order rather than a variant of it. The active mode is logged at startup.

**Discovery-bearing `401`.** `requireBearerAuth` now receives `resourceMetadataUrl`. The challenge previously read `Bearer error="invalid_token"` with no `resource_metadata`, so clients could never follow the RFC 9728 chain to the authorization server.

**Scope advertised, not enforced.** The natural fix — passing `requiredScopes: ['mcp:tools']` — also *enforces* the scope, and would start returning `403 insufficient_scope` for every token issued before scopes were requested, as well as for the `MCP_INTERNAL_TOKEN` service token, which `provider.ts` mints with `scopes: []`. The header is instead decorated on its way out, so the challenge advertises `scope="mcp:tools"` (narrowing the consent prompt) while token acceptance is unchanged.

**Bug fix: expired tokens returned `500`, not `401`.** `verifyAccessToken` threw a bare `Error` on an invalid or expired token. The SDK maps anything that isn't an `OAuthError` to `500`, so a client holding a stale token saw a server fault rather than a cue to re-authenticate — sessions could appear to hang once a token aged out after its one-hour lifetime. Now throws `InvalidTokenError` → proper `401` + challenge. Found by curling the running server, not by reading the code.

**Docs.** `docs/mcp/oauth.md` gains a "Lazy authentication" section, a rewritten verification step (the old one asserted that all unauthenticated requests are rejected), a Security Notes line stating plainly that the tool inventory is readable without a token, and a troubleshooting entry for the 500→401 fix. `MCP_LAZY_AUTH` is documented in the `CLAUDE.md` env table.

**Version.** Bumped to 0.3.30 across `mcp-server/package.json`, `server.json` (+ image tag), `nextcloud-app/appinfo/info.xml`, `nextcloud-app/package.json`, and the lock file. Patch, since the feature is additive and the escape hatch preserves prior behaviour.

## Verification

`npm test` (836 pass), `npm run lint` (0 errors), `npx prettier --check src/` all green.

Driven end-to-end against a live server with `MCP_AUTH_ENABLED=true`:

| Request | Before | After (default) | After (`MCP_LAZY_AUTH=false`) |
|---|---|---|---|
| `tools/list`, no token | 401 | **200**, 318 tools | 401 |
| `tools/call get_local_time`, no token | 401 | **200** | 401 |
| `tools/call list_files`, no token | 401, bare challenge | **401** + `resource_metadata` + `scope` | 401 + challenge |
| batch `tools/list` + `list_files`, no token | 401 | **401** | 401 |
| `tools/call list_files`, garbage token | **500** | **401** + challenge | 401 + challenge |

The improved challenge header survives the opt-out — that fix is independent of the gate.

## Follow-up

CIMD (`client_id_metadata_document_supported`) for registration-free onboarding is tracked in #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
