### PR TITLE
feat(nextcloud): add Claude Opus 5 and Sonnet 5, default to Sonnet 5

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -28,11 +28,11 @@ AIquila is built on these excellent open-source projects and services.
 ## Key libraries
 | Library | Version | Role |
 |---------|---------|------|
-| [@modelcontextprotocol/sdk](https://github.com/modelcontextprotocol/typescript-sdk) | ^1.27 | MCP protocol implementation — tools, resources, and OAuth |
-| [pino](https://getpino.io) | ^9.0 | Structured JSON logging to stderr in the MCP server |
-| [webdav](https://github.com/perry-mitchell/webdav-client) | ^5.8 | WebDAV client — Nextcloud file operations in the MCP server |
-| [zod](https://zod.dev) | ^3.25 | Runtime schema validation for MCP tool inputs |
-| [anthropic-ai/sdk](https://packagist.org/packages/anthropic-ai/sdk) | ^0.5 | Claude API PHP client used by the Nextcloud app |
+| [@modelcontextprotocol/sdk](https://github.com/modelcontextprotocol/typescript-sdk) | ^1.29 | MCP protocol implementation — tools, resources, and OAuth |
+| [pino](https://getpino.io) | ^10.3 | Structured JSON logging to stderr in the MCP server |
+| [webdav](https://github.com/perry-mitchell/webdav-client) | ^5.10 | WebDAV client — Nextcloud file operations in the MCP server |
+| [zod](https://zod.dev) | ^4.4 | Runtime schema validation for MCP tool inputs |
+| [anthropic-ai/sdk](https://packagist.org/packages/anthropic-ai/sdk) | ^0.40 | Claude API PHP client used by the Nextcloud app |
 | [symfony/http-client](https://symfony.com/doc/current/http_client.html) | ^8.0 | HTTP client for the Nextcloud app backend |
 | [hcloud-go](https://github.com/hetznercloud/hcloud-go) | v2.10 | Hetzner Cloud Go SDK — server provisioning in the CLI |
 | [cobra](https://github.com/spf13/cobra) | v1.9 | CLI framework for `aiquila-hetzner` |

--- a/docs/installation/aiquila-setup.md
+++ b/docs/installation/aiquila-setup.md
@@ -93,9 +93,10 @@ sudo -u www-data php occ app:enable aiquila
 1. Navigate to **Settings → Administration → AIquila**
 2. Enter your Claude API key from [console.anthropic.com](https://console.anthropic.com)
 3. Configure settings (optional):
-   - **Claude Model**: Default is `claude-sonnet-4-6` (adaptive thinking, medium effort)
-     - Most capable: `claude-opus-4-7` (adaptive thinking, xhigh effort — recommended for complex reasoning and agentic coding)
-     - Other options: `claude-opus-4-6`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`, `claude-opus-4-5-20251101`
+   - **Claude Model**: Default is `claude-sonnet-5` (adaptive thinking, medium effort)
+     - Most capable: `claude-fable-5` (adaptive thinking always on, xhigh effort)
+     - For complex agentic coding and enterprise work: `claude-opus-5` (adaptive thinking, xhigh effort)
+     - Other options: `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`, `claude-opus-4-5-20251101`
    - **Max Tokens**: Response length limit (1-100,000, default: 4096)
    - **API Timeout**: Request timeout in seconds (10-1800, default: 30)
 4. Click **Save**

--- a/docs/internal-api.md
+++ b/docs/internal-api.md
@@ -126,7 +126,7 @@ Get current AIquila configuration status.
   ```php
   [
       'configured' => bool,      // Whether an API key is set
-      'model' => string,         // Claude model (e.g., 'claude-opus-4-7', 'claude-sonnet-4-6')
+      'model' => string,         // Claude model (e.g., 'claude-opus-5', 'claude-sonnet-5')
       'max_tokens' => int,       // Maximum tokens (1-100000)
       'timeout' => int           // API timeout in seconds (10-1800)
   ]

--- a/docs/mcp/mcp-connector.md
+++ b/docs/mcp/mcp-connector.md
@@ -20,7 +20,7 @@ import Anthropic from "@anthropic-ai/sdk";
 const anthropic = new Anthropic(); // reads ANTHROPIC_API_KEY from env
 
 const response = await (anthropic.beta.messages as any).create({
-  model: "claude-opus-4-7",
+  model: "claude-opus-5",
   max_tokens: 2000,
   messages: [
     {

--- a/docs/mcp/tools/apps/aiquila.md
+++ b/docs/mcp/tools/apps/aiquila.md
@@ -246,12 +246,19 @@ php occ aiquila:test --user username
 
 ### Model
 Current Claude models:
-- `claude-opus-4-7` - Most capable; adaptive thinking, xhigh effort (recommended for complex reasoning and agentic coding)
-- `claude-opus-4-6` - Frontier model with adaptive thinking, high effort
-- `claude-sonnet-4-6` - Adaptive thinking, medium effort (**default**)
+- `claude-fable-5` - Most capable; adaptive thinking (always on), xhigh effort
+- `claude-opus-5` - Complex agentic coding and enterprise work; adaptive thinking, xhigh effort
+- `claude-sonnet-5` - Best speed/intelligence balance; adaptive thinking, medium effort (**default**)
+- `claude-opus-4-8` - Previous-generation Opus; adaptive thinking, xhigh effort
+- `claude-opus-4-7` - Adaptive thinking, xhigh effort
+- `claude-opus-4-6` - Adaptive thinking, high effort
+- `claude-sonnet-4-6` - Adaptive thinking, medium effort
 - `claude-sonnet-4-5-20250929` - Fast, cost-effective
 - `claude-haiku-4-5-20251001` - Fastest, most economical
-- `claude-opus-4-5-20251101` - Previous Opus generation
+- `claude-opus-4-5-20251101` - Older Opus generation
+
+Fable 5, Opus 5, Sonnet 5, and Opus 4.7+ reject the `temperature` / `top_p` / `top_k`
+sampling parameters; AIquila omits them automatically for those models.
 
 ### Max Tokens
 - **Range**: 1 - 100,000

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.31",
+      "version": "0.3.32",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "description": "Nextcloud MCP server — files, calendar, contacts, mail, maps, notes, tasks & 120+ more tools",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/scripts/test-mcp-connector.ts
+++ b/mcp-server/scripts/test-mcp-connector.ts
@@ -204,7 +204,7 @@ async function testWithConnector(accessToken: string): Promise<boolean> {
   // Use beta.messages for mcp-client-2025-11-20 support.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const response = await (anthropic.beta.messages as any).create({
-    model: 'claude-opus-4-6',
+    model: 'claude-opus-5',
     max_tokens: 2000,
     messages: [
       {

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,7 +18,7 @@
       ]
     }
   ],
-  "version": "0.3.31",
+  "version": "0.3.32",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "remotes": [
     {
@@ -36,7 +36,7 @@
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.31",
+      "version": "0.3.32",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -64,7 +64,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.31",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.32",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/tools/apps/aiquila.ts
+++ b/mcp-server/src/tools/apps/aiquila.ts
@@ -78,9 +78,7 @@ export const configureTool = {
     model: z
       .string()
       .optional()
-      .describe(
-        "Claude model to use (e.g., 'claude-fable-5', 'claude-opus-4-8', 'claude-sonnet-4-6')"
-      ),
+      .describe("Claude model to use (e.g., 'claude-fable-5', 'claude-opus-5', 'claude-sonnet-5')"),
     maxTokens: z.number().optional().describe('Maximum tokens for responses (default: 4096)'),
     timeout: z.number().optional().describe('Request timeout in seconds (default: 60)'),
   }),

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.31</version>
+    <version>0.3.32</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/composer.json
+++ b/nextcloud-app/composer.json
@@ -5,7 +5,7 @@
     "license": "AGPL-3.0-or-later",
     "require": {
         "php": "^8.4",
-        "anthropic-ai/sdk": "^0.28.0",
+        "anthropic-ai/sdk": "^0.40.0",
         "psr/log": "*",
         "symfony/http-client": "^8.0",
         "nyholm/psr7": "^1.8"

--- a/nextcloud-app/composer.lock
+++ b/nextcloud-app/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df6ddc1c7b9ccd594093e45de777541f",
+    "content-hash": "c79fd0d11a6e351b386361463e334ee3",
     "packages": [
         {
             "name": "anthropic-ai/sdk",
-            "version": "v0.28.0",
+            "version": "v0.40.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/anthropics/anthropic-sdk-php.git",
-                "reference": "5116de361fde853f122dfac349842512d15da57e"
+                "reference": "273764dcec650b985422d50a4847993579e513aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/anthropics/anthropic-sdk-php/zipball/5116de361fde853f122dfac349842512d15da57e",
-                "reference": "5116de361fde853f122dfac349842512d15da57e",
+                "url": "https://api.github.com/repos/anthropics/anthropic-sdk-php/zipball/273764dcec650b985422d50a4847993579e513aa",
+                "reference": "273764dcec650b985422d50a4847993579e513aa",
                 "shasum": ""
             },
             "require": {
@@ -46,7 +46,7 @@
             },
             "suggest": {
                 "aws/aws-sdk-php": "Allows using the AWS Bedrock, AWS gateway, and Bedrock Mantle SDKs",
-                "google/auth": "Allows using the Google Vertex SDK",
+                "google/auth": "Allows using the Google Vertex and Google Cloud gateway SDKs",
                 "mcp/sdk": "Required to use the BetaMcp helpers for integrating MCP servers with the Anthropic SDK"
             },
             "type": "library",
@@ -65,9 +65,9 @@
             "description": "Anthropic PHP SDK",
             "support": {
                 "issues": "https://github.com/anthropics/anthropic-sdk-php/issues",
-                "source": "https://github.com/anthropics/anthropic-sdk-php/tree/v0.28.0"
+                "source": "https://github.com/anthropics/anthropic-sdk-php/tree/v0.40.0"
             },
-            "time": "2026-06-09T16:46:52+00:00"
+            "time": "2026-07-24T16:35:04+00:00"
         },
         {
             "name": "nyholm/psr7",

--- a/nextcloud-app/lib/Command/ConfigureCommand.php
+++ b/nextcloud-app/lib/Command/ConfigureCommand.php
@@ -36,7 +36,7 @@ class ConfigureCommand extends Base {
                 'model',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Set Claude model (e.g., claude-fable-5, claude-opus-4-8, claude-sonnet-4-6)'
+                'Set Claude model (e.g., claude-fable-5, claude-opus-5, claude-sonnet-5)'
             )
             ->addOption(
                 'max-tokens',

--- a/nextcloud-app/lib/Service/ClaudeModels.php
+++ b/nextcloud-app/lib/Service/ClaudeModels.php
@@ -17,7 +17,13 @@ class ClaudeModels {
     /** Fable 5 – most powerful model, new tier above Opus (adaptive thinking, 128K output, 1M context, xhigh effort) */
     public const FABLE_5    = 'claude-fable-5';
 
-    /** Opus 4.8 – most capable Opus-tier model (adaptive thinking, 128K output, 1M context, xhigh effort) */
+    /** Opus 5 – for complex agentic coding and enterprise work (adaptive thinking, 128K output, 1M context, xhigh effort) */
+    public const OPUS_5     = 'claude-opus-5';
+
+    /** Sonnet 5 – best combination of speed and intelligence (adaptive thinking, 128K output, 1M context) */
+    public const SONNET_5   = 'claude-sonnet-5';
+
+    /** Opus 4.8 – previous most capable Opus-tier model (adaptive thinking, 128K output, 1M context, xhigh effort) */
     public const OPUS_4_8   = 'claude-opus-4-8';
 
     /** Opus 4.7 – previous-generation Opus (adaptive thinking, 128K output, 1M context, xhigh effort) */
@@ -62,13 +68,15 @@ class ClaudeModels {
 
     // ── Application defaults ───────────────────────────────────────────────
 
-    public const DEFAULT_MODEL      = self::SONNET_4_6;
+    public const DEFAULT_MODEL      = self::SONNET_5;
     public const DEFAULT_MAX_TOKENS = 16384;
 
     // ── Per-model output token ceilings ────────────────────────────────────
 
     private const MAX_TOKENS_CEILING = [
         self::FABLE_5    => 128000,
+        self::OPUS_5     => 128000,
+        self::SONNET_5   => 128000,
         self::OPUS_4_8   => 128000,
         self::OPUS_4_7   => 128000,
         self::OPUS_4_6   => 128000,
@@ -82,6 +90,8 @@ class ClaudeModels {
 
     private const CONTEXT_WINDOW = [
         self::FABLE_5    => 1000000,
+        self::OPUS_5     => 1000000,
+        self::SONNET_5   => 1000000,
         self::OPUS_4_8   => 1000000,
         self::OPUS_4_7   => 1000000,
         self::OPUS_4_6   => 1000000,
@@ -92,6 +102,8 @@ class ClaudeModels {
 
     private const SUPPORTS_THINKING = [
         self::FABLE_5    => true,
+        self::OPUS_5     => true,
+        self::SONNET_5   => true,
         self::OPUS_4_8   => true,
         self::OPUS_4_7   => true,
         self::OPUS_4_6   => true,
@@ -100,6 +112,8 @@ class ClaudeModels {
 
     private const SUPPORTS_EFFORT = [
         self::FABLE_5    => true,
+        self::OPUS_5     => true,
+        self::SONNET_5   => true,
         self::OPUS_4_8   => true,
         self::OPUS_4_7   => true,
         self::OPUS_4_6   => true,
@@ -140,6 +154,8 @@ class ClaudeModels {
     public static function getAllModels(): array {
         return [
             self::FABLE_5,
+            self::OPUS_5,
+            self::SONNET_5,
             self::OPUS_4_8,
             self::OPUS_4_7,
             self::OPUS_4_6,
@@ -154,6 +170,8 @@ class ClaudeModels {
 
     public const EFFORT_LEVEL = [
         self::FABLE_5    => 'xhigh',
+        self::OPUS_5     => 'xhigh',
+        self::SONNET_5   => 'medium',
         self::OPUS_4_8   => 'xhigh',
         self::OPUS_4_7   => 'xhigh',
         self::OPUS_4_6   => 'high',
@@ -172,9 +190,11 @@ class ClaudeModels {
     /** Every effort value any model accepts; used for settings validation. */
     public const ALL_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'];
 
-    /** `xhigh` requires Fable 5 / Opus 4.7+; older models reject it with a 400. */
+    /** `xhigh` requires Fable 5 / Opus 5 / Sonnet 5 / Opus 4.7+; older models reject it with a 400. */
     private const ALLOWED_EFFORTS = [
         self::FABLE_5    => ['low', 'medium', 'high', 'xhigh', 'max'],
+        self::OPUS_5     => ['low', 'medium', 'high', 'xhigh', 'max'],
+        self::SONNET_5   => ['low', 'medium', 'high', 'xhigh', 'max'],
         self::OPUS_4_8   => ['low', 'medium', 'high', 'xhigh', 'max'],
         self::OPUS_4_7   => ['low', 'medium', 'high', 'xhigh', 'max'],
         self::OPUS_4_6   => ['low', 'medium', 'high', 'max'],
@@ -199,13 +219,17 @@ class ClaudeModels {
     /** Models that reject temperature/top_p/top_k with a 400. */
     private const NO_SAMPLING_PARAMS = [
         self::FABLE_5  => true,
+        self::OPUS_5   => true,
+        self::SONNET_5 => true,
         self::OPUS_4_8 => true,
         self::OPUS_4_7 => true,
     ];
 
     /**
      * Whether a model accepts the temperature/top_p/top_k sampling
-     * parameters. Fable 5 and Opus 4.7+ removed them entirely.
+     * parameters. Fable 5, Opus 4.7+, and the 5-series removed them: Opus 5
+     * rejects them outright, Sonnet 5 rejects any non-default value, so we
+     * omit them for both.
      */
     public static function supportsSamplingParams(string $model): bool {
         return !isset(self::NO_SAMPLING_PARAMS[$model]);

--- a/nextcloud-app/lib/Service/ClaudeSDKService.php
+++ b/nextcloud-app/lib/Service/ClaudeSDKService.php
@@ -215,7 +215,8 @@ class ClaudeSDKService implements LLMProviderInterface {
             $params['system'] = [$systemBlock];
         }
 
-        // Sampling parameters — Fable 5 and Opus 4.7+ reject temperature/top_p/top_k with a 400
+        // Sampling parameters — Fable 5, the 5-series, and Opus 4.7+ reject
+        // temperature/top_p/top_k with a 400
         $samplingKeys = ClaudeModels::supportsSamplingParams($model)
             ? ['temperature', 'top_p', 'top_k', 'stop_sequences']
             : ['stop_sequences'];

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",

--- a/nextcloud-app/tests/Unit/ClaudeModelsTest.php
+++ b/nextcloud-app/tests/Unit/ClaudeModelsTest.php
@@ -7,14 +7,16 @@ use PHPUnit\Framework\TestCase;
 
 class ClaudeModelsTest extends TestCase {
 
-    public function testDefaultModelIsSonnet46(): void {
-        $this->assertEquals(ClaudeModels::SONNET_4_6, ClaudeModels::DEFAULT_MODEL);
+    public function testDefaultModelIsSonnet5(): void {
+        $this->assertEquals(ClaudeModels::SONNET_5, ClaudeModels::DEFAULT_MODEL);
     }
 
     public function testGetAllModelsReturnsCurrentModelsOnly(): void {
         $models = ClaudeModels::getAllModels();
-        $this->assertCount(8, $models);
+        $this->assertCount(10, $models);
         $this->assertContains(ClaudeModels::FABLE_5,    $models);
+        $this->assertContains(ClaudeModels::OPUS_5,     $models);
+        $this->assertContains(ClaudeModels::SONNET_5,   $models);
         $this->assertContains(ClaudeModels::OPUS_4_8,   $models);
         $this->assertContains(ClaudeModels::OPUS_4_7,   $models);
         $this->assertContains(ClaudeModels::OPUS_4_6,   $models);
@@ -29,6 +31,11 @@ class ClaudeModelsTest extends TestCase {
         $this->assertNotContains(ClaudeModels::OPUS_4,   $models);
         // Most capable first
         $this->assertSame(ClaudeModels::FABLE_5, $models[0]);
+    }
+
+    public function testGetMaxTokenCeilingFor5Series(): void {
+        $this->assertEquals(128000, ClaudeModels::getMaxTokenCeiling(ClaudeModels::OPUS_5));
+        $this->assertEquals(128000, ClaudeModels::getMaxTokenCeiling(ClaudeModels::SONNET_5));
     }
 
     public function testGetMaxTokenCeilingForOpus47(): void {
@@ -52,6 +59,8 @@ class ClaudeModelsTest extends TestCase {
 
     public function testGetContextWindowFor1MModels(): void {
         $this->assertEquals(1000000, ClaudeModels::getContextWindow(ClaudeModels::FABLE_5));
+        $this->assertEquals(1000000, ClaudeModels::getContextWindow(ClaudeModels::OPUS_5));
+        $this->assertEquals(1000000, ClaudeModels::getContextWindow(ClaudeModels::SONNET_5));
         $this->assertEquals(1000000, ClaudeModels::getContextWindow(ClaudeModels::OPUS_4_8));
         $this->assertEquals(1000000, ClaudeModels::getContextWindow(ClaudeModels::OPUS_4_7));
         $this->assertEquals(1000000, ClaudeModels::getContextWindow(ClaudeModels::OPUS_4_6));
@@ -73,6 +82,8 @@ class ClaudeModelsTest extends TestCase {
 
     public function testSupportsThinkingForAdaptiveModels(): void {
         $this->assertTrue(ClaudeModels::supportsThinking(ClaudeModels::FABLE_5));
+        $this->assertTrue(ClaudeModels::supportsThinking(ClaudeModels::OPUS_5));
+        $this->assertTrue(ClaudeModels::supportsThinking(ClaudeModels::SONNET_5));
         $this->assertTrue(ClaudeModels::supportsThinking(ClaudeModels::OPUS_4_8));
         $this->assertTrue(ClaudeModels::supportsThinking(ClaudeModels::OPUS_4_7));
         $this->assertTrue(ClaudeModels::supportsThinking(ClaudeModels::OPUS_4_6));
@@ -83,6 +94,8 @@ class ClaudeModelsTest extends TestCase {
 
     public function testSupportsEffortForAdaptiveModels(): void {
         $this->assertTrue(ClaudeModels::supportsEffort(ClaudeModels::FABLE_5));
+        $this->assertTrue(ClaudeModels::supportsEffort(ClaudeModels::OPUS_5));
+        $this->assertTrue(ClaudeModels::supportsEffort(ClaudeModels::SONNET_5));
         $this->assertTrue(ClaudeModels::supportsEffort(ClaudeModels::OPUS_4_8));
         $this->assertTrue(ClaudeModels::supportsEffort(ClaudeModels::OPUS_4_7));
         $this->assertTrue(ClaudeModels::supportsEffort(ClaudeModels::OPUS_4_6));
@@ -100,8 +113,15 @@ class ClaudeModelsTest extends TestCase {
         $this->assertEquals('xhigh', ClaudeModels::getEffortLevel(ClaudeModels::OPUS_4_8));
     }
 
+    public function testGetEffortLevelFor5Series(): void {
+        $this->assertEquals('xhigh', ClaudeModels::getEffortLevel(ClaudeModels::OPUS_5));
+        $this->assertEquals('medium', ClaudeModels::getEffortLevel(ClaudeModels::SONNET_5));
+    }
+
     public function testSupportsSamplingParams(): void {
         $this->assertFalse(ClaudeModels::supportsSamplingParams(ClaudeModels::FABLE_5));
+        $this->assertFalse(ClaudeModels::supportsSamplingParams(ClaudeModels::OPUS_5));
+        $this->assertFalse(ClaudeModels::supportsSamplingParams(ClaudeModels::SONNET_5));
         $this->assertFalse(ClaudeModels::supportsSamplingParams(ClaudeModels::OPUS_4_8));
         $this->assertFalse(ClaudeModels::supportsSamplingParams(ClaudeModels::OPUS_4_7));
         $this->assertTrue(ClaudeModels::supportsSamplingParams(ClaudeModels::SONNET_4_6));
@@ -121,7 +141,14 @@ class ClaudeModelsTest extends TestCase {
     }
 
     public function testAllowedEffortsIncludeXhighOnlyOnOpus47Plus(): void {
-        foreach ([ClaudeModels::FABLE_5, ClaudeModels::OPUS_4_8, ClaudeModels::OPUS_4_7] as $model) {
+        $xhighCapable = [
+            ClaudeModels::FABLE_5,
+            ClaudeModels::OPUS_5,
+            ClaudeModels::SONNET_5,
+            ClaudeModels::OPUS_4_8,
+            ClaudeModels::OPUS_4_7,
+        ];
+        foreach ($xhighCapable as $model) {
             $this->assertEquals(['low', 'medium', 'high', 'xhigh', 'max'], ClaudeModels::getAllowedEfforts($model));
         }
         foreach ([ClaudeModels::OPUS_4_6, ClaudeModels::SONNET_4_6] as $model) {
@@ -154,6 +181,8 @@ class ClaudeModelsTest extends TestCase {
 
     public function testEffortLevelConstantsArePublic(): void {
         $this->assertIsArray(ClaudeModels::EFFORT_LEVEL);
+        $this->assertArrayHasKey(ClaudeModels::OPUS_5, ClaudeModels::EFFORT_LEVEL);
+        $this->assertArrayHasKey(ClaudeModels::SONNET_5, ClaudeModels::EFFORT_LEVEL);
         $this->assertArrayHasKey(ClaudeModels::OPUS_4_7, ClaudeModels::EFFORT_LEVEL);
         $this->assertArrayHasKey(ClaudeModels::OPUS_4_6, ClaudeModels::EFFORT_LEVEL);
         $this->assertArrayHasKey(ClaudeModels::SONNET_4_6, ClaudeModels::EFFORT_LEVEL);

--- a/nextcloud-app/tests/Unit/ClaudeServiceTest.php
+++ b/nextcloud-app/tests/Unit/ClaudeServiceTest.php
@@ -211,12 +211,13 @@ class ClaudeServiceTest extends TestCase {
         );
     }
 
-    private function configWithApiKey(): void {
+    private function configWithApiKey(?string $model = null): void {
+        $model ??= ClaudeModels::DEFAULT_MODEL;
         $this->credentials->method('getApiKey')->willReturn('test-key');
         $this->config->method('getUserValue')->willReturn('');
         $this->config->method('getAppValue')
             ->willReturnCallback(fn($app, $key, $default) => match ($key) {
-                'model'      => ClaudeModels::DEFAULT_MODEL,
+                'model'      => $model,
                 'max_tokens' => '4096',
                 default      => $default,
             });
@@ -398,7 +399,8 @@ class ClaudeServiceTest extends TestCase {
     // ── ask(): options passthrough ─────────────────────────────────────────
 
     public function testAskWithOptionsPassesTemperatureToParams(): void {
-        $this->configWithApiKey();
+        // Sonnet 4.6 still accepts sampling params; the 5-series does not.
+        $this->configWithApiKey(ClaudeModels::SONNET_4_6);
 
         $result = $this->testable->ask('Hi', '', 'testuser', ['temperature' => 0.7]);
 
@@ -408,12 +410,32 @@ class ClaudeServiceTest extends TestCase {
     }
 
     public function testAskWithOptionsPassesTopPAndTopKToParams(): void {
-        $this->configWithApiKey();
+        $this->configWithApiKey(ClaudeModels::SONNET_4_6);
 
         $this->testable->ask('Hi', '', 'testuser', ['top_p' => 0.9, 'top_k' => 40]);
 
         $this->assertSame(0.9, $this->testable->lastCreateParams['top_p']);
         $this->assertSame(40,  $this->testable->lastCreateParams['top_k']);
+    }
+
+    /**
+     * Opus 5 rejects temperature/top_p/top_k with a 400 and Sonnet 5 rejects
+     * any non-default value, so buildParams() must drop them rather than
+     * forward a caller-supplied value.
+     */
+    public function testAskDropsSamplingParamsOn5Series(): void {
+        $this->configWithApiKey(ClaudeModels::SONNET_5);
+
+        $result = $this->testable->ask('Hi', '', 'testuser', [
+            'temperature' => 0.7,
+            'top_p'       => 0.9,
+            'top_k'       => 40,
+        ]);
+
+        $this->assertArrayNotHasKey('error', $result);
+        $this->assertArrayNotHasKey('temperature', $this->testable->lastCreateParams);
+        $this->assertArrayNotHasKey('top_p', $this->testable->lastCreateParams);
+        $this->assertArrayNotHasKey('top_k', $this->testable->lastCreateParams);
     }
 
     public function testAskWithOptionsPassesStopSequencesToParams(): void {


### PR DESCRIPTION
Adds `claude-opus-5` and `claude-sonnet-5` to the model registry and moves the app default to Sonnet 5.

Closes #409

## Model facts

| Model | Context | Max output | Price (in/out per MTok) | Effort policy |
|---|---|---|---|---|
| `claude-opus-5` | 1M | 128K | $5 / $25 | `xhigh` |
| `claude-sonnet-5` | 1M | 128K | $3 / $15 (intro **$2 / $10 through 2026-08-31**) | `medium` |

Both support adaptive thinking and the full `low`…`max` effort ladder, and both reject `temperature` / `top_p` / `top_k` — Opus 5 outright, Sonnet 5 for any non-default value — so `buildParams()` omits them for both.

## ⚠️ Default-model change

`DEFAULT_MODEL` moves from `claude-sonnet-4-6` to `claude-sonnet-5`.

- **Only installs that never set an explicit model** follow the new default. Explicit admin and user selections are untouched — `getModel()` falls back to `DEFAULT_MODEL` only when the app config key is unset.
- **Sonnet 5 uses the Opus-4.7-generation tokenizer**: the same text produces roughly 30% more tokens than on Sonnet 4.6. Token-usage metrics (`UsageStatMapper`, the `aiquila_usage` dashboard widget) will step up for identical workloads. This is expected, **not a regression**.
- Sonnet 5's output ceiling is 128000 vs Sonnet 4.6's 64000, so the ceiling table entry differs from the model it replaces.

## SDK bump

`anthropic-ai/sdk` `^0.28.0` → `^0.40.0`. The 0.28.0 `Messages\Model` enum knew `claude-fable-5` but not the 5-series; 0.40.0 adds `CLAUDE_OPUS_5` and `CLAUDE_SONNET_5`. Model IDs reach the SDK as plain strings so this was not a hard blocker, but it keeps the typed constants and `models.retrieve()` capability metadata current.

I checked every symbol `ClaudeSDKService` imports against 0.40.0 — `AnthropicBeta::FILES_API_2025_04_14`, the `Batches\*` result classes, `Core\FileParam`, `Core\Contracts\BaseStream`, and the `ModelInfo` `maxTokens` / `maxInputTokens` / `capabilities` fields all still exist. No call-site changes were needed across the 12 minor versions.

## Docs

The model lists had drifted further than the 5-series: they topped out at Opus 4.7 and mentioned neither Fable 5 nor Opus 4.8, both already in the registry. This resyncs them with `ClaudeModels.php`. The `ACKNOWLEDGMENTS.md` dependency table was also stale on five entries (`@modelcontextprotocol/sdk` `^1.27`→`^1.29`, `pino` `^9.0`→`^10.3`, `webdav` `^5.8`→`^5.10`, `zod` `^3.25`→`^4.4`, `anthropic-ai/sdk` `^0.5`→`^0.40`).

## Verification

- `vendor/bin/phpunit` — **425 tests pass**. Two sampling-passthrough tests in `ClaudeServiceTest` ran against `DEFAULT_MODEL` and legitimately failed once that became Sonnet 5; they are now pinned to Sonnet 4.6, plus a new test asserting the params *are* dropped on the 5-series.
- `npm test` — 869 tests, 55 files pass. `npm run lint` 0 errors, `npx prettier --check src/` clean.
- `vendor/bin/generate-spec` — no OpenAPI diff (no annotated controller changed).
- Dev stack (`docker/installation/`): app upgraded to 0.3.32, `occ aiquila:configure --model claude-opus-5` and `--model claude-sonnet-5` both accepted, capabilities endpoint reports `claude-sonnet-5`, app page and `aiquila_usage` widget both 200, **zero level-3/4 lines** in `nextcloud.log`.

A live chat round-trip against `claude-opus-5` was **not** exercised — no `ANTHROPIC_API_KEY` in the dev environment.

## Follow-ups filed separately

Found while reading the release docs; each is its own ticket so it can be evaluated on its own merits:

- #410 — guard Opus 5 thinking-disabled + `xhigh`/`max` effort (400)
- #411 — handle `stop_reason: "refusal"` and opt into server-side fallbacks
- #412 — mid-conversation tool changes to preserve the prompt cache
- #413 — mid-conversation system messages (`role:"system"` in `messages`)
- #414 — task budgets for the `chatWithTools` loop
- #415 — verify prompt-cache hit rates on the 5-series (512-token minimum)
- #416 — evaluate fast mode (`speed:"fast"`) on Opus 5
- 300k Batches output + no fallbacks on Batches noted on the existing #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)