### PR TITLE
fix(docker): mount postgres volume at /var/lib/postgresql for PG 18

### DIFF
--- a/docker/installation/docker-compose.yml
+++ b/docker/installation/docker-compose.yml
@@ -9,7 +9,9 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-nextcloud}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-nextcloud_secure_password}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      # postgres:18+ stores data in a major-version subdirectory and refuses to
+      # start with a mount at /var/lib/postgresql/data.
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-nextcloud}"]
       interval: 10s

--- a/docs/dev/docker-setup.md
+++ b/docs/dev/docker-setup.md
@@ -234,6 +234,11 @@ make reset
 > **Upgrading PostgreSQL major versions:** the stack ships `postgres:18`. A major upgrade
 > won't read an older major's data volume automatically — dump before bumping the image and
 > restore afterwards. See [Upgrading PostgreSQL to 18](../hetzner/advanced.md#upgrading-postgresql-to-18).
+>
+> Note that `postgres_data` is mounted at `/var/lib/postgresql` (not `/var/lib/postgresql/data`),
+> because `postgres:18` stores its data in a major-version subdirectory and refuses to start
+> against the older mount point. A volume from a stack that predates this cannot be reused in
+> place — see [Where the data volume is mounted](../hetzner/advanced.md#where-the-data-volume-is-mounted).
 
 ## Architecture
 

--- a/docs/hetzner/advanced.md
+++ b/docs/hetzner/advanced.md
@@ -274,3 +274,24 @@ docker compose up -d
 
 For the local dev stack (`docker/installation/`) the service is `db` and the volume is
 `aiquila_postgres_data`; adjust the names accordingly.
+
+### Where the data volume is mounted
+
+The database volume is mounted at **`/var/lib/postgresql`**, not at
+`/var/lib/postgresql/data`:
+
+```yaml
+volumes:
+  - nc_db_data:/var/lib/postgresql
+```
+
+`postgres:18` and newer keep their data in a major-version subdirectory
+(`/var/lib/postgresql/18/docker`) so that in-place `pg_upgrade` works. The image refuses to
+start when it finds a mount at the old `/var/lib/postgresql/data` path, reporting
+`there appears to be PostgreSQL data in: /var/lib/postgresql/data (unused mount/volume)`
+and entering a restart loop — which also blocks Nextcloud, the MCP server and Caddy, since
+they all wait for the database to become healthy.
+
+If you are running a stack that predates this change, its volume still holds a
+pre-18 layout and **cannot be reused in place**. Follow the dump/restore steps above; step
+2 removes the old volume, which is exactly what is needed here.

--- a/hetzner/docker/full/docker-compose.yml
+++ b/hetzner/docker/full/docker-compose.yml
@@ -71,7 +71,9 @@ services:
       POSTGRES_USER: nextcloud
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
     volumes:
-      - nc_db_data:/var/lib/postgresql/data
+      # postgres:18+ stores data in a major-version subdirectory and refuses to
+      # start with a mount at /var/lib/postgresql/data.
+      - nc_db_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U nextcloud"]
       interval: 10s

--- a/hetzner/docker/nextcloud/docker-compose.yml
+++ b/hetzner/docker/nextcloud/docker-compose.yml
@@ -70,7 +70,9 @@ services:
       POSTGRES_USER: nextcloud
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
     volumes:
-      - nc_db_data:/var/lib/postgresql/data
+      # postgres:18+ stores data in a major-version subdirectory and refuses to
+      # start with a mount at /var/lib/postgresql/data.
+      - nc_db_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U nextcloud"]
       interval: 10s


### PR DESCRIPTION
Closes #407

## Problem

`postgres:18` stores its data in a major-version subdirectory and refuses to start when a volume is mounted at `/var/lib/postgresql/data`:

> Error: in 18+, these Docker images are configured to store database data in a format which is compatible with "pg_ctlcluster" … there appears to be PostgreSQL data in: /var/lib/postgresql/data (unused mount/volume)

This puts the container in a restart loop, and everything with `depends_on: db` (Nextcloud, MCP, Caddy) never starts. It reproduces on a completely fresh volume, so it is not a leftover-data problem — the mount point itself is wrong for PG 18.

## Change

Mount the volume at `/var/lib/postgresql` instead, per the image's own recommendation, in all three affected stacks:

- `docker/installation/docker-compose.yml` (dev stack)
- `hetzner/docker/nextcloud/docker-compose.yml`
- `hetzner/docker/full/docker-compose.yml`

## Verification

`cd docker/installation && make reset` — the whole stack now comes up healthy and Nextcloud 33.0.0 installs cleanly (`status.php` reports `"installed":true`).

Note: existing volumes are not migrated by this change; a PG 18 deployment could never have started with the old layout, so there is no working data to preserve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)