### PR TITLE
fix(nextcloud): don't break the TaskProcessing event chain in notification listeners

### DIFF
--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.32</version>
+    <version>0.3.33</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/lib/Listener/TaskFailedListener.php
+++ b/nextcloud-app/lib/Listener/TaskFailedListener.php
@@ -17,21 +17,7 @@ use Psr\Log\LoggerInterface;
  * @implements IEventListener<TaskFailedEvent>
  */
 class TaskFailedListener implements IEventListener {
-
-    private static array $typeLabels = [
-        'core:text2text' => 'Text generation',
-        'core:text2text:summary' => 'Summarization',
-        'core:text2text:headline' => 'Headline generation',
-        'core:text2text:topics' => 'Topic extraction',
-        'core:text2text:translate' => 'Translation',
-        'core:text2text:proofread' => 'Proofreading',
-        'core:text2text:reformulate' => 'Reformulation',
-        'core:text2text:formalize' => 'Formalization',
-        'core:text2text:simplify' => 'Simplification',
-        'core:text2text:change-tone' => 'Tone adjustment',
-        'core:image2text' => 'Image analysis',
-        'core:analyze-images' => 'Multi-image analysis',
-    ];
+    use TaskListenerTrait;
 
     public function __construct(
         private INotificationManager $notificationManager,
@@ -57,7 +43,7 @@ class TaskFailedListener implements IEventListener {
     }
 
     private function notifyTaskFailure(Task $task): void {
-        if (!TaskSuccessfulListener::isAiquilaTask($this->taskProcessingManager, $task)) {
+        if (!$this->isAiquilaTask($task)) {
             return;
         }
 
@@ -66,7 +52,7 @@ class TaskFailedListener implements IEventListener {
             return;
         }
 
-        $taskTypeLabel = TaskSuccessfulListener::getTaskTypeLabel($task->getTaskTypeId());
+        $taskTypeLabel = self::getTaskTypeLabel($task->getTaskTypeId());
         $errorMessage = $task->getErrorMessage() ?? '';
         if (strlen($errorMessage) > 200) {
             $errorMessage = substr($errorMessage, 0, 200) . '…';

--- a/nextcloud-app/lib/Listener/TaskFailedListener.php
+++ b/nextcloud-app/lib/Listener/TaskFailedListener.php
@@ -9,6 +9,8 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\TaskProcessing\Events\TaskFailedEvent;
+use OCP\TaskProcessing\IManager as ITaskProcessingManager;
+use OCP\TaskProcessing\Task;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -33,6 +35,7 @@ class TaskFailedListener implements IEventListener {
 
     public function __construct(
         private INotificationManager $notificationManager,
+        private ITaskProcessingManager $taskProcessingManager,
         private LoggerInterface $logger,
     ) {
     }
@@ -42,9 +45,19 @@ class TaskFailedListener implements IEventListener {
             return;
         }
 
-        $task = $event->getTask();
+        // Same reasoning as TaskSuccessfulListener: a throwable here would
+        // abort the whole TaskProcessing event chain, so guard against it.
+        try {
+            $this->notifyTaskFailure($event->getTask());
+        } catch (\Throwable $e) {
+            $this->logger->error('AIquila: failed to send task failure notification', [
+                'exception' => $e,
+            ]);
+        }
+    }
 
-        if (!str_starts_with($task->getProviderId(), 'aiquila:')) {
+    private function notifyTaskFailure(Task $task): void {
+        if (!TaskSuccessfulListener::isAiquilaTask($this->taskProcessingManager, $task)) {
             return;
         }
 

--- a/nextcloud-app/lib/Listener/TaskListenerTrait.php
+++ b/nextcloud-app/lib/Listener/TaskListenerTrait.php
@@ -1,0 +1,60 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Listener;
+
+use OCP\TaskProcessing\Task;
+
+/**
+ * Shared helpers for the TaskProcessing event listeners. Using classes must
+ * inject OCP\TaskProcessing\IManager as $taskProcessingManager.
+ */
+trait TaskListenerTrait {
+
+    private static array $typeLabels = [
+        'core:text2text' => 'Text generation',
+        'core:text2text:summary' => 'Summarization',
+        'core:text2text:headline' => 'Headline generation',
+        'core:text2text:topics' => 'Topic extraction',
+        'core:text2text:translate' => 'Translation',
+        'core:text2text:proofread' => 'Proofreading',
+        'core:text2text:reformulate' => 'Reformulation',
+        'core:text2text:formalize' => 'Formalization',
+        'core:text2text:simplify' => 'Simplification',
+        'core:text2text:change-tone' => 'Tone adjustment',
+        'core:image2text' => 'Image analysis',
+        'core:analyze-images' => 'Multi-image analysis',
+    ];
+
+    /**
+     * OCP\TaskProcessing\Task exposes no provider id, so the provider is resolved
+     * through the manager. Note getPreferredProvider() answers "who would run
+     * this task type now", not "who ran this task": the admin preference is
+     * cached for a few minutes, so a change between scheduling and completion
+     * can misattribute. Best approximation available; for aiquila's synchronous
+     * providers the event fires in-process right after the preferred provider
+     * ran, so it is accurate in practice.
+     */
+    private function isAiquilaTask(Task $task): bool {
+        try {
+            $provider = $this->taskProcessingManager->getPreferredProvider($task->getTaskTypeId());
+        } catch (\OCP\TaskProcessing\Exception\Exception) {
+            // No provider for this task type -> not ours. Unexpected throwables
+            // propagate to handle(), which logs rather than hides them.
+            return false;
+        }
+
+        return str_starts_with($provider->getId(), 'aiquila:');
+    }
+
+    public static function getTaskTypeLabel(string $taskTypeId): string {
+        if (isset(self::$typeLabels[$taskTypeId])) {
+            return self::$typeLabels[$taskTypeId];
+        }
+
+        $parts = explode(':', $taskTypeId);
+        return ucfirst(end($parts));
+    }
+}

--- a/nextcloud-app/lib/Listener/TaskSuccessfulListener.php
+++ b/nextcloud-app/lib/Listener/TaskSuccessfulListener.php
@@ -9,6 +9,8 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\TaskProcessing\Events\TaskSuccessfulEvent;
+use OCP\TaskProcessing\IManager as ITaskProcessingManager;
+use OCP\TaskProcessing\Task;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -33,6 +35,7 @@ class TaskSuccessfulListener implements IEventListener {
 
     public function __construct(
         private INotificationManager $notificationManager,
+        private ITaskProcessingManager $taskProcessingManager,
         private LoggerInterface $logger,
     ) {
     }
@@ -42,9 +45,20 @@ class TaskSuccessfulListener implements IEventListener {
             return;
         }
 
-        $task = $event->getTask();
+        // Apps load alphabetically, so this listener runs before Assistant's in
+        // the event chain; an uncaught throwable here would abort the chain and
+        // stop Assistant persisting its chat reply. Never let one escape.
+        try {
+            $this->notifyTaskSuccess($event->getTask());
+        } catch (\Throwable $e) {
+            $this->logger->error('AIquila: failed to send task success notification', [
+                'exception' => $e,
+            ]);
+        }
+    }
 
-        if (!str_starts_with($task->getProviderId(), 'aiquila:')) {
+    private function notifyTaskSuccess(Task $task): void {
+        if (!self::isAiquilaTask($this->taskProcessingManager, $task)) {
             return;
         }
 
@@ -69,6 +83,22 @@ class TaskSuccessfulListener implements IEventListener {
             'taskType' => $task->getTaskTypeId(),
             'user' => $userId,
         ]);
+    }
+
+    /**
+     * OCP\TaskProcessing\Task exposes no provider id, so the provider is resolved
+     * through the manager to tell whether an aiquila provider handled the task.
+     */
+    public static function isAiquilaTask(ITaskProcessingManager $taskProcessingManager, Task $task): bool {
+        try {
+            $provider = $taskProcessingManager->getPreferredProvider($task->getTaskTypeId());
+        } catch (\OCP\TaskProcessing\Exception\Exception) {
+            // No provider for this task type -> not ours. Unexpected throwables
+            // propagate to handle() above, which logs rather than hides them.
+            return false;
+        }
+
+        return str_starts_with($provider->getId(), 'aiquila:');
     }
 
     public static function getTaskTypeLabel(string $taskTypeId): string {

--- a/nextcloud-app/lib/Listener/TaskSuccessfulListener.php
+++ b/nextcloud-app/lib/Listener/TaskSuccessfulListener.php
@@ -17,21 +17,7 @@ use Psr\Log\LoggerInterface;
  * @implements IEventListener<TaskSuccessfulEvent>
  */
 class TaskSuccessfulListener implements IEventListener {
-
-    private static array $typeLabels = [
-        'core:text2text' => 'Text generation',
-        'core:text2text:summary' => 'Summarization',
-        'core:text2text:headline' => 'Headline generation',
-        'core:text2text:topics' => 'Topic extraction',
-        'core:text2text:translate' => 'Translation',
-        'core:text2text:proofread' => 'Proofreading',
-        'core:text2text:reformulate' => 'Reformulation',
-        'core:text2text:formalize' => 'Formalization',
-        'core:text2text:simplify' => 'Simplification',
-        'core:text2text:change-tone' => 'Tone adjustment',
-        'core:image2text' => 'Image analysis',
-        'core:analyze-images' => 'Multi-image analysis',
-    ];
+    use TaskListenerTrait;
 
     public function __construct(
         private INotificationManager $notificationManager,
@@ -58,7 +44,7 @@ class TaskSuccessfulListener implements IEventListener {
     }
 
     private function notifyTaskSuccess(Task $task): void {
-        if (!self::isAiquilaTask($this->taskProcessingManager, $task)) {
+        if (!$this->isAiquilaTask($task)) {
             return;
         }
 
@@ -83,30 +69,5 @@ class TaskSuccessfulListener implements IEventListener {
             'taskType' => $task->getTaskTypeId(),
             'user' => $userId,
         ]);
-    }
-
-    /**
-     * OCP\TaskProcessing\Task exposes no provider id, so the provider is resolved
-     * through the manager to tell whether an aiquila provider handled the task.
-     */
-    public static function isAiquilaTask(ITaskProcessingManager $taskProcessingManager, Task $task): bool {
-        try {
-            $provider = $taskProcessingManager->getPreferredProvider($task->getTaskTypeId());
-        } catch (\OCP\TaskProcessing\Exception\Exception) {
-            // No provider for this task type -> not ours. Unexpected throwables
-            // propagate to handle() above, which logs rather than hides them.
-            return false;
-        }
-
-        return str_starts_with($provider->getId(), 'aiquila:');
-    }
-
-    public static function getTaskTypeLabel(string $taskTypeId): string {
-        if (isset(self::$typeLabels[$taskTypeId])) {
-            return self::$typeLabels[$taskTypeId];
-        }
-
-        $parts = explode(':', $taskTypeId);
-        return ucfirst(end($parts));
     }
 }

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",

--- a/nextcloud-app/tests/Unit/Listener/TaskFailedListenerTest.php
+++ b/nextcloud-app/tests/Unit/Listener/TaskFailedListenerTest.php
@@ -6,25 +6,39 @@ use OCA\AIquila\Listener\TaskFailedListener;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
 use OCP\TaskProcessing\Events\TaskFailedEvent;
+use OCP\TaskProcessing\IManager as ITaskProcessingManager;
+use OCP\TaskProcessing\IProvider;
 use OCP\TaskProcessing\Task;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 class TaskFailedListenerTest extends TestCase {
     private INotificationManager $notificationManager;
+    private ITaskProcessingManager $taskProcessingManager;
     private LoggerInterface $logger;
     private TaskFailedListener $listener;
 
     protected function setUp(): void {
         $this->notificationManager = $this->createMock(INotificationManager::class);
+        $this->taskProcessingManager = $this->createMock(ITaskProcessingManager::class);
         $this->logger = $this->createMock(LoggerInterface::class);
-        $this->listener = new TaskFailedListener($this->notificationManager, $this->logger);
+        $this->listener = new TaskFailedListener(
+            $this->notificationManager,
+            $this->taskProcessingManager,
+            $this->logger,
+        );
+    }
+
+    private function mockPreferredProvider(string $providerId): void {
+        $provider = $this->createMock(IProvider::class);
+        $provider->method('getId')->willReturn($providerId);
+        $this->taskProcessingManager->method('getPreferredProvider')->willReturn($provider);
     }
 
     public function testIgnoresNonAiquilaProvider(): void {
-        $task = $this->createMock(Task::class);
-        $task->method('getProviderId')->willReturn('other_app:text2text');
+        $this->mockPreferredProvider('other_app:text2text');
 
+        $task = $this->createMock(Task::class);
         $event = $this->createMock(TaskFailedEvent::class);
         $event->method('getTask')->willReturn($task);
 
@@ -33,8 +47,9 @@ class TaskFailedListenerTest extends TestCase {
     }
 
     public function testCreatesNotificationOnFailure(): void {
+        $this->mockPreferredProvider('aiquila:text2text');
+
         $task = $this->createMock(Task::class);
-        $task->method('getProviderId')->willReturn('aiquila:text2text');
         $task->method('getUserId')->willReturn('testuser');
         $task->method('getTaskTypeId')->willReturn('core:text2text');
         $task->method('getId')->willReturn(99);
@@ -60,10 +75,11 @@ class TaskFailedListenerTest extends TestCase {
     }
 
     public function testTruncatesLongErrorMessage(): void {
+        $this->mockPreferredProvider('aiquila:text2text');
+
         $longError = str_repeat('x', 300);
 
         $task = $this->createMock(Task::class);
-        $task->method('getProviderId')->willReturn('aiquila:text2text');
         $task->method('getUserId')->willReturn('testuser');
         $task->method('getTaskTypeId')->willReturn('core:text2text');
         $task->method('getId')->willReturn(100);
@@ -91,8 +107,9 @@ class TaskFailedListenerTest extends TestCase {
     }
 
     public function testHandlesNullErrorMessage(): void {
+        $this->mockPreferredProvider('aiquila:text2text');
+
         $task = $this->createMock(Task::class);
-        $task->method('getProviderId')->willReturn('aiquila:text2text');
         $task->method('getUserId')->willReturn('testuser');
         $task->method('getTaskTypeId')->willReturn('core:text2text');
         $task->method('getId')->willReturn(101);
@@ -113,6 +130,60 @@ class TaskFailedListenerTest extends TestCase {
 
         $this->notificationManager->method('createNotification')->willReturn($notification);
         $this->notificationManager->expects($this->once())->method('notify');
+
+        $this->listener->handle($event);
+    }
+
+    public function testUnknownTaskTypeIsSkippedSilently(): void {
+        $this->taskProcessingManager->method('getPreferredProvider')
+            ->willThrowException(new \OCP\TaskProcessing\Exception\Exception('no provider'));
+
+        $task = $this->createMock(Task::class);
+        $event = $this->createMock(TaskFailedEvent::class);
+        $event->method('getTask')->willReturn($task);
+
+        $this->notificationManager->expects($this->never())->method('createNotification');
+        $this->notificationManager->expects($this->never())->method('notify');
+        $this->logger->expects($this->never())->method('error');
+        $this->listener->handle($event);
+    }
+
+    public function testUnexpectedErrorIsLoggedNotPropagated(): void {
+        $this->taskProcessingManager->method('getPreferredProvider')
+            ->willThrowException(new \RuntimeException('boom'));
+
+        $task = $this->createMock(Task::class);
+        $event = $this->createMock(TaskFailedEvent::class);
+        $event->method('getTask')->willReturn($task);
+
+        $this->notificationManager->expects($this->never())->method('notify');
+        $this->logger->expects($this->once())->method('error');
+        $this->listener->handle($event);
+    }
+
+    public function testNotificationFailureDoesNotBreakTheEventChain(): void {
+        $this->mockPreferredProvider('aiquila:text2text');
+
+        $task = $this->createMock(Task::class);
+        $task->method('getUserId')->willReturn('testuser');
+        $task->method('getTaskTypeId')->willReturn('core:text2text');
+        $task->method('getId')->willReturn(99);
+        $task->method('getErrorMessage')->willReturn('boom');
+
+        $event = $this->createMock(TaskFailedEvent::class);
+        $event->method('getTask')->willReturn($task);
+
+        $notification = $this->createMock(INotification::class);
+        $notification->method('setApp')->willReturn($notification);
+        $notification->method('setUser')->willReturn($notification);
+        $notification->method('setDateTime')->willReturn($notification);
+        $notification->method('setObject')->willReturn($notification);
+        $notification->method('setSubject')->willReturn($notification);
+
+        $this->notificationManager->method('createNotification')->willReturn($notification);
+        $this->notificationManager->method('notify')
+            ->willThrowException(new \RuntimeException('boom'));
+        $this->logger->expects($this->once())->method('error');
 
         $this->listener->handle($event);
     }

--- a/nextcloud-app/tests/Unit/Listener/TaskSuccessfulListenerTest.php
+++ b/nextcloud-app/tests/Unit/Listener/TaskSuccessfulListenerTest.php
@@ -6,25 +6,39 @@ use OCA\AIquila\Listener\TaskSuccessfulListener;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
 use OCP\TaskProcessing\Events\TaskSuccessfulEvent;
+use OCP\TaskProcessing\IManager as ITaskProcessingManager;
+use OCP\TaskProcessing\IProvider;
 use OCP\TaskProcessing\Task;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 class TaskSuccessfulListenerTest extends TestCase {
     private INotificationManager $notificationManager;
+    private ITaskProcessingManager $taskProcessingManager;
     private LoggerInterface $logger;
     private TaskSuccessfulListener $listener;
 
     protected function setUp(): void {
         $this->notificationManager = $this->createMock(INotificationManager::class);
+        $this->taskProcessingManager = $this->createMock(ITaskProcessingManager::class);
         $this->logger = $this->createMock(LoggerInterface::class);
-        $this->listener = new TaskSuccessfulListener($this->notificationManager, $this->logger);
+        $this->listener = new TaskSuccessfulListener(
+            $this->notificationManager,
+            $this->taskProcessingManager,
+            $this->logger,
+        );
+    }
+
+    private function mockPreferredProvider(string $providerId): void {
+        $provider = $this->createMock(IProvider::class);
+        $provider->method('getId')->willReturn($providerId);
+        $this->taskProcessingManager->method('getPreferredProvider')->willReturn($provider);
     }
 
     public function testIgnoresNonAiquilaProvider(): void {
-        $task = $this->createMock(Task::class);
-        $task->method('getProviderId')->willReturn('other_app:text2text');
+        $this->mockPreferredProvider('other_app:text2text');
 
+        $task = $this->createMock(Task::class);
         $event = $this->createMock(TaskSuccessfulEvent::class);
         $event->method('getTask')->willReturn($task);
 
@@ -33,8 +47,9 @@ class TaskSuccessfulListenerTest extends TestCase {
     }
 
     public function testIgnoresNullUser(): void {
+        $this->mockPreferredProvider('aiquila:text2text');
+
         $task = $this->createMock(Task::class);
-        $task->method('getProviderId')->willReturn('aiquila:text2text');
         $task->method('getUserId')->willReturn(null);
 
         $event = $this->createMock(TaskSuccessfulEvent::class);
@@ -45,8 +60,9 @@ class TaskSuccessfulListenerTest extends TestCase {
     }
 
     public function testCreatesNotificationOnSuccess(): void {
+        $this->mockPreferredProvider('aiquila:text2text');
+
         $task = $this->createMock(Task::class);
-        $task->method('getProviderId')->willReturn('aiquila:text2text');
         $task->method('getUserId')->willReturn('testuser');
         $task->method('getTaskTypeId')->willReturn('core:text2text:summary');
         $task->method('getId')->willReturn(42);
@@ -67,6 +83,65 @@ class TaskSuccessfulListenerTest extends TestCase {
 
         $this->notificationManager->method('createNotification')->willReturn($notification);
         $this->notificationManager->expects($this->once())->method('notify')->with($notification);
+
+        $this->listener->handle($event);
+    }
+
+    public function testUnknownTaskTypeIsSkippedSilently(): void {
+        // A task type with no registered provider is not ours: skip without
+        // notifying and without logging an error.
+        $this->taskProcessingManager->method('getPreferredProvider')
+            ->willThrowException(new \OCP\TaskProcessing\Exception\Exception('no provider'));
+
+        $task = $this->createMock(Task::class);
+        $event = $this->createMock(TaskSuccessfulEvent::class);
+        $event->method('getTask')->willReturn($task);
+
+        $this->notificationManager->expects($this->never())->method('createNotification');
+        $this->notificationManager->expects($this->never())->method('notify');
+        $this->logger->expects($this->never())->method('error');
+        $this->listener->handle($event);
+    }
+
+    public function testUnexpectedErrorIsLoggedNotPropagated(): void {
+        // Anything other than "no provider" is unexpected: it must be logged by
+        // the guarded handle() and must not propagate to break the event chain.
+        $this->taskProcessingManager->method('getPreferredProvider')
+            ->willThrowException(new \RuntimeException('boom'));
+
+        $task = $this->createMock(Task::class);
+        $event = $this->createMock(TaskSuccessfulEvent::class);
+        $event->method('getTask')->willReturn($task);
+
+        $this->notificationManager->expects($this->never())->method('notify');
+        $this->logger->expects($this->once())->method('error');
+        $this->listener->handle($event);
+    }
+
+    public function testNotificationFailureDoesNotBreakTheEventChain(): void {
+        // This listener runs before other apps' listeners in the same event
+        // chain, so a failure while notifying must be logged and swallowed.
+        $this->mockPreferredProvider('aiquila:text2text');
+
+        $task = $this->createMock(Task::class);
+        $task->method('getUserId')->willReturn('testuser');
+        $task->method('getTaskTypeId')->willReturn('core:text2text');
+        $task->method('getId')->willReturn(42);
+
+        $event = $this->createMock(TaskSuccessfulEvent::class);
+        $event->method('getTask')->willReturn($task);
+
+        $notification = $this->createMock(INotification::class);
+        $notification->method('setApp')->willReturn($notification);
+        $notification->method('setUser')->willReturn($notification);
+        $notification->method('setDateTime')->willReturn($notification);
+        $notification->method('setObject')->willReturn($notification);
+        $notification->method('setSubject')->willReturn($notification);
+
+        $this->notificationManager->method('createNotification')->willReturn($notification);
+        $this->notificationManager->method('notify')
+            ->willThrowException(new \RuntimeException('boom'));
+        $this->logger->expects($this->once())->method('error');
 
         $this->listener->handle($event);
     }

--- a/nextcloud-app/tests/bootstrap.php
+++ b/nextcloud-app/tests/bootstrap.php
@@ -486,10 +486,29 @@ if (!class_exists('OCP\TaskProcessing\Task')) {
         public function getTaskTypeId(): string { return ''; }
         public function getAppId(): string { return ''; }
         public function getUserId(): ?string { return null; }
-        public function getProviderId(): ?string { return null; }
         public function getErrorMessage(): ?string { return null; }
     }
     class_alias('OCP_TaskProcessing_Task', 'OCP\TaskProcessing\Task');
+}
+
+if (!interface_exists('OCP\TaskProcessing\IProvider')) {
+    interface OCP_TaskProcessing_IProvider {
+        public function getId(): string;
+    }
+    class_alias('OCP_TaskProcessing_IProvider', 'OCP\TaskProcessing\IProvider');
+}
+
+if (!interface_exists('OCP\TaskProcessing\IManager')) {
+    interface OCP_TaskProcessing_IManager {
+        public function getPreferredProvider(string $taskTypeId): \OCP\TaskProcessing\IProvider;
+    }
+    class_alias('OCP_TaskProcessing_IManager', 'OCP\TaskProcessing\IManager');
+}
+
+if (!class_exists('OCP\TaskProcessing\Exception\Exception')) {
+    class OCP_TaskProcessing_Exception_Exception extends \Exception {
+    }
+    class_alias('OCP_TaskProcessing_Exception_Exception', 'OCP\TaskProcessing\Exception\Exception');
 }
 
 if (!class_exists('OCP\TaskProcessing\Events\TaskSuccessfulEvent')) {


### PR DESCRIPTION
## Description

The AIquila `TaskSuccessfulListener` and `TaskFailedListener` call `$task->getProviderId()`, which does not exist on `OCP\TaskProcessing\Task` (a `final` class with no `__call`). Every task completion therefore throws inside the listener.

Because Nextcloud loads apps alphabetically, `aiquila` runs **first** in the `TaskSuccessfulEvent` chain, ahead of e.g. `assistant`. The uncaught `Error` aborts the whole chain, so `OCA\Assistant\Listener\ChattyLLMTaskListener` never persists the chat reply. The task itself succeeds and the model answers, but nothing is written to `oc_assistant_chat_msgs`, and the Assistant chat UI polls `chat/check_generation` forever, always getting **HTTP 417**. Assistant file actions and the Mail listener are silently skipped for the same reason.

Reproduced and fixed on Nextcloud 33.0.5 (aiquila 0.3.23); upstream `main` (v0.3.32) carries the identical bug.

### Why CI didn't catch it

`tests/bootstrap.php` stubs `OCP\TaskProcessing\Task` with a `getProviderId()` method the real class lacks, so the tests passed against a fictional API.

### Changes

- Resolve the provider through `IManager::getPreferredProvider($taskTypeId)->getId()` instead of the non-existent `Task::getProviderId()`. For synchronous providers (all of aiquila's) the preferred provider is the one that ran the task.
- Wrap each handler body in `try/catch (\Throwable)` so a failure while notifying can never abort the event chain again. `isAiquilaTask()` catches only the documented `OCP\TaskProcessing\Exception\Exception` ("no provider for this task type" -> not ours); any unexpected throwable reaches the guarded `handle()` and is logged rather than silently disabling notifications.
- Fix the test stub (drop the bogus `getProviderId`, add `IManager` / `IProvider` / `Exception` stubs) and update the listener tests to drive the manager. The old code no longer satisfies the tests, guarding against regression.

### Note on notification behavior

Because the old code threw before reaching the notification logic, these success/failure notifications have **never fired in any released version**. After this fix they fire for every aiquila-handled task - on installs where aiquila is the preferred `core:text2text` provider that includes every Assistant chat reply the user is already watching in the chat UI. This restores the listeners' original intent, but flagging it so it is a conscious choice; gating chat-reply notifications could be a follow-up.

### Follow-up (not in this PR)

The root cause was a hand-written OCP stub drifting from the real API. Replacing the stubs in `tests/bootstrap.php` with a dev dependency on the official `nextcloud/ocp` package would prevent this class of bug entirely.

## Type of change
- [x] Bug fix

## Component
- [x] Nextcloud App

## Checklist
- [x] I have tested my changes locally
- [x] I have added tests for new functionality
- [x] I have updated the documentation if needed
- [x] My code follows the project's style guidelines

## Related Issues
Fixes #422

## Screenshots (if applicable)
N/A

