### PR TITLE
chore(nextcloud): wire psalm into composer and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Run tests
         run: composer test
 
+      - name: Static analysis (psalm)
+        run: composer psalm
+
       - name: Generate OpenAPI spec
         run: vendor/bin/generate-spec
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,18 @@ make logs-follow
 make test
 ```
 
+## Nextcloud app — static analysis
+
+Psalm runs over `lib/` at `errorLevel=3` and **CI fails on any error**:
+
+```bash
+cd nextcloud-app && composer psalm
+```
+
+`OCP\*` resolves through `vendor/nextcloud/ocp` (parsed via `<extraFiles>`); the private
+`OC\` classes the app touches are stubbed in `tests/stubs/`. There is no baseline — fix
+findings rather than adding one.
+
 ## Nextcloud app — OpenAPI spec
 
 After editing a controller annotated with `#[OpenAPI]`, regenerate and commit the spec

--- a/nextcloud-app/composer.json
+++ b/nextcloud-app/composer.json
@@ -14,7 +14,8 @@
         "phpunit/phpunit": "^13.0",
         "nextcloud/openapi-extractor": "^1.8",
         "nextcloud/ocp": "^33.0",
-        "doctrine/dbal": "^4.4"
+        "doctrine/dbal": "^4.4",
+        "vimeo/psalm": "^6.0"
     },
     "autoload": {
         "psr-4": {
@@ -27,7 +28,8 @@
         }
     },
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit",
+        "psalm": "psalm --no-cache"
     },
     "config": {
         "allow-plugins": {

--- a/nextcloud-app/composer.lock
+++ b/nextcloud-app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "241f0b34938bd8cb4c936eac7463c489",
+    "content-hash": "8252045c2f4a1651eb035dcedcdbc5df",
     "packages": [
         {
             "name": "anthropic-ai/sdk",
@@ -536,16 +536,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -583,7 +583,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -603,7 +603,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:52:40+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/http-client",
@@ -704,16 +704,16 @@
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d"
+                "reference": "41fc42d276aeff21192465331ebbab7d83a743c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
-                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/41fc42d276aeff21192465331ebbab7d83a743c0",
+                "reference": "41fc42d276aeff21192465331ebbab7d83a743c0",
                 "shasum": ""
             },
             "require": {
@@ -762,7 +762,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -782,20 +782,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T13:17:50+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
                 "shasum": ""
             },
             "require": {
@@ -849,7 +849,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -869,7 +869,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-28T09:44:51+00:00"
+            "time": "2026-06-16T09:55:08+00:00"
         }
     ],
     "packages-dev": [
@@ -945,6 +945,1175 @@
                 }
             ],
             "time": "2025-05-11T13:23:54+00:00"
+        },
+        {
+            "name": "amphp/amp",
+            "version": "v3.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "73c38b323ff8d790abf0f76c56fcc892bda4111a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/73c38b323ff8d790abf0f76c56fcc892bda4111a",
+                "reference": "73c38b323ff8d790abf0f76c56fcc892bda4111a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Future/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "https://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v3.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-19T17:59:20+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/parser": "^1.1",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2.3"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.22.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\ByteStream\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "https://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/v2.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-16T17:10:27+00:00"
+        },
+        {
+            "name": "amphp/cache",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/cache.git",
+                "reference": "46912e387e6aa94933b61ea1ead9cf7540b7797c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/cache/zipball/46912e387e6aa94933b61ea1ead9cf7540b7797c",
+                "reference": "46912e387e6aa94933b61ea1ead9cf7540b7797c",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Cache\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                }
+            ],
+            "description": "A fiber-aware cache API based on Amp and Revolt.",
+            "homepage": "https://amphp.org/cache",
+            "support": {
+                "issues": "https://github.com/amphp/cache/issues",
+                "source": "https://github.com/amphp/cache/tree/v2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-19T03:38:06+00:00"
+        },
+        {
+            "name": "amphp/dns",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/dns.git",
+                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/dns/zipball/78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
+                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/cache": "^2",
+                "amphp/parser": "^1",
+                "amphp/process": "^2",
+                "daverandom/libdns": "^2.0.2",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.20"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Dns\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Wright",
+                    "email": "addr@daverandom.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "Async DNS resolution for Amp.",
+            "homepage": "https://github.com/amphp/dns",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "client",
+                "dns",
+                "resolve"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/dns/issues",
+                "source": "https://github.com/amphp/dns/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-19T15:43:40+00:00"
+        },
+        {
+            "name": "amphp/parallel",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/parallel.git",
+                "reference": "37f5b2754fadc229c00f9416bd68fb8d04529a81"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/parallel/zipball/37f5b2754fadc229c00f9416bd68fb8d04529a81",
+                "reference": "37f5b2754fadc229c00f9416bd68fb8d04529a81",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/cache": "^2",
+                "amphp/parser": "^1",
+                "amphp/pipeline": "^1",
+                "amphp/process": "^2",
+                "amphp/serialization": "^1",
+                "amphp/socket": "^2",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Context/functions.php",
+                    "src/Context/Internal/functions.php",
+                    "src/Ipc/functions.php",
+                    "src/Worker/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Parallel\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Stephen Coakley",
+                    "email": "me@stephencoakley.com"
+                }
+            ],
+            "description": "Parallel processing component for Amp.",
+            "homepage": "https://github.com/amphp/parallel",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrent",
+                "multi-processing",
+                "multi-threading"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/parallel/issues",
+                "source": "https://github.com/amphp/parallel/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-16T16:54:01+00:00"
+        },
+        {
+            "name": "amphp/parser",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/parser.git",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/parser/zipball/3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Parser\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A generator parser to make streaming parsers simple.",
+            "homepage": "https://github.com/amphp/parser",
+            "keywords": [
+                "async",
+                "non-blocking",
+                "parser",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/parser/issues",
+                "source": "https://github.com/amphp/parser/tree/v1.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-21T19:16:53+00:00"
+        },
+        {
+            "name": "amphp/pipeline",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/pipeline.git",
+                "reference": "cf2d67696c2015ea7c7fd8f6ec5f8ed7c2d17c17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/cf2d67696c2015ea7c7fd8f6ec5f8ed7c2d17c17",
+                "reference": "cf2d67696c2015ea7c7fd8f6ec5f8ed7c2d17c17",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Pipeline\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Asynchronous iterators and operators.",
+            "homepage": "https://amphp.org/pipeline",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "iterator",
+                "non-blocking"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/pipeline/issues",
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-26T14:50:43+00:00"
+        },
+        {
+            "name": "amphp/process",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/process.git",
+                "reference": "583959df17d00304ad7b0b32285373f985935643"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/process/zipball/583959df17d00304ad7b0b32285373f985935643",
+                "reference": "583959df17d00304ad7b0b32285373f985935643",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Process\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A fiber-aware process manager based on Amp and Revolt.",
+            "homepage": "https://amphp.org/process",
+            "support": {
+                "issues": "https://github.com/amphp/process/issues",
+                "source": "https://github.com/amphp/process/tree/v2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-31T15:11:55+00:00"
+        },
+        {
+            "name": "amphp/serialization",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/serialization.git",
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/fdf2834d78cebb0205fb2672676c1b1eb84371f0",
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "ext-json": "*",
+                "ext-zlib": "*",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Serialization\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Serialization tools for IPC and data storage in PHP.",
+            "homepage": "https://github.com/amphp/serialization",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "serialization",
+                "serialize"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/serialization/issues",
+                "source": "https://github.com/amphp/serialization/tree/v1.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-05T15:59:53+00:00"
+        },
+        {
+            "name": "amphp/socket",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/socket.git",
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/socket/zipball/dadb63c5d3179fd83803e29dfeac27350e619314",
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/dns": "^2",
+                "ext-openssl": "*",
+                "kelunik/certificate": "^1.1",
+                "league/uri": "^7",
+                "league/uri-interfaces": "^7",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "amphp/process": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php",
+                    "src/SocketAddress/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Socket\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@gmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Non-blocking socket connection / server implementations based on Amp and Revolt.",
+            "homepage": "https://github.com/amphp/socket",
+            "keywords": [
+                "amp",
+                "async",
+                "encryption",
+                "non-blocking",
+                "sockets",
+                "tcp",
+                "tls"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/socket/issues",
+                "source": "https://github.com/amphp/socket/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-19T15:09:56+00:00"
+        },
+        {
+            "name": "amphp/sync",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/sync.git",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/sync/zipball/217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Sync\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Stephen Coakley",
+                    "email": "me@stephencoakley.com"
+                }
+            ],
+            "description": "Non-blocking synchronization primitives for PHP based on Amp and Revolt.",
+            "homepage": "https://github.com/amphp/sync",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "mutex",
+                "semaphore",
+                "synchronization"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/sync/issues",
+                "source": "https://github.com/amphp/sync/tree/v2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-03T19:31:26+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<2.2.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-07T11:47:49+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "danog/advanced-json-rpc",
+            "version": "v3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/danog/php-advanced-json-rpc.git",
+                "reference": "ae703ea7b4811797a10590b6078de05b3b33dd91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/danog/php-advanced-json-rpc/zipball/ae703ea7b4811797a10590b6078de05b3b33dd91",
+                "reference": "ae703ea7b4811797a10590b6078de05b3b33dd91",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^5",
+                "php": ">=8.1",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0 || ^6"
+            },
+            "replace": {
+                "felixfbecker/php-advanced-json-rpc": "^3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                },
+                {
+                    "name": "Daniil Gentili",
+                    "email": "daniil@daniil.it"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/danog/php-advanced-json-rpc/issues",
+                "source": "https://github.com/danog/php-advanced-json-rpc/tree/v3.2.3"
+            },
+            "time": "2026-01-12T21:07:10+00:00"
+        },
+        {
+            "name": "daverandom/libdns",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DaveRandom/LibDNS.git",
+                "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DaveRandom/LibDNS/zipball/b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+                "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "Required for IDN support"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "LibDNS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "DNS protocol implementation written in pure PHP",
+            "keywords": [
+                "dns"
+            ],
+            "support": {
+                "issues": "https://github.com/DaveRandom/LibDNS/issues",
+                "source": "https://github.com/DaveRandom/LibDNS/tree/v2.1.0"
+            },
+            "time": "2024-04-12T12:12:48+00:00"
+        },
+        {
+            "name": "dnoegel/php-xdg-base-dir",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "XdgBaseDir\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "implementation of xdg base directory specification for php",
+            "support": {
+                "issues": "https://github.com/dnoegel/php-xdg-base-dir/issues",
+                "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
+            },
+            "time": "2019-12-04T15:06:13+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -1101,6 +2270,363 @@
             "time": "2026-02-07T07:09:04+00:00"
         },
         {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "v1.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "a9e113dbc7d849e35b8776da39edaf4313b7b6c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/a9e113dbc7d849e35b8776da39edaf4313b7b6c9",
+                "reference": "a9e113dbc7d849e35b8776da39edaf4313b7b6c9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "squizlabs/php_codesniffer": "^3.1",
+                "vimeo/psalm": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.3"
+            },
+            "time": "2024-04-30T00:40:11+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-14T07:29:31+00:00"
+        },
+        {
+            "name": "kelunik/certificate",
+            "version": "v1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kelunik/certificate.git",
+                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kelunik/certificate/zipball/7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^6 | 7 | ^8 | ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Kelunik\\Certificate\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Access certificate details and transform between different formats.",
+            "keywords": [
+                "DER",
+                "certificate",
+                "certificates",
+                "openssl",
+                "pem",
+                "x509"
+            ],
+            "support": {
+                "issues": "https://github.com/kelunik/certificate/issues",
+                "source": "https://github.com/kelunik/certificate/tree/v1.1.3"
+            },
+            "time": "2023-02-03T21:26:53+00:00"
+        },
+        {
+            "name": "league/uri",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri-interfaces": "^7.8.1",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
+            },
+            "conflict": {
+                "league/uri-schemes": "^1.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
+                "ext-fileinfo": "to create Data URI from file contennts",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "ext-uri": "to use the PHP native URI class",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-components": "to provide additional tools to manipulate URI objects components",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "URN",
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "middleware",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc2141",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "rfc8141",
+                "uri",
+                "uri-template",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-15T20:22:25+00:00"
+        },
+        {
+            "name": "league/uri-interfaces",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-interfaces.git",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^8.1",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-08T20:05:35+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",
             "source": {
@@ -1159,6 +2685,57 @@
                 }
             ],
             "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "netresearch/jsonmapper",
+            "version": "v5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "980674efdda65913492d29a8fd51c82270dd37bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/980674efdda65913492d29a8fd51c82270dd37bb",
+                "reference": "980674efdda65913492d29a8fd51c82270dd37bb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.5 || ~8.0 || ~9.0 || ~10.0",
+                "squizlabs/php_codesniffer": "~3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "support": {
+                "email": "cweiske@cweiske.de",
+                "issues": "https://github.com/cweiske/jsonmapper/issues",
+                "source": "https://github.com/cweiske/jsonmapper/tree/v5.0.1"
+            },
+            "time": "2026-02-22T16:28:03+00:00"
         },
         {
             "name": "nextcloud/ocp",
@@ -1257,20 +2834,19 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.7.0",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": ">=7.4"
@@ -1309,9 +2885,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
-            "time": "2025-12-06T11:56:16+00:00"
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1432,17 +3008,193 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
-            "name": "phpstan/phpdoc-parser",
-            "version": "2.3.2",
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
+            },
+            "time": "2026-03-18T20:49:53+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
+            },
+            "time": "2026-01-06T21:53:42+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
                 "shasum": ""
             },
             "require": {
@@ -1474,9 +3226,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
             },
-            "time": "2026-01-25T14:56:51+00:00"
+            "time": "2026-07-08T07:01:06+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2098,6 +3850,78 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "revolt/event-loop",
+            "version": "v1.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/revoltphp/event-loop.git",
+                "reference": "44061cf513e53c6200372fc935ac42271566295d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/44061cf513e53c6200372fc935ac42271566295d",
+                "reference": "44061cf513e53c6200372fc935ac42271566295d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Revolt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Rock-solid event loop for concurrent PHP applications.",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrency",
+                "event",
+                "event-loop",
+                "non-blocking",
+                "scheduler"
+            ],
+            "support": {
+                "issues": "https://github.com/revoltphp/event-loop/issues",
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.9"
+            },
+            "time": "2026-05-16T17:55:38+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -3138,6 +4962,74 @@
             "time": "2026-02-06T04:52:52+00:00"
         },
         {
+            "name": "spatie/array-to-xml",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/array-to-xml.git",
+                "reference": "88b2f3852a922dd73177a68938f8eb2ec70c7224"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/88b2f3852a922dd73177a68938f8eb2ec70c7224",
+                "reference": "88b2f3852a922dd73177a68938f8eb2ec70c7224",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.2",
+                "pestphp/pest": "^1.21",
+                "spatie/pest-plugin-snapshots": "^1.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\ArrayToXml\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://freek.dev",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Convert an array to xml",
+            "homepage": "https://github.com/spatie/array-to-xml",
+            "keywords": [
+                "array",
+                "convert",
+                "xml"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/array-to-xml/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-12-15T09:00:41+00:00"
+        },
+        {
             "name": "staabm/side-effects-detector",
             "version": "1.0.5",
             "source": {
@@ -3190,6 +5082,757 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
+            "name": "symfony/console",
+            "version": "v8.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "68efa2ebfd9a362951eb5a8b09fd177c66ddec24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/68efa2ebfd9a362951eb5a8b09fd177c66ddec24",
+                "reference": "68efa2ebfd9a362951eb5a8b09fd177c66ddec24",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/polyfill-php85": "^1.32",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^7.4.6|^8.0.6"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<8.1",
+                "symfony/event-dispatcher": "<8.1"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^8.1",
+                "symfony/event-dispatcher": "^8.1",
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/uid": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v8.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-31T12:43:13+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v8.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "17856b7a222664a26a5ea1cb06ee0721c2438217"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/17856b7a222664a26a5ea1cb06ee0721c2438217",
+                "reference": "17856b7a222664a26a5ea1cb06ee0721c2438217",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v8.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-22T15:42:13+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.41.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "bb899c1db0aa8127dc3afe8cda4a67eb24915f8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/bb899c1db0aa8127dc3afe8cda4a67eb24915f8d",
+                "reference": "bb899c1db0aa8127dc3afe8cda4a67eb24915f8d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.41.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-28T08:25:59+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.38.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T13:48:31+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php84",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php84.git",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php84\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:51:13+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php85",
+            "version": "v1.41.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php85.git",
+                "reference": "255fab485aaa1006ed411040c42aecd7b5302d7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/255fab485aaa1006ed411040c42aecd7b5302d7a",
+                "reference": "255fab485aaa1006ed411040c42aecd7b5302d7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php85\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.5+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.41.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-01T12:47:55+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v8.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "286a76b7255e5cc4bf0101a0bc5388ecf1c38ccc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/286a76b7255e5cc4bf0101a0bc5388ecf1c38ccc",
+                "reference": "286a76b7255e5cc4bf0101a0bc5388ecf1c38ccc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v8.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-28T07:35:25+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "2.0.1",
             "source": {
@@ -3238,6 +5881,190 @@
                 }
             ],
             "time": "2025-12-08T11:19:18+00:00"
+        },
+        {
+            "name": "vimeo/psalm",
+            "version": "6.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "f1f5de594dc76faf8784e02d3dc4716c91c6f6ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f1f5de594dc76faf8784e02d3dc4716c91c6f6ac",
+                "reference": "f1f5de594dc76faf8784e02d3dc4716c91c6f6ac",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/parallel": "^2.3",
+                "composer-runtime-api": "^2",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "composer/xdebug-handler": "^2.0 || ^3.0",
+                "danog/advanced-json-rpc": "^3.1",
+                "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "felixfbecker/language-server-protocol": "^1.5.3",
+                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
+                "netresearch/jsonmapper": "^5.0",
+                "nikic/php-parser": "^5.0.0",
+                "php": "~8.1.31 || ~8.2.27 || ~8.3.16 || ~8.4.3 || ~8.5.0",
+                "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+                "spatie/array-to-xml": "^2.17.0 || ^3.0",
+                "symfony/console": "^6.0 || ^7.0 || ^8.0",
+                "symfony/filesystem": "~6.3.12 || ~6.4.3 || ^7.0.3 || ^8.0",
+                "symfony/polyfill-php84": "^1.31.0"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "amphp/phpunit-util": "^3",
+                "bamarni/composer-bin-plugin": "^1.4",
+                "brianium/paratest": "^6.9",
+                "danog/class-finder": "^0.4.8",
+                "dg/bypass-finals": "^1.5",
+                "ext-curl": "*",
+                "mockery/mockery": "^1.5",
+                "nunomaduro/mock-final-classes": "^1.1",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpdoc-parser": "^1.6",
+                "phpunit/phpunit": "^9.6",
+                "psalm/plugin-mockery": "^1.1",
+                "psalm/plugin-phpunit": "^0.19",
+                "slevomat/coding-standard": "^8.4",
+                "squizlabs/php_codesniffer": "^3.6",
+                "symfony/process": "^6.0 || ^7.0 || ^8.0"
+            },
+            "suggest": {
+                "ext-curl": "In order to send data to shepherd",
+                "ext-igbinary": "^2.0.5 is required, used to serialize caching data"
+            },
+            "bin": [
+                "psalm",
+                "psalm-language-server",
+                "psalm-plugin",
+                "psalm-refactor",
+                "psalm-review",
+                "psalter"
+            ],
+            "type": "project",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-4.x": "4.x-dev",
+                    "dev-5.x": "5.x-dev",
+                    "dev-6.x": "6.x-dev",
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                },
+                {
+                    "name": "Daniil Gentili",
+                    "email": "daniil@daniil.it"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://psalm.dev/docs",
+                "issues": "https://github.com/vimeo/psalm/issues",
+                "source": "https://github.com/vimeo/psalm"
+            },
+            "time": "2026-03-19T10:56:09+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "2.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev",
+                    "dev-feature/2-0": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/2.4.1"
+            },
+            "time": "2026-06-15T15:31:57+00:00"
         }
     ],
     "aliases": [],

--- a/nextcloud-app/lib/AppInfo/Application.php
+++ b/nextcloud-app/lib/AppInfo/Application.php
@@ -13,6 +13,8 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use Psr\Container\ContainerInterface;
+
 class Application extends App implements IBootstrap {
     public const APP_ID = 'aiquila';
 
@@ -53,10 +55,11 @@ class Application extends App implements IBootstrap {
         $context->registerDashboardWidget(\OCA\AIquila\Dashboard\CoworkerOutputWidget::class);
 
         // Cowork task-type registry — the set of jobs coworkers can run
-        $context->registerService(CoworkerTaskRegistry::class, function ($c) {
-            return new CoworkerTaskRegistry([
-                $c->get(VisionClassifyImagesTaskType::class),
-            ]);
+        $context->registerService(CoworkerTaskRegistry::class, function (ContainerInterface $c) {
+            $visionClassify = $c->get(VisionClassifyImagesTaskType::class);
+            assert($visionClassify instanceof VisionClassifyImagesTaskType);
+
+            return new CoworkerTaskRegistry([$visionClassify]);
         });
 
         // Register Claude TaskProcessing Providers for Nextcloud Assistant integration

--- a/nextcloud-app/lib/Command/TestSDKCommand.php
+++ b/nextcloud-app/lib/Command/TestSDKCommand.php
@@ -103,11 +103,11 @@ class TestSDKCommand extends Base {
                     return 1;
                 }
 
-                $output->writeln('<info>✓ Response received in ' . $duration . 's</info>');
+                $output->writeln('<info>✓ Response received in ' . (string)$duration . 's</info>');
                 $output->writeln('');
                 $output->writeln('<comment>Claude\'s Response:</comment>');
                 $output->writeln('<comment>─────────────────────</comment>');
-                $output->writeln($result['response']);
+                $output->writeln($result['response'] ?? '');
                 $output->writeln('<comment>─────────────────────</comment>');
             }
 

--- a/nextcloud-app/lib/Controller/ChatController.php
+++ b/nextcloud-app/lib/Controller/ChatController.php
@@ -4,6 +4,7 @@
 namespace OCA\AIquila\Controller;
 
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\JSONResponse;
@@ -19,6 +20,8 @@ use OCA\AIquila\Service\Provider\LLMProviderFactory;
 use OCA\AIquila\Service\Provider\LLMProviderInterface;
 
 class ChatController extends Controller {
+    use RequiresUserIdTrait;
+
     private LLMProviderFactory $providerFactory;
     private FileService $fileService;
     private FilesService $filesService;
@@ -66,7 +69,7 @@ class ChatController extends Controller {
      */
     private function checkRateLimit(): bool {
         $key = 'rate_limit_' . ($this->userId ?? 'anonymous');
-        $requests = (int)$this->cache->get($key) ?? 0;
+        $requests = (int)($this->cache->get($key) ?? 0);
 
         if ($requests >= self::RATE_LIMIT_REQUESTS) {
             return false;
@@ -95,12 +98,9 @@ class ChatController extends Controller {
      * 404: One of the attached files was not found
      * 413: Prompt or context exceeds the 5 MB content limit
      * 429: Rate limit exceeded (10 requests per minute)
+     * 500: An attached file could not be read
      *
-     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_TOO_MANY_REQUESTS, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_TOO_MANY_REQUESTS, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
      *
      * @NoAdminRequired
      */
@@ -134,12 +134,16 @@ class ChatController extends Controller {
 
     /**
      * Handle ask() with attached files — reads content and delegates to the appropriate Claude method
+     *
+     * @param list<string> $files
+     *
+     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
      */
     private function askWithFiles(string $prompt, array $files): JSONResponse {
         $fileDataList = [];
         foreach ($files as $path) {
             try {
-                $fileDataList[] = $this->fileService->getContent($path, $this->userId);
+                $fileDataList[] = $this->fileService->getContent($path, $this->requireUserId());
             } catch (\OCP\Files\NotFoundException $e) {
                 return new JSONResponse(['error' => 'File not found: ' . $path], 404);
             } catch (\InvalidArgumentException $e) {
@@ -299,10 +303,7 @@ class ChatController extends Controller {
      * 413: Combined message content exceeds the 5 MB content limit
      * 429: Rate limit exceeded (10 requests per minute)
      *
-     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_TOO_MANY_REQUESTS, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_TOO_MANY_REQUESTS, array{error: string}, array{}>
      *
      * @NoAdminRequired
      */
@@ -323,7 +324,7 @@ class ChatController extends Controller {
         $totalLength = 0;
         foreach ($messages as $msg) {
             $content = $msg['content'] ?? '';
-            $totalLength += is_string($content) ? strlen($content) : strlen(json_encode($content));
+            $totalLength += is_string($content) ? strlen($content) : strlen((string)json_encode($content));
         }
         if ($totalLength > self::MAX_CONTENT_LENGTH) {
             return new JSONResponse([
@@ -390,10 +391,7 @@ class ChatController extends Controller {
      * 413: Content exceeds the 5 MB content limit
      * 429: Rate limit exceeded (10 requests per minute)
      *
-     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_TOO_MANY_REQUESTS, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_TOO_MANY_REQUESTS, array{error: string}, array{}>
      *
      * @NoAdminRequired
      */
@@ -432,12 +430,7 @@ class ChatController extends Controller {
      * 413: Prompt exceeds the 5 MB content limit
      * 429: Rate limit exceeded (10 requests per minute)
      *
-     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_TOO_MANY_REQUESTS, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_TOO_MANY_REQUESTS, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
      *
      * @NoAdminRequired
      */
@@ -461,7 +454,7 @@ class ChatController extends Controller {
         }
 
         try {
-            $fileData = $this->fileService->getContent($filePath, $this->userId);
+            $fileData = $this->fileService->getContent($filePath, $this->requireUserId());
         } catch (\OCP\Files\NotFoundException $e) {
             return new JSONResponse(['error' => 'File not found: ' . $filePath], 404);
         } catch (\InvalidArgumentException $e) {

--- a/nextcloud-app/lib/Controller/ConversationController.php
+++ b/nextcloud-app/lib/Controller/ConversationController.php
@@ -23,6 +23,7 @@ use OCA\AIquila\Service\NativeMcpService;
 use OCA\AIquila\Service\Provider\LLMProviderFactory;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCA\AIquila\BackgroundJob\IndexConversationJob;
@@ -33,6 +34,8 @@ use OCP\BackgroundJob\IJobList;
 use OCP\IRequest;
 
 class ConversationController extends Controller {
+    use RequiresUserIdTrait;
+
     private ConversationMapper $conversationMapper;
     private MessageMapper $messageMapper;
     private MessageFileMapper $messageFileMapper;
@@ -96,12 +99,12 @@ class ConversationController extends Controller {
      *
      * 200: List of conversations
      *
-     * @return JSONResponse<Http::STATUS_OK, list<array{id: int, title: ?string, model: string, createdAt: int, updatedAt: int}>, array{}>
+     * @return JSONResponse<Http::STATUS_OK, list<array{id: int, userId: string, title: ?string, model: string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}>, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function index(): JSONResponse {
-        $conversations = $this->conversationMapper->findAllByUser($this->userId);
+        $conversations = $this->conversationMapper->findAllByUser($this->requireUserId());
         return new JSONResponse(array_map(
             fn(Conversation $c) => $c->jsonSerialize(),
             $conversations
@@ -113,14 +116,14 @@ class ConversationController extends Controller {
      *
      * 200: The created conversation
      *
-     * @return JSONResponse<Http::STATUS_OK, array{id: int, title: ?string, model: string, createdAt: int, updatedAt: int}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function create(): JSONResponse {
         $now = time();
         $conversation = new Conversation();
-        $conversation->setUserId($this->userId);
+        $conversation->setUserId($this->requireUserId());
         $conversation->setModel($this->providerFactory->getProvider($this->userId)->getModel($this->userId));
         $conversation->setCreatedAt($now);
         $conversation->setUpdatedAt($now);
@@ -137,14 +140,13 @@ class ConversationController extends Controller {
      * 200: Conversation with messages
      * 404: Conversation not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{id: int, title: ?string, model: string, messages: list<array<string, mixed>>}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool, messages: list<array{id: int, conversationId: int, role: string, content: string, inputTokens: ?int, outputTokens: ?int, cacheCreationTokens: ?int, cacheReadTokens: ?int, latencyMs: ?int, citations: ?array<string, mixed>, documents: ?array<string, mixed>, createdAt: int, files: list<array{id: int, messageId: int, filePath: string, fileName: string, mimeType: ?string, createdAt: int}>}>}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function show(int $id): JSONResponse {
         try {
-            $conversation = $this->conversationMapper->findByIdAndUser($id, $this->userId);
+            $conversation = $this->conversationMapper->findByIdAndUser($id, $this->requireUserId());
         } catch (DoesNotExistException $e) {
             return new JSONResponse(['error' => 'Conversation not found'], 404);
         }
@@ -178,15 +180,13 @@ class ConversationController extends Controller {
      * 400: Invalid effort or thinking value
      * 404: Conversation not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{id: int, title: ?string, model: string}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string, allowed?: list<string>}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string, allowed: list<string>}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function update(int $id, string $title = '', ?int $projectId = null, ?string $effort = null, ?string $thinking = null): JSONResponse {
         try {
-            $conversation = $this->conversationMapper->findByIdAndUser($id, $this->userId);
+            $conversation = $this->conversationMapper->findByIdAndUser($id, $this->requireUserId());
         } catch (DoesNotExistException $e) {
             return new JSONResponse(['error' => 'Conversation not found'], 404);
         }
@@ -236,14 +236,13 @@ class ConversationController extends Controller {
      * 200: Deletion confirmed
      * 404: Conversation not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{deleted: true}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{deleted: true}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function destroy(int $id): JSONResponse {
         try {
-            $conversation = $this->conversationMapper->findByIdAndUser($id, $this->userId);
+            $conversation = $this->conversationMapper->findByIdAndUser($id, $this->requireUserId());
         } catch (DoesNotExistException $e) {
             return new JSONResponse(['error' => 'Conversation not found'], 404);
         }
@@ -273,9 +272,7 @@ class ConversationController extends Controller {
      * 400: No prompt provided
      * 404: Conversation not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{userMessage: array<string, mixed>, assistantMessage: array<string, mixed>, conversation: array<string, mixed>}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{userMessage: array<string, mixed>, assistantMessage: array<string, mixed>, conversation: array<string, mixed>}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
@@ -285,7 +282,7 @@ class ConversationController extends Controller {
         }
 
         try {
-            $conversation = $this->conversationMapper->findByIdAndUser($id, $this->userId);
+            $conversation = $this->conversationMapper->findByIdAndUser($id, $this->requireUserId());
         } catch (DoesNotExistException $e) {
             return new JSONResponse(['error' => 'Conversation not found'], 404);
         }
@@ -304,7 +301,7 @@ class ConversationController extends Controller {
         $fileEntities = [];
         foreach ($files as $filePath) {
             try {
-                $info = $this->fileService->getInfo($filePath, $this->userId);
+                $info = $this->fileService->getInfo($filePath, $this->requireUserId());
             } catch (\Exception $e) {
                 // Store with basic info if lookup fails
                 $info = ['name' => basename($filePath), 'mimeType' => 'application/octet-stream'];
@@ -336,7 +333,7 @@ class ConversationController extends Controller {
             $built = $this->buildFileContentBlocks($files);
             $contentBlocks = $built['blocks'];
             $documentsIndex = $built['documents'];
-            if (!empty($contentBlocks)) {
+            if (!empty($contentBlocks) && $claudeMessages !== []) {
                 $lastIdx = count($claudeMessages) - 1;
                 $userText = $claudeMessages[$lastIdx]['content'];
                 // Convert plain string content to structured array with file blocks + text
@@ -349,9 +346,10 @@ class ConversationController extends Controller {
 
         // 5. Load project system prompt if conversation has a project
         $systemPrompt = null;
-        if ($conversation->getProjectId() !== null) {
+        $projectId = $conversation->getProjectId();
+        if ($projectId !== null) {
             try {
-                $project = $this->projectMapper->findByIdAndUser($conversation->getProjectId(), $this->userId);
+                $project = $this->projectMapper->findByIdAndUser($projectId, $this->requireUserId());
                 $systemPrompt = $project->getSystemPrompt();
 
                 // Build project context from paths
@@ -372,7 +370,7 @@ class ConversationController extends Controller {
         // 6. Call Claude (with MCP tools if available). If the call fails because
         //    a cached Anthropic file_id was evicted server-side, drop the row,
         //    rebuild content blocks (re-uploading), and retry once.
-        $startMs = (int)(microtime(true) * 1000);
+        $startMs = (int)(microtime(true) * 1000.0);
         $options = $this->conversationOptions($conversation);
         $result = $this->callClaude($claudeMessages, $systemPrompt, $options);
         if (
@@ -382,13 +380,13 @@ class ConversationController extends Controller {
             && $this->filesService->evictByFileId($staleId)
         ) {
             $rebuilt = $this->buildFileContentBlocks($files);
-            if (!empty($rebuilt['blocks'])) {
+            if (!empty($rebuilt['blocks']) && $claudeMessages !== []) {
                 $documentsIndex = $rebuilt['documents'];
                 $lastIdx = count($claudeMessages) - 1;
                 $userText = $claudeMessages[$lastIdx]['content'];
                 if (is_array($userText)) {
                     $textBlock = end($userText) ?: ['type' => 'text', 'text' => ''];
-                    $userText = is_array($textBlock) ? ($textBlock['text'] ?? '') : '';
+                    $userText = $textBlock['text'] ?? '';
                 }
                 $claudeMessages[$lastIdx]['content'] = array_merge(
                     $rebuilt['blocks'],
@@ -397,7 +395,7 @@ class ConversationController extends Controller {
             }
             $result = $this->callClaude($claudeMessages, $systemPrompt, $options);
         }
-        $latencyMs = (int)(microtime(true) * 1000) - $startMs;
+        $latencyMs = (int)(microtime(true) * 1000.0) - $startMs;
 
         if (isset($result['error'])) {
             // Persist error as assistant message so user sees it in history
@@ -430,9 +428,9 @@ class ConversationController extends Controller {
         $assistantMsg->setCacheReadTokens($result['usage']['cache_read_tokens'] ?? null);
         $assistantMsg->setLatencyMs($latencyMs);
         if (!empty($result['citations'])) {
-            $assistantMsg->setCitations(json_encode($result['citations']));
+            $assistantMsg->setCitations(json_encode($result['citations']) ?: null);
             if (!empty($documentsIndex)) {
-                $assistantMsg->setDocuments(json_encode($documentsIndex));
+                $assistantMsg->setDocuments(json_encode($documentsIndex) ?: null);
             }
         }
         $assistantMsg->setCreatedAt(time());
@@ -485,7 +483,7 @@ class ConversationController extends Controller {
             return new JSONResponse(['error' => 'No prompt provided'], 400);
         }
         try {
-            $this->conversationMapper->findByIdAndUser($id, $this->userId);
+            $this->conversationMapper->findByIdAndUser($id, $this->requireUserId());
         } catch (DoesNotExistException $e) {
             return new JSONResponse(['error' => 'Conversation not found'], 404);
         }
@@ -504,7 +502,7 @@ class ConversationController extends Controller {
         $now = time();
 
         try {
-            $conversation = $this->conversationMapper->findByIdAndUser($id, $this->userId);
+            $conversation = $this->conversationMapper->findByIdAndUser($id, $this->requireUserId());
         } catch (DoesNotExistException $e) {
             yield ['type' => 'error', 'error' => 'Conversation not found'];
             return;
@@ -521,7 +519,7 @@ class ConversationController extends Controller {
         $fileEntities = [];
         foreach ($files as $filePath) {
             try {
-                $info = $this->fileService->getInfo($filePath, $this->userId);
+                $info = $this->fileService->getInfo($filePath, $this->requireUserId());
             } catch (\Exception $e) {
                 $info = ['name' => basename($filePath), 'mimeType' => 'application/octet-stream'];
             }
@@ -548,7 +546,7 @@ class ConversationController extends Controller {
             $built = $this->buildFileContentBlocks($files);
             $contentBlocks = $built['blocks'];
             $documentsIndex = $built['documents'];
-            if (!empty($contentBlocks)) {
+            if (!empty($contentBlocks) && $claudeMessages !== []) {
                 $lastIdx = count($claudeMessages) - 1;
                 $userText = $claudeMessages[$lastIdx]['content'];
                 $claudeMessages[$lastIdx]['content'] = array_merge(
@@ -559,9 +557,10 @@ class ConversationController extends Controller {
         }
 
         $systemPrompt = null;
-        if ($conversation->getProjectId() !== null) {
+        $projectId = $conversation->getProjectId();
+        if ($projectId !== null) {
             try {
-                $project = $this->projectMapper->findByIdAndUser($conversation->getProjectId(), $this->userId);
+                $project = $this->projectMapper->findByIdAndUser($projectId, $this->requireUserId());
                 $systemPrompt = $project->getSystemPrompt();
                 $paths = $this->projectPathMapper->findByProject($project->getId());
                 if (!empty($paths)) {
@@ -593,6 +592,10 @@ class ConversationController extends Controller {
             }
         }
 
+        $tools = [];
+        // Replaced below unless the native connector handles the tools instead;
+        // keeping it callable spares every caller a null check.
+        $toolExecutor = static fn(string $_name, array $_input): array => [];
         if (!$useNativeMcp) {
             try {
                 $allTools = $this->mcpClient->getAllTools();
@@ -612,7 +615,7 @@ class ConversationController extends Controller {
         $finalCitations = [];
         $finalUsage = ['input_tokens' => 0, 'output_tokens' => 0, 'cache_creation_tokens' => null, 'cache_read_tokens' => null];
         $errorMessage = null;
-        $startMs = (int)(microtime(true) * 1000);
+        $startMs = (int)(microtime(true) * 1000.0);
         $options = $this->conversationOptions($conversation);
 
         $eventStream = $useNativeMcp
@@ -651,7 +654,7 @@ class ConversationController extends Controller {
             yield $event;
         }
 
-        $latencyMs = (int)(microtime(true) * 1000) - $startMs;
+        $latencyMs = (int)(microtime(true) * 1000.0) - $startMs;
 
         // 5. Persist assistant message — even on error, so partial output is preserved.
         $assistantContent = $accumulatedText !== ''
@@ -671,9 +674,9 @@ class ConversationController extends Controller {
         $assistantMsg->setCacheReadTokens($finalUsage['cache_read_tokens'] ?? null);
         $assistantMsg->setLatencyMs($latencyMs);
         if (!empty($finalCitations)) {
-            $assistantMsg->setCitations(json_encode($finalCitations));
+            $assistantMsg->setCitations(json_encode($finalCitations) ?: null);
             if (!empty($documentsIndex)) {
-                $assistantMsg->setDocuments(json_encode($documentsIndex));
+                $assistantMsg->setDocuments(json_encode($documentsIndex) ?: null);
             }
         }
         $assistantMsg->setCreatedAt(time());
@@ -707,14 +710,13 @@ class ConversationController extends Controller {
      * 200: The duplicated conversation
      * 404: Conversation not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{id: int, title: ?string, model: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function duplicate(int $id): JSONResponse {
         try {
-            $original = $this->conversationMapper->findByIdAndUser($id, $this->userId);
+            $original = $this->conversationMapper->findByIdAndUser($id, $this->requireUserId());
         } catch (DoesNotExistException $e) {
             return new JSONResponse(['error' => 'Conversation not found'], 404);
         }
@@ -723,7 +725,7 @@ class ConversationController extends Controller {
 
         // Clone conversation
         $newConv = new Conversation();
-        $newConv->setUserId($this->userId);
+        $newConv->setUserId($this->requireUserId());
         $newConv->setTitle(($original->getTitle() ?? '') . ' (copy)');
         $newConv->setModel($original->getModel());
         $newConv->setProjectId($original->getProjectId());
@@ -783,12 +785,12 @@ class ConversationController extends Controller {
             return new JSONResponse([]);
         }
 
-        $messages = $this->messageMapper->search($this->userId, $query, $limit, $cursor);
+        $messages = $this->messageMapper->search($this->requireUserId(), $query, $limit, $cursor);
         $result = [];
         foreach ($messages as $msg) {
             $data = $msg->jsonSerialize();
             try {
-                $conv = $this->conversationMapper->findByIdAndUser($msg->getConversationId(), $this->userId);
+                $conv = $this->conversationMapper->findByIdAndUser($msg->getConversationId(), $this->requireUserId());
                 $data['conversationTitle'] = $conv->getTitle();
             } catch (DoesNotExistException $e) {
                 $data['conversationTitle'] = null;
@@ -824,7 +826,7 @@ class ConversationController extends Controller {
         $documents = [];
         foreach ($files as $filePath) {
             try {
-                $fileData = $this->fileService->getContent($filePath, $this->userId);
+                $fileData = $this->fileService->getContent($filePath, $this->requireUserId());
                 $mimeType = $fileData['mimeType'];
 
                 if (str_starts_with($mimeType, 'image/') && $this->imageOptimizer->isSupported($mimeType)) {

--- a/nextcloud-app/lib/Controller/CoworkerController.php
+++ b/nextcloud-app/lib/Controller/CoworkerController.php
@@ -26,6 +26,8 @@ use OCP\IRequest;
  * NoCSRFRequired alongside NoAdminRequired.
  */
 class CoworkerController extends Controller {
+    use RequiresUserIdTrait;
+
 
     public function __construct(
         string $appName,
@@ -61,8 +63,7 @@ class CoworkerController extends Controller {
      * 200: The coworker
      * 404: Coworker not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -82,8 +83,7 @@ class CoworkerController extends Controller {
      * 200: The created coworker
      * 400: Invalid coworker configuration
      *
-     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -106,9 +106,7 @@ class CoworkerController extends Controller {
      * 400: Invalid coworker configuration
      * 404: Coworker not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -132,8 +130,7 @@ class CoworkerController extends Controller {
      * 200: Coworker deleted
      * 404: Coworker not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{deleted: bool}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{deleted: bool}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -155,8 +152,7 @@ class CoworkerController extends Controller {
      * 200: The updated coworker
      * 404: Coworker not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -173,8 +169,7 @@ class CoworkerController extends Controller {
      * 200: The updated coworker
      * 404: Coworker not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -191,8 +186,7 @@ class CoworkerController extends Controller {
      * 200: The updated coworker
      * 404: Coworker not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -209,8 +203,7 @@ class CoworkerController extends Controller {
      * 200: The updated coworker
      * 404: Coworker not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -227,8 +220,7 @@ class CoworkerController extends Controller {
      * 200: The completed run
      * 404: Coworker not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -251,8 +243,7 @@ class CoworkerController extends Controller {
      * 200: List of runs, newest first
      * 404: Coworker not found
      *
-     * @return JSONResponse<Http::STATUS_OK, list<array<string, mixed>>, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, list<array<string, mixed>>, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -292,9 +283,7 @@ class CoworkerController extends Controller {
      * 400: Invalid coworker configuration
      * 404: Unknown template
      *
-     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -345,8 +334,7 @@ class CoworkerController extends Controller {
      * 200: The stored selection
      * 404: Coworker not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{coworkerId: int|null}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{coworkerId: int|null}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -365,6 +353,9 @@ class CoworkerController extends Controller {
         return new JSONResponse(['coworkerId' => $coworkerId]);
     }
 
+    /**
+     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     */
     private function togglePaused(int $id, bool $paused): JSONResponse {
         try {
             $coworker = $this->service->setPaused($id, (string)$this->userId, $paused);
@@ -374,6 +365,9 @@ class CoworkerController extends Controller {
         return new JSONResponse($coworker->jsonSerialize());
     }
 
+    /**
+     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     */
     private function toggleActive(int $id, bool $active): JSONResponse {
         try {
             $coworker = $this->service->setActive($id, (string)$this->userId, $active);

--- a/nextcloud-app/lib/Controller/FileController.php
+++ b/nextcloud-app/lib/Controller/FileController.php
@@ -5,6 +5,7 @@ namespace OCA\AIquila\Controller;
 
 use OCA\AIquila\Service\FileService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
@@ -15,6 +16,8 @@ use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
 class FileController extends Controller {
+    use RequiresUserIdTrait;
+
     private FileService $fileService;
     private ?string $userId;
     private LoggerInterface $logger;
@@ -40,10 +43,9 @@ class FileController extends Controller {
      * 200: File or directory metadata
      * 400: No path provided
      * 404: File or directory not found at the given path
+     * 500: Reading the file metadata failed
      *
-     * @return JSONResponse<Http::STATUS_OK, array{name: string, path: string, size: int, mimeType: string, mtime: int, etag: string, permissions: int}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{name: string, path: string, size: int, mimeType: string, mtime: int, etag: string, permissions: int}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -56,7 +58,7 @@ class FileController extends Controller {
             return new JSONResponse(['error' => 'No path provided'], 400);
         }
         try {
-            return new JSONResponse($this->fileService->getInfo($path, $this->userId));
+            return new JSONResponse($this->fileService->getInfo($path, $this->requireUserId()));
         } catch (NotFoundException $e) {
             return new JSONResponse(['error' => 'File not found: ' . $path], 404);
         } catch (\Exception $e) {
@@ -73,10 +75,9 @@ class FileController extends Controller {
      * 200: Directory listing
      * 400: Path is not a directory or is otherwise invalid
      * 404: Directory not found at the given path
+     * 500: Reading the directory failed
      *
-     * @return JSONResponse<Http::STATUS_OK, array{files: list<array{name: string, path: string, size: int, mimeType: string, mtime: int, type: string}>}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{files: list<array{name: string, path: string, size: int, mimeType: string, mtime: int, type: string}>}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -86,7 +87,7 @@ class FileController extends Controller {
     #[OpenAPI]
     public function listDir(string $path = '/'): JSONResponse {
         try {
-            return new JSONResponse($this->fileService->listDirectory($path, $this->userId));
+            return new JSONResponse($this->fileService->listDirectory($path, $this->requireUserId()));
         } catch (NotFoundException $e) {
             return new JSONResponse(['error' => 'Directory not found: ' . $path], 404);
         } catch (\InvalidArgumentException $e) {
@@ -105,10 +106,10 @@ class FileController extends Controller {
      * 200: File content with encoding and MIME type
      * 400: No path provided or path refers to a directory
      * 404: File not found at the given path
+     * 413: File exceeds the size limit
+     * 500: Reading the file failed
      *
-     * @return JSONResponse<Http::STATUS_OK, array{content: string, mimeType: string, name: string, size: int, encoding: string}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{content: string, mimeType: string, name: string, size: int, encoding: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -121,7 +122,7 @@ class FileController extends Controller {
             return new JSONResponse(['error' => 'No path provided'], 400);
         }
         try {
-            return new JSONResponse($this->fileService->getContent($path, $this->userId));
+            return new JSONResponse($this->fileService->getContent($path, $this->requireUserId()));
         } catch (NotFoundException $e) {
             return new JSONResponse(['error' => 'File not found: ' . $path], 404);
         } catch (\InvalidArgumentException $e) {
@@ -149,7 +150,7 @@ class FileController extends Controller {
             return new DataDownloadResponse('', 'error.txt', 'text/plain');
         }
         try {
-            $file = $this->fileService->getFile($path, $this->userId);
+            $file = $this->fileService->getFile($path, $this->requireUserId());
             return new DataDownloadResponse($file->getContent(), $file->getName(), $file->getMimetype());
         } catch (NotFoundException $e) {
             return new DataDownloadResponse('File not found', 'error.txt', 'text/plain');
@@ -169,10 +170,9 @@ class FileController extends Controller {
      * 200: Search results
      * 400: No search query provided or query is invalid
      * 404: Base path not found
+     * 500: The search failed
      *
-     * @return JSONResponse<Http::STATUS_OK, array{results: list<array{name: string, path: string, mimeType: string, size: int}>}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{results: list<array{name: string, path: string, mimeType: string, size: int}>}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -185,7 +185,7 @@ class FileController extends Controller {
             return new JSONResponse(['error' => 'No search query provided'], 400);
         }
         try {
-            return new JSONResponse($this->fileService->search($query, $this->userId, $mime, $path));
+            return new JSONResponse($this->fileService->search($query, $this->requireUserId(), $mime, $path));
         } catch (NotFoundException $e) {
             return new JSONResponse(['error' => 'Base path not found: ' . $path], 404);
         } catch (\InvalidArgumentException $e) {
@@ -206,10 +206,9 @@ class FileController extends Controller {
      * 200: Base64-encoded preview image with MIME type
      * 400: No path provided or preview cannot be generated
      * 404: File not found at the given path
+     * 500: Generating the preview failed
      *
-     * @return JSONResponse<Http::STATUS_OK, array{preview: string, mimeType: string}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{preview: string, mimeType: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -224,7 +223,7 @@ class FileController extends Controller {
         $width = max(16, min($width, 1024));
         $height = max(16, min($height, 1024));
         try {
-            return new JSONResponse($this->fileService->getPreview($path, $this->userId, $width, $height));
+            return new JSONResponse($this->fileService->getPreview($path, $this->requireUserId(), $width, $height));
         } catch (NotFoundException $e) {
             return new JSONResponse(['error' => 'File not found: ' . $path], 404);
         } catch (\RuntimeException $e) {
@@ -245,10 +244,11 @@ class FileController extends Controller {
      * 200: Archive created
      * 400: No sources provided or a path is invalid
      * 404: A source path was not found
+     * 409: Destination already exists and overwrite was not requested
+     * 413: Archive exceeds the maximum size
+     * 500: Creating the archive failed
      *
-     * @return JSONResponse<Http::STATUS_OK, array{archive: string, entries: int, size: int}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{archive: string, entries: int, size: int}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_CONFLICT, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -264,7 +264,7 @@ class FileController extends Controller {
             return new JSONResponse(['error' => 'No destination provided'], 400);
         }
         try {
-            return new JSONResponse($this->fileService->compress($sources, $destination, $this->userId, $overwrite));
+            return new JSONResponse($this->fileService->compress($sources, $destination, $this->requireUserId(), $overwrite));
         } catch (NotFoundException $e) {
             return new JSONResponse(['error' => $e->getMessage()], 404);
         } catch (\InvalidArgumentException $e) {
@@ -289,10 +289,11 @@ class FileController extends Controller {
      * 200: Archive extracted
      * 400: Invalid path or unsafe archive entry
      * 404: Archive not found
+     * 409: An entry already exists and overwrite was not requested
+     * 413: Archive exceeds the maximum size
+     * 500: Extracting the archive failed
      *
-     * @return JSONResponse<Http::STATUS_OK, array{destination: string, extracted: int}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{destination: string, extracted: int}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_CONFLICT, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -308,7 +309,7 @@ class FileController extends Controller {
             return new JSONResponse(['error' => 'No destination provided'], 400);
         }
         try {
-            return new JSONResponse($this->fileService->extract($archive, $destination, $this->userId, $overwrite));
+            return new JSONResponse($this->fileService->extract($archive, $destination, $this->requireUserId(), $overwrite));
         } catch (NotFoundException $e) {
             return new JSONResponse(['error' => 'Archive not found: ' . $archive], 404);
         } catch (\InvalidArgumentException $e) {
@@ -331,10 +332,9 @@ class FileController extends Controller {
      * 200: Archive entries
      * 400: No path provided or path is not a file
      * 404: Archive not found
+     * 500: Reading the archive failed
      *
-     * @return JSONResponse<Http::STATUS_OK, array{archive: string, count: int, entries: list<array{name: string, size: int, compressedSize: int, isDirectory: bool}>}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{archive: string, count: int, entries: list<array{name: string, size: int, compressedSize: int, isDirectory: bool}>}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -347,7 +347,7 @@ class FileController extends Controller {
             return new JSONResponse(['error' => 'No archive path provided'], 400);
         }
         try {
-            return new JSONResponse($this->fileService->listArchive($archive, $this->userId));
+            return new JSONResponse($this->fileService->listArchive($archive, $this->requireUserId()));
         } catch (NotFoundException $e) {
             return new JSONResponse(['error' => 'Archive not found: ' . $archive], 404);
         } catch (\InvalidArgumentException $e) {

--- a/nextcloud-app/lib/Controller/McpServerController.php
+++ b/nextcloud-app/lib/Controller/McpServerController.php
@@ -10,6 +10,7 @@ use OCA\AIquila\Db\McpServerMapper;
 use OCA\AIquila\Service\CredentialService;
 use OCA\AIquila\Service\McpClientService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\JSONResponse;
@@ -63,8 +64,7 @@ class McpServerController extends Controller {
      * 200: Created MCP server
      * 400: Validation error
      *
-     * @return JSONResponse<Http::STATUS_OK, array{id: int, display_name: string, url: string, auth_type: string, is_enabled: bool}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{id: int, display_name: string, url: string, auth_type: string, is_enabled: bool}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
      */
     #[OpenAPI(scope: OpenAPI::SCOPE_ADMINISTRATION)]
     public function create(
@@ -108,8 +108,7 @@ class McpServerController extends Controller {
      * 200: Updated MCP server
      * 404: Server not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{id: int, display_name: string, url: string, auth_type: string, is_enabled: bool}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{id: int, display_name: string, url: string, auth_type: string, is_enabled: bool}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[OpenAPI(scope: OpenAPI::SCOPE_ADMINISTRATION)]
     public function update(
@@ -167,8 +166,7 @@ class McpServerController extends Controller {
      * 200: Server deleted
      * 404: Server not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{status: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{status: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[OpenAPI(scope: OpenAPI::SCOPE_ADMINISTRATION)]
     public function destroy(int $id): JSONResponse {
@@ -190,8 +188,7 @@ class McpServerController extends Controller {
      * 200: Test result with success status and tool count
      * 404: Server not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{success: bool, message: string, tool_count: int}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{success: bool, message: string, tool_count: int}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[OpenAPI(scope: OpenAPI::SCOPE_ADMINISTRATION)]
     public function test(int $id): JSONResponse {
@@ -212,9 +209,9 @@ class McpServerController extends Controller {
      *
      * 200: List of tools from the server
      * 404: Server not found
+     * 500: Listing the tools failed
      *
-     * @return JSONResponse<Http::STATUS_OK, list<array{name: string, description: string}>, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, list<array{name: string, description: string}>, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
      */
     #[OpenAPI(scope: OpenAPI::SCOPE_ADMINISTRATION)]
     public function tools(int $id): JSONResponse {
@@ -239,9 +236,9 @@ class McpServerController extends Controller {
      *
      * 200: Authorize URL to open in popup
      * 404: Server not found
+     * 500: Starting the authorization flow failed
      *
-     * @return JSONResponse<Http::STATUS_OK, array{authorize_url: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{authorize_url: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
      */
     #[OpenAPI(scope: OpenAPI::SCOPE_ADMINISTRATION)]
     public function authorize(int $id): JSONResponse {
@@ -283,7 +280,7 @@ class McpServerController extends Controller {
             $this->mcpClient->completeOAuth($server, $code, $state, $callbackUrl);
 
             $html = '<!DOCTYPE html><html><body><script>'
-                . 'window.opener.postMessage({type:"aiquila-oauth-complete",serverId:' . (int)$id . '}, window.location.origin);'
+                . 'window.opener.postMessage({type:"aiquila-oauth-complete",serverId:' . $id . '}, window.location.origin);'
                 . 'window.close();'
                 . '</script><p>Authentication successful. This window should close automatically.</p></body></html>';
         } catch (\Throwable $e) {

--- a/nextcloud-app/lib/Controller/OccController.php
+++ b/nextcloud-app/lib/Controller/OccController.php
@@ -4,6 +4,7 @@
 namespace OCA\AIquila\Controller;
 
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\JSONResponse;
@@ -34,11 +35,10 @@ class OccController extends Controller {
      *
      * 200: Command completed; see exitCode for success/failure
      * 400: No command was provided
+     * 408: The command exceeded the requested timeout
+     * 500: The PHP CLI binary could not be located or the process failed to start
      *
-     * @return JSONResponse<Http::STATUS_OK, array{success: bool, stdout: string, stderr: string, exitCode: int}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{success: bool, error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{success: bool, error: string}, array{}>
-     *
+     * @return JSONResponse<Http::STATUS_OK, array{success: bool, stdout: string, stderr: string, exitCode: int}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{success: bool, error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{success: bool, error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_TIMEOUT, array{success: bool, error: string, stdout: string, stderr: string, exitCode: int}, array{}>
      */
     #[NoCSRFRequired]
     #[OpenAPI(scope: OpenAPI::SCOPE_ADMINISTRATION)]
@@ -113,8 +113,8 @@ class OccController extends Controller {
 
         while (true) {
             $status = proc_get_status($process);
-            $stdout .= stream_get_contents($pipes[1]);
-            $stderr .= stream_get_contents($pipes[2]);
+            $stdout .= (string)stream_get_contents($pipes[1]);
+            $stderr .= (string)stream_get_contents($pipes[2]);
 
             if (!$status['running']) {
                 break;
@@ -137,8 +137,8 @@ class OccController extends Controller {
             usleep(50000);
         }
 
-        $stdout .= stream_get_contents($pipes[1]);
-        $stderr .= stream_get_contents($pipes[2]);
+        $stdout .= (string)stream_get_contents($pipes[1]);
+        $stderr .= (string)stream_get_contents($pipes[2]);
         fclose($pipes[1]);
         fclose($pipes[2]);
         $exitCode = proc_close($process);

--- a/nextcloud-app/lib/Controller/PageController.php
+++ b/nextcloud-app/lib/Controller/PageController.php
@@ -17,6 +17,8 @@ use OCP\IRequest;
  * Page Controller for AIquila main interface
  */
 class PageController extends Controller {
+    use RequiresUserIdTrait;
+
 
     private IInitialState $initialState;
     private LLMProviderFactory $providerFactory;
@@ -57,7 +59,7 @@ class PageController extends Controller {
         $this->initialState->provideInitialState('conversations',
             array_map(
                 fn(Conversation $c) => $c->jsonSerialize(),
-                $this->conversationMapper->findAllByUser($this->userId)
+                $this->conversationMapper->findAllByUser($this->requireUserId())
             )
         );
 

--- a/nextcloud-app/lib/Controller/ProjectController.php
+++ b/nextcloud-app/lib/Controller/ProjectController.php
@@ -19,6 +19,8 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
 class ProjectController extends Controller {
+    use RequiresUserIdTrait;
+
     private ProjectMapper $projectMapper;
     private ProjectPathMapper $pathMapper;
     private ConversationMapper $conversationMapper;
@@ -49,7 +51,7 @@ class ProjectController extends Controller {
     #[NoAdminRequired]
     #[OpenAPI]
     public function index(): JSONResponse {
-        $projects = $this->projectMapper->findAllByUser($this->userId);
+        $projects = $this->projectMapper->findAllByUser($this->requireUserId());
         $result = [];
         foreach ($projects as $project) {
             $data = $project->jsonSerialize();
@@ -70,8 +72,9 @@ class ProjectController extends Controller {
      * @param string $systemPrompt System prompt for the project
      *
      * 200: The created project
+     * 400: Title is missing
      *
-     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
@@ -82,7 +85,7 @@ class ProjectController extends Controller {
 
         $now = time();
         $project = new Project();
-        $project->setUserId($this->userId);
+        $project->setUserId($this->requireUserId());
         $project->setTitle(trim($title));
         $project->setDescription($description ?: null);
         $project->setSystemPrompt($systemPrompt ?: null);
@@ -104,14 +107,13 @@ class ProjectController extends Controller {
      * 200: Project with paths
      * 404: Project not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function show(int $id): JSONResponse {
         try {
-            $project = $this->projectMapper->findByIdAndUser($id, $this->userId);
+            $project = $this->projectMapper->findByIdAndUser($id, $this->requireUserId());
         } catch (DoesNotExistException $e) {
             return new JSONResponse(['error' => 'Project not found'], 404);
         }
@@ -135,14 +137,13 @@ class ProjectController extends Controller {
      * 200: Updated project
      * 404: Project not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function update(int $id, string $title = '', string $description = '', string $systemPrompt = ''): JSONResponse {
         try {
-            $project = $this->projectMapper->findByIdAndUser($id, $this->userId);
+            $project = $this->projectMapper->findByIdAndUser($id, $this->requireUserId());
         } catch (DoesNotExistException $e) {
             return new JSONResponse(['error' => 'Project not found'], 404);
         }
@@ -172,20 +173,19 @@ class ProjectController extends Controller {
      * 200: Deletion confirmed
      * 404: Project not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{deleted: true}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{deleted: true}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function destroy(int $id): JSONResponse {
         try {
-            $project = $this->projectMapper->findByIdAndUser($id, $this->userId);
+            $project = $this->projectMapper->findByIdAndUser($id, $this->requireUserId());
         } catch (DoesNotExistException $e) {
             return new JSONResponse(['error' => 'Project not found'], 404);
         }
 
         // Null out project_id on any conversations referencing this project
-        $conversations = $this->conversationMapper->findAllByUser($this->userId);
+        $conversations = $this->conversationMapper->findAllByUser($this->requireUserId());
         foreach ($conversations as $conv) {
             if ($conv->getProjectId() === $id) {
                 $conv->setProjectId(null);
@@ -210,9 +210,7 @@ class ProjectController extends Controller {
      * 400: Invalid path type
      * 404: Project not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array<string, mixed>, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
@@ -226,7 +224,7 @@ class ProjectController extends Controller {
         }
 
         try {
-            $this->projectMapper->findByIdAndUser($id, $this->userId);
+            $this->projectMapper->findByIdAndUser($id, $this->requireUserId());
         } catch (DoesNotExistException $e) {
             return new JSONResponse(['error' => 'Project not found'], 404);
         }
@@ -250,14 +248,13 @@ class ProjectController extends Controller {
      * 200: Deletion confirmed
      * 404: Project or path not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{deleted: true}, array{}>
-     *        |JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{deleted: true}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function removePath(int $id, int $pathId): JSONResponse {
         try {
-            $this->projectMapper->findByIdAndUser($id, $this->userId);
+            $this->projectMapper->findByIdAndUser($id, $this->requireUserId());
         } catch (DoesNotExistException $e) {
             return new JSONResponse(['error' => 'Project not found'], 404);
         }

--- a/nextcloud-app/lib/Controller/RequiresUserIdTrait.php
+++ b/nextcloud-app/lib/Controller/RequiresUserIdTrait.php
@@ -1,0 +1,29 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Controller;
+
+/**
+ * Helper for controllers whose routes all require a login.
+ *
+ * The container injects the user id as `?string` because it has no way to know
+ * that a controller is never reached anonymously. Calls that genuinely need a
+ * user (mappers scoped by owner, file access) would fatal on null, so funnel
+ * them through {@see requireUserId()} instead of passing the property directly.
+ */
+trait RequiresUserIdTrait {
+
+    /**
+     * @throws \RuntimeException if there is no user session, which the route
+     *                           attributes already rule out
+     */
+    private function requireUserId(): string {
+        if ($this->userId === null) {
+            throw new \RuntimeException('This route requires a logged-in user');
+        }
+
+        return $this->userId;
+    }
+}

--- a/nextcloud-app/lib/Controller/SettingsController.php
+++ b/nextcloud-app/lib/Controller/SettingsController.php
@@ -10,6 +10,7 @@ use OCA\AIquila\Service\MistralModels;
 use OCA\AIquila\Service\NativeMcpService;
 use OCA\AIquila\Service\Provider\LLMProviderFactory;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\JSONResponse;
@@ -17,6 +18,8 @@ use OCP\IRequest;
 use OCP\IConfig;
 
 class SettingsController extends Controller {
+    use RequiresUserIdTrait;
+
     private IConfig $config;
     private ?string $userId;
     private LLMProviderFactory $providerFactory;
@@ -45,7 +48,11 @@ class SettingsController extends Controller {
         return $providerId === 'anthropic' ? 'user_model' : 'user_model_' . $providerId;
     }
 
-    /** Static fallback model list for a provider id. */
+    /**
+     * Static fallback model list for a provider id.
+     *
+     * @return list<string>
+     */
     private function staticModels(string $providerId): array {
         return match ($providerId) {
             'mistral' => MistralModels::getAllModels(),
@@ -59,7 +66,7 @@ class SettingsController extends Controller {
      *
      * 200: User settings and available models
      *
-     * @return JSONResponse<Http::STATUS_OK, array{hasUserKey: bool, userModel: string, availableModels: list<array{id: string, name: string}>}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{provider: string, userProvider: string, providers: list<array{id: string, label: string, configured: bool, hasUserKey: bool, userModel: string, availableModels: list<string>}>, hasUserKey: bool, userModel: string, availableModels: list<string>, defaultSystemPrompt: string, defaultVerbose: bool, nativeMcpUserOverride: string, nativeMcpAdminDefault: bool, nativeMcpEffective: bool}, array{}>
      *
      * @NoAdminRequired
      */
@@ -142,9 +149,9 @@ class SettingsController extends Controller {
         // Provider override: '' clears (inherit admin default), non-empty sets it.
         if ($provider !== null) {
             if ($provider === '') {
-                $this->config->deleteUserValue($this->userId, $this->appName, 'user_provider');
+                $this->config->deleteUserValue($this->requireUserId(), $this->appName, 'user_provider');
             } else {
-                $this->config->setUserValue($this->userId, $this->appName, 'user_provider', $provider);
+                $this->config->setUserValue($this->requireUserId(), $this->appName, 'user_provider', $provider);
             }
         }
 
@@ -166,29 +173,29 @@ class SettingsController extends Controller {
 
         $modelKey = $this->userModelKey($scopeProvider);
         if ($model !== '') {
-            $this->config->setUserValue($this->userId, $this->appName, $modelKey, $model);
+            $this->config->setUserValue($this->requireUserId(), $this->appName, $modelKey, $model);
         } else {
-            $this->config->deleteUserValue($this->userId, $this->appName, $modelKey);
+            $this->config->deleteUserValue($this->requireUserId(), $this->appName, $modelKey);
         }
 
         if ($default_system_prompt !== null) {
             if ($default_system_prompt !== '') {
-                $this->config->setUserValue($this->userId, $this->appName, 'default_system_prompt', $default_system_prompt);
+                $this->config->setUserValue($this->requireUserId(), $this->appName, 'default_system_prompt', $default_system_prompt);
             } else {
-                $this->config->deleteUserValue($this->userId, $this->appName, 'default_system_prompt');
+                $this->config->deleteUserValue($this->requireUserId(), $this->appName, 'default_system_prompt');
             }
         }
 
         if ($default_verbose !== null) {
-            $this->config->setUserValue($this->userId, $this->appName, 'default_verbose', $default_verbose === '1' ? '1' : '0');
+            $this->config->setUserValue($this->requireUserId(), $this->appName, 'default_verbose', $default_verbose === '1' ? '1' : '0');
         }
 
         if ($native_mcp_enabled !== null) {
             // '' clears the override (inherit admin); '1' / '0' explicitly opt in/out.
             if ($native_mcp_enabled === '') {
-                $this->config->deleteUserValue($this->userId, $this->appName, 'native_mcp_enabled');
+                $this->config->deleteUserValue($this->requireUserId(), $this->appName, 'native_mcp_enabled');
             } else {
-                $this->config->setUserValue($this->userId, $this->appName, 'native_mcp_enabled', $native_mcp_enabled === '1' ? '1' : '0');
+                $this->config->setUserValue($this->requireUserId(), $this->appName, 'native_mcp_enabled', $native_mcp_enabled === '1' ? '1' : '0');
             }
         }
 
@@ -287,9 +294,7 @@ class SettingsController extends Controller {
      * 200: Test request completed; see success field for result
      * 400: No API key available or the test request failed
      *
-     * @return JSONResponse<Http::STATUS_OK, array{success: bool, message: string}, array{}>
-     *        |JSONResponse<Http::STATUS_BAD_REQUEST, array{success: bool, message: string}, array{}>
-     *        |JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{success: bool, message: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{success: bool, message: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{success: bool, message: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{success: bool, message: string}, array{}>
      */
     #[OpenAPI(scope: OpenAPI::SCOPE_ADMINISTRATION)]
     public function testConfig(string $api_key = '', ?string $provider = null): JSONResponse {
@@ -318,7 +323,7 @@ class SettingsController extends Controller {
                 return new JSONResponse(['success' => false, 'message' => $result['error']], 400);
             }
 
-            return new JSONResponse(['success' => true, 'message' => $result['response']]);
+            return new JSONResponse(['success' => true, 'message' => $result['response'] ?? '']);
 
         } catch (\Throwable $e) {
             $this->restoreKey($providerId, $originalApiKey);

--- a/nextcloud-app/lib/Cowork/CronSchedule.php
+++ b/nextcloud-app/lib/Cowork/CronSchedule.php
@@ -86,8 +86,9 @@ class CronSchedule {
             $step = 1;
             $range = $token;
             if (str_contains($token, '/')) {
-                [$range, $stepStr] = explode('/', $token, 2);
-                $step = (int)$stepStr;
+                $parts = explode('/', $token, 2);
+                $range = $parts[0];
+                $step = (int)($parts[1] ?? '');
                 if ($step < 1) {
                     throw new \InvalidArgumentException("Invalid step in cron field: $token");
                 }
@@ -97,9 +98,9 @@ class CronSchedule {
                 $start = $min;
                 $end = $max;
             } elseif (str_contains($range, '-')) {
-                [$a, $b] = explode('-', $range, 2);
-                $start = (int)$a;
-                $end = (int)$b;
+                $bounds = explode('-', $range, 2);
+                $start = (int)$bounds[0];
+                $end = (int)($bounds[1] ?? '');
             } else {
                 $start = $end = (int)$range;
             }

--- a/nextcloud-app/lib/Db/Conversation.php
+++ b/nextcloud-app/lib/Db/Conversation.php
@@ -47,6 +47,9 @@ class Conversation extends Entity implements \JsonSerializable {
         $this->addType('thinking', 'boolean');
     }
 
+    /**
+     * @return array{id: int, userId: string, title: ?string, model: string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}
+     */
     public function jsonSerialize(): array {
         return [
             'id' => $this->getId(),

--- a/nextcloud-app/lib/Db/ConversationMapper.php
+++ b/nextcloud-app/lib/Db/ConversationMapper.php
@@ -49,7 +49,7 @@ class ConversationMapper extends QBMapper {
     /**
      * All conversations across all users, used for full Context Chat re-imports.
      *
-     * @return Conversation[]
+     * @return list<Conversation>
      */
     public function findAll(): array {
         $qb = $this->db->getQueryBuilder();
@@ -60,7 +60,7 @@ class ConversationMapper extends QBMapper {
     }
 
     /**
-     * @return Conversation[]
+     * @return list<Conversation>
      */
     public function findAllByUser(string $userId): array {
         $qb = $this->db->getQueryBuilder();

--- a/nextcloud-app/lib/Db/CoworkerMapper.php
+++ b/nextcloud-app/lib/Db/CoworkerMapper.php
@@ -36,7 +36,7 @@ class CoworkerMapper extends QBMapper {
      * coworkers carry a non-null owner_app and are excluded so they don't show
      * up in the user-facing list.
      *
-     * @return Coworker[]
+     * @return list<Coworker>
      */
     public function findAllByUser(string $userId): array {
         $qb = $this->db->getQueryBuilder();
@@ -68,7 +68,7 @@ class CoworkerMapper extends QBMapper {
     /**
      * List coworkers owned by an app, optionally filtered to a single user.
      *
-     * @return Coworker[]
+     * @return list<Coworker>
      */
     public function findAllByApp(string $appId, ?string $userId = null): array {
         $qb = $this->db->getQueryBuilder();
@@ -88,7 +88,7 @@ class CoworkerMapper extends QBMapper {
      * next_run_at never satisfies the `<= now` comparison, so paused/disabled
      * coworkers (whose next_run_at is cleared) are excluded automatically.
      *
-     * @return Coworker[]
+     * @return list<Coworker>
      */
     public function findDueForRun(int $now): array {
         $qb = $this->db->getQueryBuilder();

--- a/nextcloud-app/lib/Db/CoworkerRunMapper.php
+++ b/nextcloud-app/lib/Db/CoworkerRunMapper.php
@@ -34,7 +34,7 @@ class CoworkerRunMapper extends QBMapper {
     /**
      * Recent runs for a coworker, newest first.
      *
-     * @return CoworkerRun[]
+     * @return list<CoworkerRun>
      */
     public function findByCoworker(int $coworkerId, string $userId, int $limit = 20): array {
         $qb = $this->db->getQueryBuilder();

--- a/nextcloud-app/lib/Db/McpServer.php
+++ b/nextcloud-app/lib/Db/McpServer.php
@@ -85,7 +85,7 @@ class McpServer extends Entity {
     }
 
     public function getIsEnabled(): bool {
-        return (int)$this->isEnabled === 1;
+        return $this->isEnabled === 1;
     }
 
     public function setIsEnabled(bool $isEnabled): void {

--- a/nextcloud-app/lib/Db/McpServerMapper.php
+++ b/nextcloud-app/lib/Db/McpServerMapper.php
@@ -31,7 +31,7 @@ class McpServerMapper extends QBMapper {
     }
 
     /**
-     * @return McpServer[]
+     * @return list<McpServer>
      */
     public function findAll(): array {
         $qb = $this->db->getQueryBuilder();
@@ -43,7 +43,7 @@ class McpServerMapper extends QBMapper {
     }
 
     /**
-     * @return McpServer[]
+     * @return list<McpServer>
      */
     public function findAllEnabled(): array {
         $qb = $this->db->getQueryBuilder();

--- a/nextcloud-app/lib/Db/Message.php
+++ b/nextcloud-app/lib/Db/Message.php
@@ -59,6 +59,9 @@ class Message extends Entity implements \JsonSerializable {
         $this->addType('documents', 'string');
     }
 
+    /**
+     * @return array{id: int, conversationId: int, role: string, content: string, inputTokens: ?int, outputTokens: ?int, cacheCreationTokens: ?int, cacheReadTokens: ?int, latencyMs: ?int, citations: ?array<string, mixed>, documents: ?array<string, mixed>, createdAt: int}
+     */
     public function jsonSerialize(): array {
         $citationsJson = $this->getCitations();
         $citations = null;

--- a/nextcloud-app/lib/Db/MessageFile.php
+++ b/nextcloud-app/lib/Db/MessageFile.php
@@ -35,6 +35,9 @@ class MessageFile extends Entity implements \JsonSerializable {
         $this->addType('createdAt', 'integer');
     }
 
+    /**
+     * @return array{id: int, messageId: int, filePath: string, fileName: string, mimeType: ?string, createdAt: int}
+     */
     public function jsonSerialize(): array {
         return [
             'id' => $this->getId(),

--- a/nextcloud-app/lib/Db/MessageFileMapper.php
+++ b/nextcloud-app/lib/Db/MessageFileMapper.php
@@ -18,7 +18,7 @@ class MessageFileMapper extends QBMapper {
     }
 
     /**
-     * @return MessageFile[]
+     * @return list<MessageFile>
      */
     public function findByMessage(int $messageId): array {
         $qb = $this->db->getQueryBuilder();

--- a/nextcloud-app/lib/Db/MessageMapper.php
+++ b/nextcloud-app/lib/Db/MessageMapper.php
@@ -18,7 +18,7 @@ class MessageMapper extends QBMapper {
     }
 
     /**
-     * @return Message[]
+     * @return list<Message>
      */
     public function findByConversation(int $conversationId): array {
         $qb = $this->db->getQueryBuilder();
@@ -31,7 +31,7 @@ class MessageMapper extends QBMapper {
     }
 
     /**
-     * @return Message[]
+     * @return list<Message>
      */
     public function search(string $userId, string $query, int $limit, int $cursor): array {
         $qb = $this->db->getQueryBuilder();

--- a/nextcloud-app/lib/Db/ProjectMapper.php
+++ b/nextcloud-app/lib/Db/ProjectMapper.php
@@ -32,7 +32,7 @@ class ProjectMapper extends QBMapper {
     }
 
     /**
-     * @return Project[]
+     * @return list<Project>
      */
     public function findAllByUser(string $userId, bool $activeOnly = false): array {
         $qb = $this->db->getQueryBuilder();

--- a/nextcloud-app/lib/Db/ProjectPathMapper.php
+++ b/nextcloud-app/lib/Db/ProjectPathMapper.php
@@ -18,7 +18,7 @@ class ProjectPathMapper extends QBMapper {
     }
 
     /**
-     * @return ProjectPath[]
+     * @return list<ProjectPath>
      */
     public function findByProject(int $projectId): array {
         $qb = $this->db->getQueryBuilder();

--- a/nextcloud-app/lib/Db/PromptMapper.php
+++ b/nextcloud-app/lib/Db/PromptMapper.php
@@ -32,7 +32,7 @@ class PromptMapper extends QBMapper {
     }
 
     /**
-     * @return Prompt[]
+     * @return list<Prompt>
      */
     public function findAllByUser(string $userId, bool $activeOnly = false): array {
         $qb = $this->db->getQueryBuilder();

--- a/nextcloud-app/lib/Db/UsageStatMapper.php
+++ b/nextcloud-app/lib/Db/UsageStatMapper.php
@@ -18,7 +18,7 @@ class UsageStatMapper extends QBMapper {
     }
 
     /**
-     * @return UsageStat[]
+     * @return list<UsageStat>
      */
     public function findByUser(string $userId, int $limit = 100, int $offset = 0): array {
         $qb = $this->db->getQueryBuilder();
@@ -37,12 +37,10 @@ class UsageStatMapper extends QBMapper {
      */
     public function sumTokensByUser(string $userId): array {
         $qb = $this->db->getQueryBuilder();
-        $qb->select(
-            $qb->func()->sum('input_tokens', 'total_input'),
-            $qb->func()->sum('output_tokens', 'total_output'),
-            $qb->func()->sum('cache_creation_tokens', 'total_cache_creation'),
-            $qb->func()->sum('cache_read_tokens', 'total_cache_read')
-        )
+        $qb->selectAlias($qb->func()->sum('input_tokens'), 'total_input')
+            ->selectAlias($qb->func()->sum('output_tokens'), 'total_output')
+            ->selectAlias($qb->func()->sum('cache_creation_tokens'), 'total_cache_creation')
+            ->selectAlias($qb->func()->sum('cache_read_tokens'), 'total_cache_read')
             ->from($this->getTableName())
             ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)));
 
@@ -65,10 +63,8 @@ class UsageStatMapper extends QBMapper {
      */
     public function sumTokensByUserSince(string $userId, int $since): array {
         $qb = $this->db->getQueryBuilder();
-        $qb->select(
-            $qb->func()->sum('input_tokens', 'total_input'),
-            $qb->func()->sum('output_tokens', 'total_output')
-        )
+        $qb->selectAlias($qb->func()->sum('input_tokens'), 'total_input')
+            ->selectAlias($qb->func()->sum('output_tokens'), 'total_output')
             ->from($this->getTableName())
             ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)))
             ->andWhere($qb->expr()->gte('created_at', $qb->createNamedParameter($since, IQueryBuilder::PARAM_INT)));

--- a/nextcloud-app/lib/Http/SSEResponse.php
+++ b/nextcloud-app/lib/Http/SSEResponse.php
@@ -20,6 +20,9 @@ use OCP\AppFramework\Http\Response;
  *     not target text/event-stream responses.
  *   - PHP-FPM: `fastcgi_buffering off` may be needed at the proxy.
  */
+/**
+ * @template-extends Response<Http::STATUS_OK, array<string, mixed>>
+ */
 class SSEResponse extends Response {
     /** @param iterable<array<string, mixed>> $events */
     public function __construct(

--- a/nextcloud-app/lib/Migration/Version0001Date20260218000000.php
+++ b/nextcloud-app/lib/Migration/Version0001Date20260218000000.php
@@ -13,7 +13,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 class Version0001Date20260218000000 extends SimpleMigrationStep {
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-        /** @var ISchemaWrapper $schema */
         $schema = $schemaClosure();
 
         $this->createConversationsTable($schema);

--- a/nextcloud-app/lib/Migration/Version0002Date20260315000000.php
+++ b/nextcloud-app/lib/Migration/Version0002Date20260315000000.php
@@ -13,7 +13,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 class Version0002Date20260315000000 extends SimpleMigrationStep {
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-        /** @var ISchemaWrapper $schema */
         $schema = $schemaClosure();
 
         $this->createMcpServersTable($schema);

--- a/nextcloud-app/lib/Migration/Version0002Date20260612000000.php
+++ b/nextcloud-app/lib/Migration/Version0002Date20260612000000.php
@@ -17,7 +17,6 @@ use OCP\Migration\SimpleMigrationStep;
  */
 class Version0002Date20260612000000 extends SimpleMigrationStep {
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-        /** @var ISchemaWrapper $schema */
         $schema = $schemaClosure();
 
         $this->extendCoworkersTable($schema);

--- a/nextcloud-app/lib/Migration/Version0003Date20260320000000.php
+++ b/nextcloud-app/lib/Migration/Version0003Date20260320000000.php
@@ -13,7 +13,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 class Version0003Date20260320000000 extends SimpleMigrationStep {
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-        /** @var ISchemaWrapper $schema */
         $schema = $schemaClosure();
 
         $changed = false;

--- a/nextcloud-app/lib/Migration/Version0003Date20260612120000.php
+++ b/nextcloud-app/lib/Migration/Version0003Date20260612120000.php
@@ -19,7 +19,6 @@ use OCP\Migration\SimpleMigrationStep;
  */
 class Version0003Date20260612120000 extends SimpleMigrationStep {
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-        /** @var ISchemaWrapper $schema */
         $schema = $schemaClosure();
 
         if (!$schema->hasTable('aiquila_coworkers')) {

--- a/nextcloud-app/lib/Migration/Version0004Date20260331000000.php
+++ b/nextcloud-app/lib/Migration/Version0004Date20260331000000.php
@@ -13,7 +13,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 class Version0004Date20260331000000 extends SimpleMigrationStep {
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-        /** @var ISchemaWrapper $schema */
         $schema = $schemaClosure();
 
         $changed = false;

--- a/nextcloud-app/lib/Migration/Version0005Date20260506000000.php
+++ b/nextcloud-app/lib/Migration/Version0005Date20260506000000.php
@@ -13,7 +13,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 class Version0005Date20260506000000 extends SimpleMigrationStep {
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-        /** @var ISchemaWrapper $schema */
         $schema = $schemaClosure();
 
         if (!$schema->hasTable('aiquila_messages')) {

--- a/nextcloud-app/lib/Migration/Version0006Date20260506100000.php
+++ b/nextcloud-app/lib/Migration/Version0006Date20260506100000.php
@@ -13,7 +13,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 class Version0006Date20260506100000 extends SimpleMigrationStep {
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-        /** @var ISchemaWrapper $schema */
         $schema = $schemaClosure();
 
         if ($schema->hasTable('aiquila_file_uploads')) {

--- a/nextcloud-app/lib/Migration/Version0007Date20260508000000.php
+++ b/nextcloud-app/lib/Migration/Version0007Date20260508000000.php
@@ -13,7 +13,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 class Version0007Date20260508000000 extends SimpleMigrationStep {
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-        /** @var ISchemaWrapper $schema */
         $schema = $schemaClosure();
 
         if (!$schema->hasTable('aiquila_messages')) {

--- a/nextcloud-app/lib/Migration/Version0008Date20260610000000.php
+++ b/nextcloud-app/lib/Migration/Version0008Date20260610000000.php
@@ -13,7 +13,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 class Version0008Date20260610000000 extends SimpleMigrationStep {
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-        /** @var ISchemaWrapper $schema */
         $schema = $schemaClosure();
 
         if (!$schema->hasTable('aiquila_conversations')) {

--- a/nextcloud-app/lib/Search/AiquilaSearchProvider.php
+++ b/nextcloud-app/lib/Search/AiquilaSearchProvider.php
@@ -73,7 +73,9 @@ class AiquilaSearchProvider implements IProvider {
         $lastCursor = null;
         if (count($messages) >= $limit) {
             $lastMessage = end($messages);
-            $lastCursor = (string)$lastMessage->getId();
+            if ($lastMessage !== false) {
+                $lastCursor = (string)$lastMessage->getId();
+            }
         }
 
         return $lastCursor !== null

--- a/nextcloud-app/lib/Service/AIquilaService.php
+++ b/nextcloud-app/lib/Service/AIquilaService.php
@@ -5,7 +5,6 @@ namespace OCA\AIquila\Service;
 
 use OCA\AIquila\Public\IAIquila;
 use OCP\Files\NotFoundException;
-use OCP\IConfig;
 use OCP\Notification\IManager as INotificationManager;
 use Psr\Log\LoggerInterface;
 
@@ -19,7 +18,6 @@ class AIquilaService implements IAIquila {
     private ClaudeSDKService $claudeSDKService;
     private FileService $fileService;
     private ImageOptimizer $imageOptimizer;
-    private IConfig $config;
     private INotificationManager $notificationManager;
     private LoggerInterface $logger;
     private string $appName = 'aiquila';
@@ -28,14 +26,12 @@ class AIquilaService implements IAIquila {
         ClaudeSDKService $claudeSDKService,
         FileService $fileService,
         ImageOptimizer $imageOptimizer,
-        IConfig $config,
         INotificationManager $notificationManager,
         LoggerInterface $logger
     ) {
         $this->claudeSDKService = $claudeSDKService;
         $this->fileService = $fileService;
         $this->imageOptimizer = $imageOptimizer;
-        $this->config = $config;
         $this->notificationManager = $notificationManager;
         $this->logger = $logger;
     }
@@ -106,6 +102,10 @@ class AIquilaService implements IAIquila {
             'file' => $filePath,
         ]);
 
+        if ($userId === null) {
+            return ['error' => 'A user id is required to read files'];
+        }
+
         try {
             $fileData = $this->fileService->getContent($filePath, $userId);
             $mimeType = $fileData['mimeType'];
@@ -149,6 +149,10 @@ class AIquilaService implements IAIquila {
             'user' => $userId,
             'file_count' => count($filePaths),
         ]);
+
+        if ($userId === null) {
+            return ['error' => 'A user id is required to read files'];
+        }
 
         try {
             $images = [];

--- a/nextcloud-app/lib/Service/ClaudeModels.php
+++ b/nextcloud-app/lib/Service/ClaudeModels.php
@@ -150,6 +150,8 @@ class ClaudeModels {
      * Ordered model list for the admin UI datalist (most capable first).
      * SONNET_4 / OPUS_4 are intentionally omitted — Anthropic deprecated them
      * and the SDK removed them from its typed Model enum in 0.15.0.
+     *
+     * @return list<string>
      */
     public static function getAllModels(): array {
         return [
@@ -204,7 +206,7 @@ class ClaudeModels {
     /**
      * Effort values the API accepts for a model; empty if effort is unsupported.
      *
-     * @return string[]
+     * @return list<string>
      */
     public static function getAllowedEfforts(string $model): array {
         return self::ALLOWED_EFFORTS[$model] ?? [];

--- a/nextcloud-app/lib/Service/ClaudeSDKService.php
+++ b/nextcloud-app/lib/Service/ClaudeSDKService.php
@@ -456,6 +456,10 @@ class ClaudeSDKService implements LLMProviderInterface {
             $base?->usage->serviceTier ?? null,
         );
 
+        // The accumulated blocks are the loosely-typed stdClass shapes the stream
+        // hands us; Message::with() stores them as-is and every reader in this
+        // class goes through the same property access.
+        /** @psalm-suppress InvalidArgument */
         return Message::with(
             $base?->id ?? '',
             null,
@@ -591,7 +595,7 @@ class ClaudeSDKService implements LLMProviderInterface {
             }
             foreach ($citations as $c) {
                 // SDK exposes citation entries as objects; normalise to array.
-                $out[] = is_object($c) ? json_decode(json_encode($c), true) : $c;
+                $out[] = is_object($c) ? json_decode((string)json_encode($c), true) : $c;
             }
         }
         return $out;
@@ -687,7 +691,7 @@ class ClaudeSDKService implements LLMProviderInterface {
      * @param string $context Optional context
      * @param string|null $userId User ID for user-specific API key
      * @param array $options Optional: system, temperature, top_p, top_k, stop_sequences, cache_system
-     * @return array ['response' => string] or ['error' => string]
+     * @return array{response: string, usage?: array, citations?: array}|array{error: string}
      */
     public function ask(
         string  $prompt,
@@ -745,7 +749,7 @@ class ClaudeSDKService implements LLMProviderInterface {
      * @param string|null $system Optional system prompt
      * @param string|null $userId User ID for API key resolution
      * @param array $options Optional: temperature, top_p, top_k, stop_sequences, cache_system
-     * @return array ['response' => string, 'usage' => [...]] or ['error' => string]
+     * @return array{response: string, usage?: array, citations?: array}|array{error: string}
      */
     public function chat(
         array   $messages,
@@ -801,7 +805,7 @@ class ClaudeSDKService implements LLMProviderInterface {
      * @param string|null $userId User ID for API key resolution
      * @param array $options Optional: temperature, top_p, etc.
      * @param int $maxIterations Safety cap on tool-use loop iterations
-     * @return array ['response' => string, 'usage' => [...]] or ['error' => string]
+     * @return array{response: string, usage?: array, citations?: array}|array{error: string}
      */
     public function chatWithTools(
         array    $messages,
@@ -947,7 +951,7 @@ class ClaudeSDKService implements LLMProviderInterface {
      *
      * @param string $content Content to summarize
      * @param string|null $userId User ID for user-specific API key
-     * @return array ['response' => string] or ['error' => string]
+     * @return array{response: string, usage?: array, citations?: array}|array{error: string}
      */
     public function summarize(string $content, ?string $userId = null): array {
         return $this->ask("Summarize the following content concisely:\n\n$content", '', $userId);
@@ -1055,7 +1059,7 @@ class ClaudeSDKService implements LLMProviderInterface {
                 return $batch;
             }
             if ($reportProgress !== null) {
-                $progress = min(0.9, 0.1 + ($i / $maxAttempts) * 0.8);
+                $progress = min(0.9, 0.1 + ((float)$i / (float)$maxAttempts) * 0.8);
                 $reportProgress($progress);
             }
             $this->sleepBetweenBatchPolls();
@@ -1132,7 +1136,7 @@ class ClaudeSDKService implements LLMProviderInterface {
      * @param bool $cacheDoc Add cache_control to the document block (default true — documents are large and benefit from cache reuse)
      * @param bool $citations Enable citations on the document block (default true). Cited text spans are returned alongside the response.
      * @param string|null $fileId Optional Anthropic Files API file_id. When provided, the document source is `{type:'file', file_id}` instead of inline base64/text.
-     * @return array ['response' => string, 'usage' => [...], 'citations' => [...]] or ['error' => string]
+     * @return array{response: string, usage?: array, citations?: array}|array{error: string}
      */
     public function askWithDocument(
         string  $prompt,
@@ -1275,7 +1279,7 @@ class ClaudeSDKService implements LLMProviderInterface {
     /**
      * Get current configuration for display/testing
      *
-     * @return array Configuration array
+     * @return array{api_key: string, model: string, max_tokens: int, timeout: int}
      */
     public function getConfiguration(): array {
         return [
@@ -1294,7 +1298,7 @@ class ClaudeSDKService implements LLMProviderInterface {
      * @param string $mimeType Image mime type (image/jpeg, image/png, image/gif, image/webp)
      * @param string|null $userId User ID for API key
      * @param string|null $fileId Optional Anthropic Files API file_id. When provided, the image source is `{type:'file', file_id}` instead of inline base64.
-     * @return array ['response' => string] or ['error' => string]
+     * @return array{response: string, usage?: array, citations?: array}|array{error: string}
      */
     public function askWithImage(string $prompt, string $base64Image, string $mimeType, ?string $userId = null, ?string $fileId = null): array {
         try {
@@ -1345,10 +1349,10 @@ class ClaudeSDKService implements LLMProviderInterface {
      * the text prompt, per Claude best practice (images before text).
      *
      * @param string $prompt What to ask about the images
-     * @param array<array{base64: string, mimeType: string}> $images Image data array
+     * @param array<array{base64: string, mimeType: string, ...}> $images Image data array
      * @param string|null $userId User ID for API key
      * @param array<int, string|null>|null $fileIds Optional per-image Anthropic Files API file_ids, indexed parallel to $images. A non-null entry triggers a `{type:'file', file_id}` source for that image; null entries fall back to inline base64.
-     * @return array ['response' => string, 'usage' => array] or ['error' => string]
+     * @return array{response: string, usage?: array, citations?: array}|array{error: string}
      */
     public function askWithImages(string $prompt, array $images, ?string $userId = null, ?array $fileIds = null): array {
         if (empty($images)) {
@@ -1588,7 +1592,7 @@ class ClaudeSDKService implements LLMProviderInterface {
                             } elseif ($deltaType === 'citations_delta') {
                                 $citation = $delta->citation ?? null;
                                 if ($citation !== null) {
-                                    $normalized = is_object($citation) ? json_decode(json_encode($citation), true) : $citation;
+                                    $normalized = is_object($citation) ? json_decode((string)json_encode($citation), true) : $citation;
                                     if (isset($blocks[$idx])) {
                                         $blocks[$idx]['citations'][] = $normalized;
                                     }
@@ -1731,6 +1735,13 @@ class ClaudeSDKService implements LLMProviderInterface {
      * Dispatch a beta streaming create call with mcp_servers attached. Overridable for testing.
      *
      * @param list<array<string, mixed>> $mcpServers
+     */
+    /**
+     * @param list<array<string, mixed>> $mcpServers Server descriptors per BetaRequestMCPServerURLDefinition
+     *
+     * @psalm-suppress ArgumentTypeCoercion the descriptors are built to the SDK's
+     *                 BetaRequestMCPServerURLDefinition shape, which psalm cannot
+     *                 verify through the generic array docblock
      */
     protected function callBetaCreateStreamWithMcp(Client $client, array $params, array $mcpServers): BaseStream {
         return $client->beta->messages->createStream(
@@ -1875,7 +1886,7 @@ class ClaudeSDKService implements LLMProviderInterface {
                         } elseif ($deltaType === 'citations_delta') {
                             $citation = $delta->citation ?? null;
                             if ($citation !== null) {
-                                $normalized = is_object($citation) ? json_decode(json_encode($citation), true) : $citation;
+                                $normalized = is_object($citation) ? json_decode((string)json_encode($citation), true) : $citation;
                                 if (isset($blocks[$idx])) {
                                     $blocks[$idx]['citations'][] = $normalized;
                                 }
@@ -1962,7 +1973,7 @@ class ClaudeSDKService implements LLMProviderInterface {
                     }
                 }
             }
-            return $out !== '' ? $out : json_encode($content);
+            return $out !== '' ? $out : (string)json_encode($content);
         }
         if (is_object($content)) {
             return json_encode($content) ?: '';
@@ -1974,6 +1985,8 @@ class ClaudeSDKService implements LLMProviderInterface {
      * Non-streaming convenience: drive chatWithNativeMcp() to completion and
      * return a flat result array compatible with the legacy chat()/chatWithTools()
      * shape (response/model/usage/citations).
+     *
+     * @param list<array<string, mixed>> $mcpServers
      */
     public function chatWithNativeMcpCollect(
         array $messages,

--- a/nextcloud-app/lib/Service/CoworkerService.php
+++ b/nextcloud-app/lib/Service/CoworkerService.php
@@ -62,7 +62,6 @@ class CoworkerService {
     }
 
     /**
-     * @param array<string, mixed> $data
      * @throws DoesNotExistException
      */
     public function findForUser(int $id, string $userId): Coworker {
@@ -70,7 +69,7 @@ class CoworkerService {
     }
 
     /**
-     * @return Coworker[]
+     * @return list<Coworker>
      */
     public function listForUser(string $userId): array {
         return $this->mapper->findAllByUser($userId);
@@ -127,7 +126,7 @@ class CoworkerService {
     }
 
     /**
-     * @return CoworkerRun[]
+     * @return list<CoworkerRun>
      * @throws DoesNotExistException
      */
     public function listRuns(int $id, string $userId, int $limit = 20): array {
@@ -308,7 +307,7 @@ class CoworkerService {
             if ($this->registry->has($taskTypeId)) {
                 $this->registry->get($taskTypeId)->validateOptions($options);
             }
-            $coworker->setOptions(json_encode($options));
+            $coworker->setOptions(json_encode($options) ?: null);
         }
 
         // Sensible defaults for required columns on first create.

--- a/nextcloud-app/lib/Service/FileService.php
+++ b/nextcloud-app/lib/Service/FileService.php
@@ -9,7 +9,6 @@ use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IPreview;
-use Psr\Log\LoggerInterface;
 
 /**
  * File operations service using Nextcloud's storage APIs.
@@ -20,7 +19,6 @@ use Psr\Log\LoggerInterface;
 class FileService {
     private IRootFolder $rootFolder;
     private IPreview $previewManager;
-    private LoggerInterface $logger;
 
     private const MAX_READ_SIZE = 20 * 1024 * 1024; // 20MB
 
@@ -45,11 +43,9 @@ class FileService {
     public function __construct(
         IRootFolder $rootFolder,
         IPreview $previewManager,
-        LoggerInterface $logger
     ) {
         $this->rootFolder = $rootFolder;
         $this->previewManager = $previewManager;
-        $this->logger = $logger;
     }
 
     private function getUserFolder(string $userId): Folder {
@@ -60,7 +56,7 @@ class FileService {
         return [
             'name' => $node->getName(),
             'path' => $node->getPath(),
-            'size' => $node->getSize(),
+            'size' => (int)$node->getSize(),
             'mimeType' => $node->getMimetype(),
             'mtime' => $node->getMTime(),
             'etag' => $node->getEtag(),
@@ -135,7 +131,7 @@ class FileService {
 
         if ($node->getSize() > self::MAX_READ_SIZE) {
             throw new \RuntimeException(
-                'File too large: ' . $node->getSize() . ' bytes (max ' . self::MAX_READ_SIZE . ')'
+                'File too large: ' . (string)$node->getSize() . ' bytes (max ' . self::MAX_READ_SIZE . ')'
             );
         }
 
@@ -146,7 +142,7 @@ class FileService {
         return [
             'name' => $node->getName(),
             'mimeType' => $mimeType,
-            'size' => $node->getSize(),
+            'size' => (int)$node->getSize(),
             'encoding' => $isText ? 'text' : 'base64',
             'content' => $isText ? $rawContent : base64_encode($rawContent),
         ];
@@ -295,7 +291,7 @@ class FileService {
             return [
                 'archive' => $dest->getPath(),
                 'entries' => $entryCount,
-                'size' => $dest->getSize(),
+                'size' => (int)$dest->getSize(),
             ];
         } finally {
             @unlink($tmpFile);
@@ -317,7 +313,7 @@ class FileService {
         }
 
         if ($node instanceof File) {
-            $totalSize += $node->getSize();
+            $totalSize += (int)$node->getSize();
             if ($totalSize > self::MAX_ARCHIVE_SIZE) {
                 throw new \RuntimeException(
                     'Archive contents exceed maximum size of ' . self::MAX_ARCHIVE_SIZE . ' bytes'
@@ -414,7 +410,9 @@ class FileService {
             ];
         } finally {
             $zip->close();
-            @unlink($tmpFile);
+            if ($tmpFile !== null) {
+                @unlink($tmpFile);
+            }
         }
     }
 
@@ -458,7 +456,9 @@ class FileService {
             ];
         } finally {
             $zip->close();
-            @unlink($tmpFile);
+            if ($tmpFile !== null) {
+                @unlink($tmpFile);
+            }
         }
     }
 

--- a/nextcloud-app/lib/Service/ImageOptimizer.php
+++ b/nextcloud-app/lib/Service/ImageOptimizer.php
@@ -113,9 +113,9 @@ class ImageOptimizer {
         }
 
         try {
-            $scale = self::MAX_LONG_EDGE / max($width, $height);
-            $newWidth = (int) round($width * $scale);
-            $newHeight = (int) round($height * $scale);
+            $scale = (float)self::MAX_LONG_EDGE / (float)max($width, $height);
+            $newWidth = (int) round((float)$width * $scale);
+            $newHeight = (int) round((float)$height * $scale);
 
             $dst = imagescale($src, $newWidth, $newHeight, IMG_BICUBIC);
             if ($dst === false) {

--- a/nextcloud-app/lib/Service/McpClientService.php
+++ b/nextcloud-app/lib/Service/McpClientService.php
@@ -89,7 +89,7 @@ class McpClientService {
             }
 
             if ($statusCode >= 400) {
-                throw new \RuntimeException("HTTP $statusCode: " . json_encode($result));
+                throw new \RuntimeException("HTTP $statusCode: " . (string)json_encode($result));
             }
 
             if (isset($result['error'])) {
@@ -108,8 +108,6 @@ class McpClientService {
      * Parse an SSE response to extract JSON-RPC result.
      */
     private function parseSseResponse(string $content, int $statusCode, $response): array {
-        $serverId = null;
-
         // Capture session ID from response headers
         $sessionHeaders = $response->getHeaders(false)['mcp-session-id'] ?? [];
 
@@ -334,7 +332,7 @@ class McpClientService {
 
     private function slugify(string $name): string {
         $slug = strtolower(trim($name));
-        $slug = preg_replace('/[^a-z0-9]+/', '_', $slug);
+        $slug = preg_replace('/[^a-z0-9]+/', '_', $slug) ?? '';
         return trim($slug, '_');
     }
 
@@ -348,7 +346,7 @@ class McpClientService {
         $response = $this->httpClient->request('GET', $url);
         $metadata = $response->toArray();
 
-        $server->setOauthMetadata(json_encode($metadata));
+        $server->setOauthMetadata(json_encode($metadata) ?: null);
         $server->setUpdatedAt(time());
         $this->mapper->update($server);
 

--- a/nextcloud-app/lib/Service/NativeMcpService.php
+++ b/nextcloud-app/lib/Service/NativeMcpService.php
@@ -7,7 +7,6 @@ namespace OCA\AIquila\Service;
 
 use OCA\AIquila\Db\McpServerMapper;
 use OCP\IConfig;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -22,19 +21,16 @@ class NativeMcpService {
     private McpServerMapper $mapper;
     private CredentialService $credentials;
     private IConfig $config;
-    private LoggerInterface $logger;
     private HttpClientInterface $httpClient;
 
     public function __construct(
         McpServerMapper $mapper,
         CredentialService $credentials,
         IConfig $config,
-        LoggerInterface $logger
     ) {
         $this->mapper = $mapper;
         $this->credentials = $credentials;
         $this->config = $config;
-        $this->logger = $logger;
         $this->httpClient = HttpClient::create(['timeout' => 5]);
     }
 
@@ -196,7 +192,7 @@ class NativeMcpService {
 
     private function slugifyName(string $name): string {
         $slug = strtolower(trim($name));
-        $slug = preg_replace('/[^a-z0-9]+/', '_', $slug);
+        $slug = preg_replace('/[^a-z0-9]+/', '_', $slug) ?? '';
         $slug = trim($slug, '_');
         return $slug !== '' ? $slug : 'mcp';
     }

--- a/nextcloud-app/lib/Service/Provider/DeepSeekProvider.php
+++ b/nextcloud-app/lib/Service/Provider/DeepSeekProvider.php
@@ -381,15 +381,20 @@ class DeepSeekProvider implements LLMProviderInterface {
             'timeout' => self::STREAM_TIMEOUT,
         ]);
         $stream = $response->getBody();
-        if (is_string($stream)) {
-            // Some client backends return the full body instead of a resource;
-            // wrap it so the SSE reader can consume it uniformly.
-            $tmp = fopen('php://temp', 'r+');
-            fwrite($tmp, $stream);
-            rewind($tmp);
-            return $tmp;
+        if (!is_string($stream) && is_resource($stream)) {
+            return $stream;
         }
-        return $stream;
+
+        // Some client backends return the full body instead of a resource;
+        // wrap it so the SSE reader can consume it uniformly.
+        $tmp = fopen('php://temp', 'r+');
+        if ($tmp === false) {
+            throw new \RuntimeException('Could not open a temporary stream');
+        }
+        fwrite($tmp, is_string($stream) ? $stream : '');
+        rewind($tmp);
+
+        return $tmp;
     }
 
     private function requireApiKey(?string $userId): string {

--- a/nextcloud-app/lib/Service/Provider/LLMProviderInterface.php
+++ b/nextcloud-app/lib/Service/Provider/LLMProviderInterface.php
@@ -52,13 +52,13 @@ interface LLMProviderInterface {
     /** @return array{response: string, usage?: array, citations?: array}|array{error: string} */
     public function ask(string $prompt, string $context = '', ?string $userId = null, array $options = []): array;
 
-    /** @return array{response: string, usage?: array}|array{error: string} */
+    /** @return array{response: string, usage?: array, citations?: array}|array{error: string} */
     public function askWithImage(string $prompt, string $base64Image, string $mimeType, ?string $userId = null, ?string $fileId = null): array;
 
     /**
-     * @param array<array{base64: string, mimeType: string}> $images
+     * @param array<array{base64: string, mimeType: string, ...}> $images
      * @param array<int, string|null>|null $fileIds
-     * @return array{response: string, usage?: array}|array{error: string}
+     * @return array{response: string, usage?: array, citations?: array}|array{error: string}
      */
     public function askWithImages(string $prompt, array $images, ?string $userId = null, ?array $fileIds = null): array;
 
@@ -90,12 +90,18 @@ interface LLMProviderInterface {
     /**
      * Native MCP connector path (Anthropic only). Providers that return false
      * from supportsNativeMcp() are never asked to run this; they yield an error.
+     *
+     * @param list<array<string, mixed>> $mcpServers Server descriptors per BetaRequestMCPServerURLDefinition
      */
     public function chatWithNativeMcp(array $messages, array $mcpServers, ?string $system = null, ?string $userId = null, array $options = []): \Generator;
 
-    /** Non-streaming convenience wrapper around chatWithNativeMcp(). */
+    /**
+     * Non-streaming convenience wrapper around chatWithNativeMcp().
+     *
+     * @param list<array<string, mixed>> $mcpServers
+     */
     public function chatWithNativeMcpCollect(array $messages, array $mcpServers, ?string $system = null, ?string $userId = null, array $options = []): array;
 
-    /** @return array{response: string, usage?: array}|array{error: string} */
+    /** @return array{response: string, usage?: array, citations?: array}|array{error: string} */
     public function summarize(string $content, ?string $userId = null): array;
 }

--- a/nextcloud-app/lib/Service/Provider/MistralProvider.php
+++ b/nextcloud-app/lib/Service/Provider/MistralProvider.php
@@ -432,9 +432,7 @@ class MistralProvider implements LLMProviderInterface {
                             $this->accumulateUsage($total, $event['usage'] ?? []);
                             break;
                         case 'conversation.response.error':
-                            if (is_resource($stream)) {
-                                fclose($stream);
-                            }
+                            fclose($stream);
                             yield ['type' => 'error', 'error' => (string)($event['message'] ?? 'Mistral conversation error'), 'usage' => $this->finalizeUsage($total)];
                             return;
                         default:
@@ -602,13 +600,18 @@ class MistralProvider implements LLMProviderInterface {
             'timeout' => self::STREAM_TIMEOUT,
         ]);
         $stream = $response->getBody();
-        if (is_string($stream)) {
-            $tmp = fopen('php://temp', 'r+');
-            fwrite($tmp, $stream);
-            rewind($tmp);
-            return $tmp;
+        if (!is_string($stream) && is_resource($stream)) {
+            return $stream;
         }
-        return $stream;
+
+        $tmp = fopen('php://temp', 'r+');
+        if ($tmp === false) {
+            throw new \RuntimeException('Could not open a temporary stream');
+        }
+        fwrite($tmp, is_string($stream) ? $stream : '');
+        rewind($tmp);
+
+        return $tmp;
     }
 
     /**
@@ -710,15 +713,20 @@ class MistralProvider implements LLMProviderInterface {
             'timeout' => self::STREAM_TIMEOUT,
         ]);
         $stream = $response->getBody();
-        if (is_string($stream)) {
-            // Some client backends return the full body instead of a resource;
-            // wrap it so the SSE reader can consume it uniformly.
-            $tmp = fopen('php://temp', 'r+');
-            fwrite($tmp, $stream);
-            rewind($tmp);
-            return $tmp;
+        if (!is_string($stream) && is_resource($stream)) {
+            return $stream;
         }
-        return $stream;
+
+        // Some client backends return the full body instead of a resource;
+        // wrap it so the SSE reader can consume it uniformly.
+        $tmp = fopen('php://temp', 'r+');
+        if ($tmp === false) {
+            throw new \RuntimeException('Could not open a temporary stream');
+        }
+        fwrite($tmp, is_string($stream) ? $stream : '');
+        rewind($tmp);
+
+        return $tmp;
     }
 
     private function requireApiKey(?string $userId): string {

--- a/nextcloud-app/lib/TaskProcessing/ClaudeAnalyzeImagesProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeAnalyzeImagesProvider.php
@@ -80,10 +80,13 @@ class ClaudeAnalyzeImagesProvider implements ISynchronousProvider {
     }
 
     public function process(?string $userId, array $input, callable $reportProgress): array {
-        $prompt = $input['input'] ?? 'Describe these images in detail.';
-        $imageList = $input['images'] ?? [];
+        $prompt = $input['input'] ?? '';
+        if (!is_string($prompt) || $prompt === '') {
+            $prompt = 'Describe these images in detail.';
+        }
 
-        if (empty($imageList)) {
+        $imageList = $input['images'] ?? [];
+        if (!is_array($imageList) || $imageList === []) {
             throw new \RuntimeException('No images provided');
         }
 
@@ -99,6 +102,10 @@ class ClaudeAnalyzeImagesProvider implements ISynchronousProvider {
         $images = [];
         $total = count($imageList);
         foreach ($imageList as $i => $imageData) {
+            if (!is_string($imageData)) {
+                throw new \RuntimeException('Image ' . ($i + 1) . ' is not raw image data');
+            }
+
             $mimeType = $this->detectMimeType($imageData);
 
             if ($this->imageOptimizer->isSupported($mimeType)) {

--- a/nextcloud-app/lib/TaskProcessing/ClaudeChangeToneProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeChangeToneProvider.php
@@ -7,7 +7,6 @@ namespace OCA\AIquila\TaskProcessing;
 
 use OCA\AIquila\Service\ClaudeSDKService;
 use OCP\TaskProcessing\ISynchronousProvider;
-use Psr\Log\LoggerInterface;
 
 /**
  * Claude change-tone TaskProcessing Provider (core:text2text:changetone)
@@ -16,7 +15,6 @@ class ClaudeChangeToneProvider implements ISynchronousProvider {
 
     public function __construct(
         private ClaudeSDKService $claudeService,
-        private LoggerInterface $logger,
     ) {
     }
 
@@ -72,8 +70,11 @@ class ClaudeChangeToneProvider implements ISynchronousProvider {
         $text = $input['input'] ?? '';
         $tone = $input['tone'] ?? 'formal';
 
-        if (empty($text)) {
+        if (!is_string($text) || $text === '') {
             throw new \RuntimeException('No input text provided');
+        }
+        if (!is_string($tone) || $tone === '') {
+            $tone = 'formal';
         }
 
         $reportProgress(0.1);

--- a/nextcloud-app/lib/TaskProcessing/ClaudeFormalizationProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeFormalizationProvider.php
@@ -7,7 +7,6 @@ namespace OCA\AIquila\TaskProcessing;
 
 use OCA\AIquila\Service\ClaudeSDKService;
 use OCP\TaskProcessing\ISynchronousProvider;
-use Psr\Log\LoggerInterface;
 
 /**
  * Claude formalization TaskProcessing Provider (core:text2text:formalization)
@@ -16,7 +15,6 @@ class ClaudeFormalizationProvider implements ISynchronousProvider {
 
     public function __construct(
         private ClaudeSDKService $claudeService,
-        private LoggerInterface $logger,
     ) {
     }
 
@@ -70,7 +68,7 @@ class ClaudeFormalizationProvider implements ISynchronousProvider {
 
     public function process(?string $userId, array $input, callable $reportProgress): array {
         $text = $input['input'] ?? '';
-        if (empty($text)) {
+        if (!is_string($text) || $text === '') {
             throw new \RuntimeException('No input text provided');
         }
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeHeadlineProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeHeadlineProvider.php
@@ -7,7 +7,6 @@ namespace OCA\AIquila\TaskProcessing;
 
 use OCA\AIquila\Service\ClaudeSDKService;
 use OCP\TaskProcessing\ISynchronousProvider;
-use Psr\Log\LoggerInterface;
 
 /**
  * Claude headline TaskProcessing Provider (core:text2text:headline)
@@ -16,7 +15,6 @@ class ClaudeHeadlineProvider implements ISynchronousProvider {
 
     public function __construct(
         private ClaudeSDKService $claudeService,
-        private LoggerInterface $logger,
     ) {
     }
 
@@ -70,7 +68,7 @@ class ClaudeHeadlineProvider implements ISynchronousProvider {
 
     public function process(?string $userId, array $input, callable $reportProgress): array {
         $text = $input['input'] ?? '';
-        if (empty($text)) {
+        if (!is_string($text) || $text === '') {
             throw new \RuntimeException('No input text provided');
         }
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeImageToTextProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeImageToTextProvider.php
@@ -91,12 +91,15 @@ class ClaudeImageToTextProvider implements ISynchronousProvider {
     }
 
     public function process(?string $userId, array $input, callable $reportProgress): array {
-        if (empty($input['image'])) {
+        $imageData = $input['image'] ?? '';
+        if (!is_string($imageData) || $imageData === '') {
             throw new \RuntimeException('No image provided in task input');
         }
 
-        $imageData = $input['image'];
-        $prompt = !empty($input['prompt']) ? $input['prompt'] : 'Describe this image in detail.';
+        $prompt = $input['prompt'] ?? '';
+        if (!is_string($prompt) || $prompt === '') {
+            $prompt = 'Describe this image in detail.';
+        }
 
         $mimeType = $this->detectMimeType($imageData);
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeProofreadProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeProofreadProvider.php
@@ -7,7 +7,6 @@ namespace OCA\AIquila\TaskProcessing;
 
 use OCA\AIquila\Service\ClaudeSDKService;
 use OCP\TaskProcessing\ISynchronousProvider;
-use Psr\Log\LoggerInterface;
 
 /**
  * Claude proofread TaskProcessing Provider (core:text2text:proofread)
@@ -16,7 +15,6 @@ class ClaudeProofreadProvider implements ISynchronousProvider {
 
     public function __construct(
         private ClaudeSDKService $claudeService,
-        private LoggerInterface $logger,
     ) {
     }
 
@@ -70,7 +68,7 @@ class ClaudeProofreadProvider implements ISynchronousProvider {
 
     public function process(?string $userId, array $input, callable $reportProgress): array {
         $text = $input['input'] ?? '';
-        if (empty($text)) {
+        if (!is_string($text) || $text === '') {
             throw new \RuntimeException('No input text provided');
         }
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeReformulationProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeReformulationProvider.php
@@ -7,7 +7,6 @@ namespace OCA\AIquila\TaskProcessing;
 
 use OCA\AIquila\Service\ClaudeSDKService;
 use OCP\TaskProcessing\ISynchronousProvider;
-use Psr\Log\LoggerInterface;
 
 /**
  * Claude reformulation TaskProcessing Provider (core:text2text:reformulation)
@@ -16,7 +15,6 @@ class ClaudeReformulationProvider implements ISynchronousProvider {
 
     public function __construct(
         private ClaudeSDKService $claudeService,
-        private LoggerInterface $logger,
     ) {
     }
 
@@ -70,7 +68,7 @@ class ClaudeReformulationProvider implements ISynchronousProvider {
 
     public function process(?string $userId, array $input, callable $reportProgress): array {
         $text = $input['input'] ?? '';
-        if (empty($text)) {
+        if (!is_string($text) || $text === '') {
             throw new \RuntimeException('No input text provided');
         }
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeSimplificationProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeSimplificationProvider.php
@@ -7,7 +7,6 @@ namespace OCA\AIquila\TaskProcessing;
 
 use OCA\AIquila\Service\ClaudeSDKService;
 use OCP\TaskProcessing\ISynchronousProvider;
-use Psr\Log\LoggerInterface;
 
 /**
  * Claude simplification TaskProcessing Provider (core:text2text:simplification)
@@ -16,7 +15,6 @@ class ClaudeSimplificationProvider implements ISynchronousProvider {
 
     public function __construct(
         private ClaudeSDKService $claudeService,
-        private LoggerInterface $logger,
     ) {
     }
 
@@ -70,7 +68,7 @@ class ClaudeSimplificationProvider implements ISynchronousProvider {
 
     public function process(?string $userId, array $input, callable $reportProgress): array {
         $text = $input['input'] ?? '';
-        if (empty($text)) {
+        if (!is_string($text) || $text === '') {
             throw new \RuntimeException('No input text provided');
         }
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeSummaryProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeSummaryProvider.php
@@ -7,7 +7,6 @@ namespace OCA\AIquila\TaskProcessing;
 
 use OCA\AIquila\Service\ClaudeSDKService;
 use OCP\TaskProcessing\ISynchronousProvider;
-use Psr\Log\LoggerInterface;
 
 /**
  * Claude summary TaskProcessing Provider (core:text2text:summary)
@@ -16,7 +15,6 @@ class ClaudeSummaryProvider implements ISynchronousProvider {
 
     public function __construct(
         private ClaudeSDKService $claudeService,
-        private LoggerInterface $logger,
     ) {
     }
 
@@ -72,7 +70,7 @@ class ClaudeSummaryProvider implements ISynchronousProvider {
 
     public function process(?string $userId, array $input, callable $reportProgress): array {
         $text = $input['input'] ?? '';
-        if (empty($text)) {
+        if (!is_string($text) || $text === '') {
             throw new \RuntimeException('No input text provided');
         }
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeTextToTextProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeTextToTextProvider.php
@@ -6,8 +6,8 @@ declare(strict_types=1);
 namespace OCA\AIquila\TaskProcessing;
 
 use OCA\AIquila\Service\ClaudeSDKService;
-use OCP\TaskProcessing\ISynchronousProvider;
 use Psr\Log\LoggerInterface;
+use OCP\TaskProcessing\ISynchronousProvider;
 
 /**
  * Claude free-prompt TaskProcessing Provider (core:text2text)
@@ -73,7 +73,7 @@ class ClaudeTextToTextProvider implements ISynchronousProvider {
 
     public function process(?string $userId, array $input, callable $reportProgress): array {
         $prompt = $input['input'] ?? '';
-        if (empty($prompt)) {
+        if (!is_string($prompt) || $prompt === '') {
             throw new \RuntimeException('No input text provided');
         }
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeTopicsProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeTopicsProvider.php
@@ -7,7 +7,6 @@ namespace OCA\AIquila\TaskProcessing;
 
 use OCA\AIquila\Service\ClaudeSDKService;
 use OCP\TaskProcessing\ISynchronousProvider;
-use Psr\Log\LoggerInterface;
 
 /**
  * Claude topics TaskProcessing Provider (core:text2text:topics)
@@ -16,7 +15,6 @@ class ClaudeTopicsProvider implements ISynchronousProvider {
 
     public function __construct(
         private ClaudeSDKService $claudeService,
-        private LoggerInterface $logger,
     ) {
     }
 
@@ -70,7 +68,7 @@ class ClaudeTopicsProvider implements ISynchronousProvider {
 
     public function process(?string $userId, array $input, callable $reportProgress): array {
         $text = $input['input'] ?? '';
-        if (empty($text)) {
+        if (!is_string($text) || $text === '') {
             throw new \RuntimeException('No input text provided');
         }
 

--- a/nextcloud-app/lib/TaskProcessing/ClaudeTranslateProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeTranslateProvider.php
@@ -7,7 +7,6 @@ namespace OCA\AIquila\TaskProcessing;
 
 use OCA\AIquila\Service\ClaudeSDKService;
 use OCP\TaskProcessing\ISynchronousProvider;
-use Psr\Log\LoggerInterface;
 
 /**
  * Claude translate TaskProcessing Provider (core:text2text:translate)
@@ -16,7 +15,6 @@ class ClaudeTranslateProvider implements ISynchronousProvider {
 
     public function __construct(
         private ClaudeSDKService $claudeService,
-        private LoggerInterface $logger,
     ) {
     }
 
@@ -73,11 +71,14 @@ class ClaudeTranslateProvider implements ISynchronousProvider {
         $originLanguage = $input['origin_language'] ?? '';
         $targetLanguage = $input['target_language'] ?? '';
 
-        if (empty($text)) {
+        if (!is_string($text) || $text === '') {
             throw new \RuntimeException('No input text provided');
         }
-        if (empty($targetLanguage)) {
+        if (!is_string($targetLanguage) || $targetLanguage === '') {
             throw new \RuntimeException('No target language provided');
+        }
+        if (!is_string($originLanguage)) {
+            $originLanguage = '';
         }
 
         $reportProgress(0.1);

--- a/nextcloud-app/openapi-administration.json
+++ b/nextcloud-app/openapi-administration.json
@@ -555,7 +555,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "The PHP CLI binary could not be located or the process failed to start",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -570,6 +570,41 @@
                                         },
                                         "error": {
                                             "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "408": {
+                        "description": "The command exceeded the requested timeout",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "success",
+                                        "error",
+                                        "stdout",
+                                        "stderr",
+                                        "exitCode"
+                                    ],
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        },
+                                        "stdout": {
+                                            "type": "string"
+                                        },
+                                        "stderr": {
+                                            "type": "string"
+                                        },
+                                        "exitCode": {
+                                            "type": "integer",
+                                            "format": "int64"
                                         }
                                     }
                                 }
@@ -1379,6 +1414,24 @@
                             }
                         }
                     },
+                    "500": {
+                        "description": "Listing the tools failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -1477,6 +1530,24 @@
                     },
                     "404": {
                         "description": "Server not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Starting the authorization flow failed",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/nextcloud-app/openapi-full.json
+++ b/nextcloud-app/openapi-full.json
@@ -60,15 +60,22 @@
                                         "type": "object",
                                         "required": [
                                             "id",
+                                            "userId",
                                             "title",
                                             "model",
                                             "createdAt",
-                                            "updatedAt"
+                                            "updatedAt",
+                                            "projectId",
+                                            "effort",
+                                            "thinking"
                                         ],
                                         "properties": {
                                             "id": {
                                                 "type": "integer",
                                                 "format": "int64"
+                                            },
+                                            "userId": {
+                                                "type": "string"
                                             },
                                             "title": {
                                                 "type": "string",
@@ -84,6 +91,19 @@
                                             "updatedAt": {
                                                 "type": "integer",
                                                 "format": "int64"
+                                            },
+                                            "projectId": {
+                                                "type": "integer",
+                                                "format": "int64",
+                                                "nullable": true
+                                            },
+                                            "effort": {
+                                                "type": "string",
+                                                "nullable": true
+                                            },
+                                            "thinking": {
+                                                "type": "boolean",
+                                                "nullable": true
                                             }
                                         }
                                     }
@@ -146,15 +166,22 @@
                                     "type": "object",
                                     "required": [
                                         "id",
+                                        "userId",
                                         "title",
                                         "model",
                                         "createdAt",
-                                        "updatedAt"
+                                        "updatedAt",
+                                        "projectId",
+                                        "effort",
+                                        "thinking"
                                     ],
                                     "properties": {
                                         "id": {
                                             "type": "integer",
                                             "format": "int64"
+                                        },
+                                        "userId": {
+                                            "type": "string"
                                         },
                                         "title": {
                                             "type": "string",
@@ -170,6 +197,19 @@
                                         "updatedAt": {
                                             "type": "integer",
                                             "format": "int64"
+                                        },
+                                        "projectId": {
+                                            "type": "integer",
+                                            "format": "int64",
+                                            "nullable": true
+                                        },
+                                        "effort": {
+                                            "type": "string",
+                                            "nullable": true
+                                        },
+                                        "thinking": {
+                                            "type": "boolean",
+                                            "nullable": true
                                         }
                                     }
                                 }
@@ -243,14 +283,23 @@
                                     "type": "object",
                                     "required": [
                                         "id",
+                                        "userId",
                                         "title",
                                         "model",
+                                        "createdAt",
+                                        "updatedAt",
+                                        "projectId",
+                                        "effort",
+                                        "thinking",
                                         "messages"
                                     ],
                                     "properties": {
                                         "id": {
                                             "type": "integer",
                                             "format": "int64"
+                                        },
+                                        "userId": {
+                                            "type": "string"
                                         },
                                         "title": {
                                             "type": "string",
@@ -259,12 +308,142 @@
                                         "model": {
                                             "type": "string"
                                         },
+                                        "createdAt": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        },
+                                        "updatedAt": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        },
+                                        "projectId": {
+                                            "type": "integer",
+                                            "format": "int64",
+                                            "nullable": true
+                                        },
+                                        "effort": {
+                                            "type": "string",
+                                            "nullable": true
+                                        },
+                                        "thinking": {
+                                            "type": "boolean",
+                                            "nullable": true
+                                        },
                                         "messages": {
                                             "type": "array",
                                             "items": {
                                                 "type": "object",
-                                                "additionalProperties": {
-                                                    "type": "object"
+                                                "required": [
+                                                    "id",
+                                                    "conversationId",
+                                                    "role",
+                                                    "content",
+                                                    "inputTokens",
+                                                    "outputTokens",
+                                                    "cacheCreationTokens",
+                                                    "cacheReadTokens",
+                                                    "latencyMs",
+                                                    "citations",
+                                                    "documents",
+                                                    "createdAt",
+                                                    "files"
+                                                ],
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "integer",
+                                                        "format": "int64"
+                                                    },
+                                                    "conversationId": {
+                                                        "type": "integer",
+                                                        "format": "int64"
+                                                    },
+                                                    "role": {
+                                                        "type": "string"
+                                                    },
+                                                    "content": {
+                                                        "type": "string"
+                                                    },
+                                                    "inputTokens": {
+                                                        "type": "integer",
+                                                        "format": "int64",
+                                                        "nullable": true
+                                                    },
+                                                    "outputTokens": {
+                                                        "type": "integer",
+                                                        "format": "int64",
+                                                        "nullable": true
+                                                    },
+                                                    "cacheCreationTokens": {
+                                                        "type": "integer",
+                                                        "format": "int64",
+                                                        "nullable": true
+                                                    },
+                                                    "cacheReadTokens": {
+                                                        "type": "integer",
+                                                        "format": "int64",
+                                                        "nullable": true
+                                                    },
+                                                    "latencyMs": {
+                                                        "type": "integer",
+                                                        "format": "int64",
+                                                        "nullable": true
+                                                    },
+                                                    "citations": {
+                                                        "type": "object",
+                                                        "nullable": true,
+                                                        "additionalProperties": {
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "documents": {
+                                                        "type": "object",
+                                                        "nullable": true,
+                                                        "additionalProperties": {
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "createdAt": {
+                                                        "type": "integer",
+                                                        "format": "int64"
+                                                    },
+                                                    "files": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "id",
+                                                                "messageId",
+                                                                "filePath",
+                                                                "fileName",
+                                                                "mimeType",
+                                                                "createdAt"
+                                                            ],
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "integer",
+                                                                    "format": "int64"
+                                                                },
+                                                                "messageId": {
+                                                                    "type": "integer",
+                                                                    "format": "int64"
+                                                                },
+                                                                "filePath": {
+                                                                    "type": "string"
+                                                                },
+                                                                "fileName": {
+                                                                    "type": "string"
+                                                                },
+                                                                "mimeType": {
+                                                                    "type": "string",
+                                                                    "nullable": true
+                                                                },
+                                                                "createdAt": {
+                                                                    "type": "integer",
+                                                                    "format": "int64"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }
@@ -392,13 +571,22 @@
                                     "type": "object",
                                     "required": [
                                         "id",
+                                        "userId",
                                         "title",
-                                        "model"
+                                        "model",
+                                        "createdAt",
+                                        "updatedAt",
+                                        "projectId",
+                                        "effort",
+                                        "thinking"
                                     ],
                                     "properties": {
                                         "id": {
                                             "type": "integer",
                                             "format": "int64"
+                                        },
+                                        "userId": {
+                                            "type": "string"
                                         },
                                         "title": {
                                             "type": "string",
@@ -406,6 +594,27 @@
                                         },
                                         "model": {
                                             "type": "string"
+                                        },
+                                        "createdAt": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        },
+                                        "updatedAt": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        },
+                                        "projectId": {
+                                            "type": "integer",
+                                            "format": "int64",
+                                            "nullable": true
+                                        },
+                                        "effort": {
+                                            "type": "string",
+                                            "nullable": true
+                                        },
+                                        "thinking": {
+                                            "type": "boolean",
+                                            "nullable": true
                                         }
                                     }
                                 }
@@ -419,7 +628,8 @@
                                 "schema": {
                                     "type": "object",
                                     "required": [
-                                        "error"
+                                        "error",
+                                        "allowed"
                                     ],
                                     "properties": {
                                         "error": {
@@ -772,13 +982,22 @@
                                     "type": "object",
                                     "required": [
                                         "id",
+                                        "userId",
                                         "title",
-                                        "model"
+                                        "model",
+                                        "createdAt",
+                                        "updatedAt",
+                                        "projectId",
+                                        "effort",
+                                        "thinking"
                                     ],
                                     "properties": {
                                         "id": {
                                             "type": "integer",
                                             "format": "int64"
+                                        },
+                                        "userId": {
+                                            "type": "string"
                                         },
                                         "title": {
                                             "type": "string",
@@ -786,6 +1005,27 @@
                                         },
                                         "model": {
                                             "type": "string"
+                                        },
+                                        "createdAt": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        },
+                                        "updatedAt": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        },
+                                        "projectId": {
+                                            "type": "integer",
+                                            "format": "int64",
+                                            "nullable": true
+                                        },
+                                        "effort": {
+                                            "type": "string",
+                                            "nullable": true
+                                        },
+                                        "thinking": {
+                                            "type": "boolean",
+                                            "nullable": true
                                         }
                                     }
                                 }
@@ -1053,6 +1293,24 @@
                                     "type": "object",
                                     "additionalProperties": {
                                         "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Title is missing",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
                                     }
                                 }
                             }
@@ -1790,6 +2048,24 @@
                             }
                         }
                     },
+                    "500": {
+                        "description": "An attached file could not be read",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -2507,11 +2783,62 @@
                                 "schema": {
                                     "type": "object",
                                     "required": [
+                                        "provider",
+                                        "userProvider",
+                                        "providers",
                                         "hasUserKey",
                                         "userModel",
-                                        "availableModels"
+                                        "availableModels",
+                                        "defaultSystemPrompt",
+                                        "defaultVerbose",
+                                        "nativeMcpUserOverride",
+                                        "nativeMcpAdminDefault",
+                                        "nativeMcpEffective"
                                     ],
                                     "properties": {
+                                        "provider": {
+                                            "type": "string"
+                                        },
+                                        "userProvider": {
+                                            "type": "string"
+                                        },
+                                        "providers": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "id",
+                                                    "label",
+                                                    "configured",
+                                                    "hasUserKey",
+                                                    "userModel",
+                                                    "availableModels"
+                                                ],
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string"
+                                                    },
+                                                    "label": {
+                                                        "type": "string"
+                                                    },
+                                                    "configured": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "hasUserKey": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "userModel": {
+                                                        "type": "string"
+                                                    },
+                                                    "availableModels": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
                                         "hasUserKey": {
                                             "type": "boolean"
                                         },
@@ -2521,20 +2848,23 @@
                                         "availableModels": {
                                             "type": "array",
                                             "items": {
-                                                "type": "object",
-                                                "required": [
-                                                    "id",
-                                                    "name"
-                                                ],
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    }
-                                                }
+                                                "type": "string"
                                             }
+                                        },
+                                        "defaultSystemPrompt": {
+                                            "type": "string"
+                                        },
+                                        "defaultVerbose": {
+                                            "type": "boolean"
+                                        },
+                                        "nativeMcpUserOverride": {
+                                            "type": "string"
+                                        },
+                                        "nativeMcpAdminDefault": {
+                                            "type": "boolean"
+                                        },
+                                        "nativeMcpEffective": {
+                                            "type": "boolean"
                                         }
                                     }
                                 }
@@ -3875,6 +4205,24 @@
                             }
                         }
                     },
+                    "500": {
+                        "description": "Reading the file metadata failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -4010,6 +4358,24 @@
                             }
                         }
                     },
+                    "500": {
+                        "description": "Reading the directory failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -4113,6 +4479,42 @@
                     },
                     "404": {
                         "description": "File not found at the given path",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "File exceeds the size limit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Reading the file failed",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4274,6 +4676,24 @@
                             }
                         }
                     },
+                    "500": {
+                        "description": "The search failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -4384,6 +4804,24 @@
                     },
                     "404": {
                         "description": "File not found at the given path",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Generating the preview failed",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4531,6 +4969,60 @@
                             }
                         }
                     },
+                    "409": {
+                        "description": "Destination already exists and overwrite was not requested",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "Archive exceeds the maximum size",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Creating the archive failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -4638,6 +5130,60 @@
                     },
                     "404": {
                         "description": "Archive not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "An entry already exists and overwrite was not requested",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "Archive exceeds the maximum size",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Extracting the archive failed",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4774,6 +5320,24 @@
                     },
                     "404": {
                         "description": "Archive not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Reading the archive failed",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -5344,7 +5908,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "The PHP CLI binary could not be located or the process failed to start",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -5359,6 +5923,41 @@
                                         },
                                         "error": {
                                             "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "408": {
+                        "description": "The command exceeded the requested timeout",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "success",
+                                        "error",
+                                        "stdout",
+                                        "stderr",
+                                        "exitCode"
+                                    ],
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        },
+                                        "stdout": {
+                                            "type": "string"
+                                        },
+                                        "stderr": {
+                                            "type": "string"
+                                        },
+                                        "exitCode": {
+                                            "type": "integer",
+                                            "format": "int64"
                                         }
                                     }
                                 }
@@ -6168,6 +6767,24 @@
                             }
                         }
                     },
+                    "500": {
+                        "description": "Listing the tools failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -6266,6 +6883,24 @@
                     },
                     "404": {
                         "description": "Server not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Starting the authorization flow failed",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/nextcloud-app/openapi.json
+++ b/nextcloud-app/openapi.json
@@ -60,15 +60,22 @@
                                         "type": "object",
                                         "required": [
                                             "id",
+                                            "userId",
                                             "title",
                                             "model",
                                             "createdAt",
-                                            "updatedAt"
+                                            "updatedAt",
+                                            "projectId",
+                                            "effort",
+                                            "thinking"
                                         ],
                                         "properties": {
                                             "id": {
                                                 "type": "integer",
                                                 "format": "int64"
+                                            },
+                                            "userId": {
+                                                "type": "string"
                                             },
                                             "title": {
                                                 "type": "string",
@@ -84,6 +91,19 @@
                                             "updatedAt": {
                                                 "type": "integer",
                                                 "format": "int64"
+                                            },
+                                            "projectId": {
+                                                "type": "integer",
+                                                "format": "int64",
+                                                "nullable": true
+                                            },
+                                            "effort": {
+                                                "type": "string",
+                                                "nullable": true
+                                            },
+                                            "thinking": {
+                                                "type": "boolean",
+                                                "nullable": true
                                             }
                                         }
                                     }
@@ -146,15 +166,22 @@
                                     "type": "object",
                                     "required": [
                                         "id",
+                                        "userId",
                                         "title",
                                         "model",
                                         "createdAt",
-                                        "updatedAt"
+                                        "updatedAt",
+                                        "projectId",
+                                        "effort",
+                                        "thinking"
                                     ],
                                     "properties": {
                                         "id": {
                                             "type": "integer",
                                             "format": "int64"
+                                        },
+                                        "userId": {
+                                            "type": "string"
                                         },
                                         "title": {
                                             "type": "string",
@@ -170,6 +197,19 @@
                                         "updatedAt": {
                                             "type": "integer",
                                             "format": "int64"
+                                        },
+                                        "projectId": {
+                                            "type": "integer",
+                                            "format": "int64",
+                                            "nullable": true
+                                        },
+                                        "effort": {
+                                            "type": "string",
+                                            "nullable": true
+                                        },
+                                        "thinking": {
+                                            "type": "boolean",
+                                            "nullable": true
                                         }
                                     }
                                 }
@@ -243,14 +283,23 @@
                                     "type": "object",
                                     "required": [
                                         "id",
+                                        "userId",
                                         "title",
                                         "model",
+                                        "createdAt",
+                                        "updatedAt",
+                                        "projectId",
+                                        "effort",
+                                        "thinking",
                                         "messages"
                                     ],
                                     "properties": {
                                         "id": {
                                             "type": "integer",
                                             "format": "int64"
+                                        },
+                                        "userId": {
+                                            "type": "string"
                                         },
                                         "title": {
                                             "type": "string",
@@ -259,12 +308,142 @@
                                         "model": {
                                             "type": "string"
                                         },
+                                        "createdAt": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        },
+                                        "updatedAt": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        },
+                                        "projectId": {
+                                            "type": "integer",
+                                            "format": "int64",
+                                            "nullable": true
+                                        },
+                                        "effort": {
+                                            "type": "string",
+                                            "nullable": true
+                                        },
+                                        "thinking": {
+                                            "type": "boolean",
+                                            "nullable": true
+                                        },
                                         "messages": {
                                             "type": "array",
                                             "items": {
                                                 "type": "object",
-                                                "additionalProperties": {
-                                                    "type": "object"
+                                                "required": [
+                                                    "id",
+                                                    "conversationId",
+                                                    "role",
+                                                    "content",
+                                                    "inputTokens",
+                                                    "outputTokens",
+                                                    "cacheCreationTokens",
+                                                    "cacheReadTokens",
+                                                    "latencyMs",
+                                                    "citations",
+                                                    "documents",
+                                                    "createdAt",
+                                                    "files"
+                                                ],
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "integer",
+                                                        "format": "int64"
+                                                    },
+                                                    "conversationId": {
+                                                        "type": "integer",
+                                                        "format": "int64"
+                                                    },
+                                                    "role": {
+                                                        "type": "string"
+                                                    },
+                                                    "content": {
+                                                        "type": "string"
+                                                    },
+                                                    "inputTokens": {
+                                                        "type": "integer",
+                                                        "format": "int64",
+                                                        "nullable": true
+                                                    },
+                                                    "outputTokens": {
+                                                        "type": "integer",
+                                                        "format": "int64",
+                                                        "nullable": true
+                                                    },
+                                                    "cacheCreationTokens": {
+                                                        "type": "integer",
+                                                        "format": "int64",
+                                                        "nullable": true
+                                                    },
+                                                    "cacheReadTokens": {
+                                                        "type": "integer",
+                                                        "format": "int64",
+                                                        "nullable": true
+                                                    },
+                                                    "latencyMs": {
+                                                        "type": "integer",
+                                                        "format": "int64",
+                                                        "nullable": true
+                                                    },
+                                                    "citations": {
+                                                        "type": "object",
+                                                        "nullable": true,
+                                                        "additionalProperties": {
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "documents": {
+                                                        "type": "object",
+                                                        "nullable": true,
+                                                        "additionalProperties": {
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "createdAt": {
+                                                        "type": "integer",
+                                                        "format": "int64"
+                                                    },
+                                                    "files": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "id",
+                                                                "messageId",
+                                                                "filePath",
+                                                                "fileName",
+                                                                "mimeType",
+                                                                "createdAt"
+                                                            ],
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "integer",
+                                                                    "format": "int64"
+                                                                },
+                                                                "messageId": {
+                                                                    "type": "integer",
+                                                                    "format": "int64"
+                                                                },
+                                                                "filePath": {
+                                                                    "type": "string"
+                                                                },
+                                                                "fileName": {
+                                                                    "type": "string"
+                                                                },
+                                                                "mimeType": {
+                                                                    "type": "string",
+                                                                    "nullable": true
+                                                                },
+                                                                "createdAt": {
+                                                                    "type": "integer",
+                                                                    "format": "int64"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }
@@ -392,13 +571,22 @@
                                     "type": "object",
                                     "required": [
                                         "id",
+                                        "userId",
                                         "title",
-                                        "model"
+                                        "model",
+                                        "createdAt",
+                                        "updatedAt",
+                                        "projectId",
+                                        "effort",
+                                        "thinking"
                                     ],
                                     "properties": {
                                         "id": {
                                             "type": "integer",
                                             "format": "int64"
+                                        },
+                                        "userId": {
+                                            "type": "string"
                                         },
                                         "title": {
                                             "type": "string",
@@ -406,6 +594,27 @@
                                         },
                                         "model": {
                                             "type": "string"
+                                        },
+                                        "createdAt": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        },
+                                        "updatedAt": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        },
+                                        "projectId": {
+                                            "type": "integer",
+                                            "format": "int64",
+                                            "nullable": true
+                                        },
+                                        "effort": {
+                                            "type": "string",
+                                            "nullable": true
+                                        },
+                                        "thinking": {
+                                            "type": "boolean",
+                                            "nullable": true
                                         }
                                     }
                                 }
@@ -419,7 +628,8 @@
                                 "schema": {
                                     "type": "object",
                                     "required": [
-                                        "error"
+                                        "error",
+                                        "allowed"
                                     ],
                                     "properties": {
                                         "error": {
@@ -772,13 +982,22 @@
                                     "type": "object",
                                     "required": [
                                         "id",
+                                        "userId",
                                         "title",
-                                        "model"
+                                        "model",
+                                        "createdAt",
+                                        "updatedAt",
+                                        "projectId",
+                                        "effort",
+                                        "thinking"
                                     ],
                                     "properties": {
                                         "id": {
                                             "type": "integer",
                                             "format": "int64"
+                                        },
+                                        "userId": {
+                                            "type": "string"
                                         },
                                         "title": {
                                             "type": "string",
@@ -786,6 +1005,27 @@
                                         },
                                         "model": {
                                             "type": "string"
+                                        },
+                                        "createdAt": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        },
+                                        "updatedAt": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        },
+                                        "projectId": {
+                                            "type": "integer",
+                                            "format": "int64",
+                                            "nullable": true
+                                        },
+                                        "effort": {
+                                            "type": "string",
+                                            "nullable": true
+                                        },
+                                        "thinking": {
+                                            "type": "boolean",
+                                            "nullable": true
                                         }
                                     }
                                 }
@@ -1053,6 +1293,24 @@
                                     "type": "object",
                                     "additionalProperties": {
                                         "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Title is missing",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
                                     }
                                 }
                             }
@@ -1790,6 +2048,24 @@
                             }
                         }
                     },
+                    "500": {
+                        "description": "An attached file could not be read",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -2507,11 +2783,62 @@
                                 "schema": {
                                     "type": "object",
                                     "required": [
+                                        "provider",
+                                        "userProvider",
+                                        "providers",
                                         "hasUserKey",
                                         "userModel",
-                                        "availableModels"
+                                        "availableModels",
+                                        "defaultSystemPrompt",
+                                        "defaultVerbose",
+                                        "nativeMcpUserOverride",
+                                        "nativeMcpAdminDefault",
+                                        "nativeMcpEffective"
                                     ],
                                     "properties": {
+                                        "provider": {
+                                            "type": "string"
+                                        },
+                                        "userProvider": {
+                                            "type": "string"
+                                        },
+                                        "providers": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "id",
+                                                    "label",
+                                                    "configured",
+                                                    "hasUserKey",
+                                                    "userModel",
+                                                    "availableModels"
+                                                ],
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string"
+                                                    },
+                                                    "label": {
+                                                        "type": "string"
+                                                    },
+                                                    "configured": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "hasUserKey": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "userModel": {
+                                                        "type": "string"
+                                                    },
+                                                    "availableModels": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
                                         "hasUserKey": {
                                             "type": "boolean"
                                         },
@@ -2521,20 +2848,23 @@
                                         "availableModels": {
                                             "type": "array",
                                             "items": {
-                                                "type": "object",
-                                                "required": [
-                                                    "id",
-                                                    "name"
-                                                ],
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    }
-                                                }
+                                                "type": "string"
                                             }
+                                        },
+                                        "defaultSystemPrompt": {
+                                            "type": "string"
+                                        },
+                                        "defaultVerbose": {
+                                            "type": "boolean"
+                                        },
+                                        "nativeMcpUserOverride": {
+                                            "type": "string"
+                                        },
+                                        "nativeMcpAdminDefault": {
+                                            "type": "boolean"
+                                        },
+                                        "nativeMcpEffective": {
+                                            "type": "boolean"
                                         }
                                     }
                                 }
@@ -3875,6 +4205,24 @@
                             }
                         }
                     },
+                    "500": {
+                        "description": "Reading the file metadata failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -4010,6 +4358,24 @@
                             }
                         }
                     },
+                    "500": {
+                        "description": "Reading the directory failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -4113,6 +4479,42 @@
                     },
                     "404": {
                         "description": "File not found at the given path",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "File exceeds the size limit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Reading the file failed",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4274,6 +4676,24 @@
                             }
                         }
                     },
+                    "500": {
+                        "description": "The search failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -4384,6 +4804,24 @@
                     },
                     "404": {
                         "description": "File not found at the given path",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Generating the preview failed",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4531,6 +4969,60 @@
                             }
                         }
                     },
+                    "409": {
+                        "description": "Destination already exists and overwrite was not requested",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "Archive exceeds the maximum size",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Creating the archive failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -4638,6 +5130,60 @@
                     },
                     "404": {
                         "description": "Archive not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "An entry already exists and overwrite was not requested",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "Archive exceeds the maximum size",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Extracting the archive failed",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4774,6 +5320,24 @@
                     },
                     "404": {
                         "description": "Archive not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Reading the archive failed",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/nextcloud-app/psalm.xml
+++ b/nextcloud-app/psalm.xml
@@ -8,10 +8,77 @@
             <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>
+    <!--
+        nextcloud/ocp ships no `autoload` section — it is published for static
+        analysers, which read the sources directly. Parsing vendor/ as extra files
+        is how psalm resolves `OCP\*` without reporting issues inside vendor/.
+    -->
+    <extraFiles>
+        <directory name="vendor"/>
+    </extraFiles>
+    <stubs>
+        <file name="tests/stubs/oc-private.php"/>
+        <file name="tests/stubs/oc-global.php"/>
+    </stubs>
     <issueHandlers>
         <LessSpecificReturnStatement errorLevel="error"/>
         <LessSpecificReturnType errorLevel="error"/>
         <LessSpecificImplementedReturnType errorLevel="error"/>
         <MoreSpecificReturnType errorLevel="error"/>
+
+        <!--
+            Nothing in a Nextcloud app is called from code psalm can see: services are
+            built by the DI container, controllers by the router, listeners/commands/
+            widgets/jobs by appinfo registration. Psalm's dead-code detection therefore
+            reports the whole app as unused.
+        -->
+        <UnusedClass errorLevel="suppress"/>
+        <PossiblyUnusedMethod errorLevel="suppress"/>
+        <PossiblyUnusedProperty errorLevel="suppress"/>
+        <PossiblyUnusedParam errorLevel="suppress"/>
+        <PossiblyUnusedReturnValue errorLevel="suppress"/>
+
+        <!--
+            #[Override] is a psalm 6 style default, not something the Nextcloud
+            codebase or its app ecosystem uses.
+        -->
+        <MissingOverrideAttribute errorLevel="suppress"/>
+
+        <!--
+            Entities extend OCP\AppFramework\Db\Entity, whose columns are magic
+            properties generated from addType() calls, and the Anthropic SDK models
+            expose their block fields the same way.
+        -->
+        <UndefinedMagicPropertyFetch errorLevel="suppress"/>
+        <UndefinedMagicPropertyAssignment errorLevel="suppress"/>
+
+        <!--
+            The Anthropic SDK models declare non-nullable typed properties, so psalm
+            reads every `isset()`/`??` guard over a response field as redundant. PHP
+            typed properties can still be *uninitialized* — the SDK leaves optional
+            fields unset — and dropping the guards makes the SDK tests fatal with
+            "must not be accessed before initialization".
+        -->
+        <RedundantCondition>
+            <errorLevel type="suppress">
+                <file name="lib/Service/ClaudeSDKService.php"/>
+            </errorLevel>
+        </RedundantCondition>
+        <TypeDoesNotContainType>
+            <errorLevel type="suppress">
+                <file name="lib/Service/ClaudeSDKService.php"/>
+            </errorLevel>
+        </TypeDoesNotContainType>
+
+        <!--
+            IMG_* constants only exist when ext-gd is loaded. Nextcloud requires gd,
+            but the analysis environment need not have it, so keep the result the same
+            either way.
+        -->
+        <UndefinedConstant>
+            <errorLevel type="suppress">
+                <file name="lib/Service/ImageOptimizer.php"/>
+            </errorLevel>
+        </UndefinedConstant>
     </issueHandlers>
 </psalm>

--- a/nextcloud-app/psalm.xml
+++ b/nextcloud-app/psalm.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0"?>
-<psalm errorLevel="3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<!--
+    findUnusedIssueHandlerSuppression is off because some suppressions below are
+    environment-dependent: the ext-gd one fires only where gd is missing, so with
+    the check on, the run fails either on the constant or on the "unused"
+    suppression, depending on the machine.
+-->
+<psalm errorLevel="3" findUnusedIssueHandlerSuppression="false"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns="https://getpsalm.org/schema/config"
        xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd">
     <projectFiles>

--- a/nextcloud-app/tests/stubs/oc-global.php
+++ b/nextcloud-app/tests/stubs/oc-global.php
@@ -1,0 +1,23 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+/**
+ * Stub for Nextcloud's global `OC` class — the legacy service locator.
+ *
+ * It lives in its own file because the rest of the private-namespace stubs in
+ * {@see oc-private.php} are namespaced and PHP cannot mix namespaced and global
+ * declarations without braces.
+ *
+ * Only the two statics the app reads are stubbed: `OccController` needs
+ * `$SERVERROOT` to shell out to `occ`, and `CoworkerOutputWidget` needs
+ * `$server` for the CSP nonce. Nothing here has an `OCP\` equivalent.
+ */
+
+if (!class_exists(OC::class)) {
+    class OC {
+        public static string $SERVERROOT = '';
+        public static \OC\Server $server;
+    }
+}

--- a/nextcloud-app/tests/stubs/oc-private.php
+++ b/nextcloud-app/tests/stubs/oc-private.php
@@ -23,3 +23,37 @@ if (!interface_exists(Emitter::class)) {
     interface Emitter {
     }
 }
+
+namespace OC\Security\CSP;
+
+// Reached through OC::$server below; there is no OCP equivalent for the CSP
+// nonce, so the whole chain has to be stubbed.
+if (!class_exists(ContentSecurityPolicyNonceManager::class)) {
+    class ContentSecurityPolicyNonceManager {
+        public function getNonce(): string {
+            return '';
+        }
+    }
+}
+
+namespace OC;
+
+if (!class_exists(Server::class)) {
+    class Server {
+        public function getContentSecurityPolicyNonceManager(): \OC\Security\CSP\ContentSecurityPolicyNonceManager {
+            return new \OC\Security\CSP\ContentSecurityPolicyNonceManager();
+        }
+    }
+}
+
+namespace OC\Core\Command;
+
+// Base class of every `occ` command. It is private, so nextcloud/ocp does not
+// carry it, but lib/Command/*.php extends it. Stubbing it (rather than
+// suppressing UndefinedClass for lib/Command/) keeps those commands analysed
+// against the real Symfony Command signatures. None of our commands use any
+// Base-specific member beyond the constructor, so nothing else is stubbed.
+if (!class_exists(Base::class)) {
+    abstract class Base extends \Symfony\Component\Console\Command\Command {
+    }
+}


### PR DESCRIPTION
`nextcloud-app/psalm.xml` was committed but dead weight: `vimeo/psalm` was in neither `composer.json` nor `composer.lock`, no CI job ran it, and its `xsi:schemaLocation` pointed at a file that did not exist. #423 replaced the hand-written `OCP\*` stubs with the real `nextcloud/ocp` package — published specifically for static analysers — so the blocker is gone.

## Wiring

- `vimeo/psalm` in `require-dev` + a `composer psalm` script, run in the `nextcloud-app` job of `test.yml`
- `<extraFiles>vendor</extraFiles>` so psalm resolves `OCP\*` (the package ships no `autoload` section), plus `<stubs>` for the private `OC\` classes
- new stubs for `OC\Core\Command\Base` (the 4 `lib/Command/*` classes extend it) and the global `OC` class (`$SERVERROOT`, `$server`) — neither is in `nextcloud/ocp` and neither has an OCP equivalent
- issue classes a Nextcloud app structurally trips are suppressed with the reason recorded inline in `psalm.xml`: DI-built classes read as dead code, `Entity` magic properties, and the SDK's typed-but-uninitialized response properties. **No baseline file** — everything else is fixed.

## Bugs the first clean run surfaced

- **`UsageStatMapper` token totals always read 0.** `sumTokensByUser()`/`sumTokensByUserSince()` passed the column alias as a second argument to `IFunctionBuilder::sum()`, which takes one parameter. The aliases were silently dropped, so `$row['total_input']` was never set. Switched to the `selectAlias()` form the third method in that file already used.
- **Nullable user id into non-nullable parameters.** Controllers passed the container-injected `?string $userId` straight into mappers and `FileService`, which declare `string`. Routed through a new `RequiresUserIdTrait::requireUserId()`.
- **Controller `@return` docblocks were wrong**, omitting error statuses (`500`, `409`, `413`, `408`) and about half the fields actually returned (`userId`, `effort`, `thinking`, `projectId`, the whole settings payload). The regenerated OpenAPI spec is the bulk of the diff.
- Unchecked `json_encode()` / `preg_replace()` / `end()` / `stream_get_contents()` / `fopen()` results, and `TaskProcessing` provider inputs used without a type guard.

## Verification

```
composer psalm   # No errors found!
composer test    # 431 tests, 1315 assertions, 0 failures
vendor/bin/generate-spec && git diff --exit-code openapi*.json
```

Gate confirmed to bite: a deliberately wrong return type makes `composer psalm` exit 2.

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)