### PR TITLE
docs: add 0.3.32 upgrade note for the default-model change

### DIFF
--- a/docs/installation/aiquila-setup.md
+++ b/docs/installation/aiquila-setup.md
@@ -2,6 +2,34 @@
 
 Complete guide to installing and configuring the AIquila Nextcloud app.
 
+## Upgrade notes
+
+### 0.3.32 — the default model changed
+
+The built-in default moved from `claude-sonnet-4-6` to **`claude-sonnet-5`**.
+
+This only affects installs that never picked a model explicitly. If an
+administrator or user has selected a model in the settings UI or via
+`occ aiquila:configure --model`, that choice is preserved.
+
+If you are on the default, two things change after upgrading:
+
+- **Token counts rise for identical work.** Sonnet 5 uses a newer tokenizer;
+  the same text produces roughly 30% more tokens than on Sonnet 4.6. Usage
+  figures in the admin dashboard and the `aiquila_usage` widget will step up
+  accordingly. This is a measurement change, not a fault.
+- **The output ceiling rises** from 64,000 to 128,000 tokens.
+
+Sonnet 5 also rejects the `temperature`, `top_p`, and `top_k` sampling
+parameters; AIquila omits them automatically for models that don't accept them,
+so no configuration change is needed.
+
+To stay on the previous model:
+
+```bash
+php occ aiquila:configure --model claude-sonnet-4-6
+```
+
 ## Prerequisites
 
 - Nextcloud 33 or higher


### PR DESCRIPTION
Follow-up to #417, which moved `DEFAULT_MODEL` from `claude-sonnet-4-6` to `claude-sonnet-5`.

The generated release notes already announce the change — the squash subject on `main` reads *"add Claude Opus 5 and Sonnet 5, default to Sonnet 5"*, so it lands under **Features** in the v0.3.32 notes. What that one line can't carry is the detail an administrator on the default actually needs:

- **Who is affected** — only installs that never picked a model explicitly; explicit admin/user selections are preserved.
- **Why usage figures jump** — Sonnet 5's newer tokenizer produces ~30% more tokens for the same text, so the admin dashboard and `aiquila_usage` widget step up for identical work. Without this stated somewhere, it reads as a billing fault.
- **The output ceiling change** — 64,000 → 128,000.
- **How to pin the previous model** — `occ aiquila:configure --model claude-sonnet-4-6`.

Placed in `docs/installation/aiquila-setup.md` under a new `## Upgrade notes` heading, since the repo has no CHANGELOG. Docs-only; no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)