### PR TITLE
fix(nextcloud): ship production-only vendor tree in release tarball

### DIFF
--- a/.github/workflows/nc-release.yml
+++ b/.github/workflows/nc-release.yml
@@ -94,8 +94,21 @@ jobs:
       - name: Run tests
         working-directory: nextcloud-app
         run: |
-          composer install  # Install dev dependencies for testing
-          composer test || echo "Tests completed"
+          composer install --no-interaction  # dev dependencies needed for phpunit
+          composer test
+
+      # The test step above reinstalls dev dependencies into vendor/. Packaging copies
+      # vendor/ verbatim, so it must be reduced back to production-only first — shipping
+      # symfony/console, amphp/amp or doctrine/dbal breaks occ and other apps (GH #453).
+      - name: Restore production-only vendor tree
+        working-directory: nextcloud-app
+        run: |
+          rm -rf vendor
+          composer install --no-dev --optimize-autoloader --no-interaction
+
+      - name: Verify vendor contains no dev dependencies
+        working-directory: nextcloud-app
+        run: php tests/check-vendor-prod-only.php
 
       - name: Create app package
         run: |

--- a/docker/scripts/build-tarball.sh
+++ b/docker/scripts/build-tarball.sh
@@ -77,6 +77,7 @@ docker run --rm \
         echo "--- [5/5] Verifying build ---"
         test -f js/dist/aiquila-main.js || { echo "ERROR: js/dist/aiquila-main.js not found!"; exit 1; }
         test -d vendor || { echo "ERROR: vendor/ not found!"; exit 1; }
+        php tests/check-vendor-prod-only.php
         echo "Build verified."
 
         echo ""

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.3.34",
+      "version": "0.3.35",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "description": "Nextcloud MCP server — files, calendar, contacts, mail, maps, notes, tasks & 120+ more tools",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,7 +18,7 @@
       ]
     }
   ],
-  "version": "0.3.34",
+  "version": "0.3.35",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "remotes": [
     {
@@ -36,7 +36,7 @@
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.3.34",
+      "version": "0.3.35",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -64,7 +64,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.34",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.3.35",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.3.34</version>
+    <version>0.3.35</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",

--- a/nextcloud-app/tests/check-vendor-prod-only.php
+++ b/nextcloud-app/tests/check-vendor-prod-only.php
@@ -1,0 +1,72 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Guard against dev dependencies leaking into the packaged app.
+ *
+ * The release tarball ships vendor/ verbatim. Anything installed there that is not a
+ * production dependency (symfony/console, amphp/amp, doctrine/dbal, …) collides with
+ * Nextcloud core and other apps at runtime — see GH #453.
+ *
+ * Usage: php tests/check-vendor-prod-only.php [path-to-app-root]
+ */
+
+declare(strict_types=1);
+
+$root = rtrim($argv[1] ?? dirname(__DIR__), '/');
+$lockFile = $root . '/composer.lock';
+$vendorDir = $root . '/vendor';
+
+if (!is_file($lockFile)) {
+	fwrite(STDERR, "ERROR: composer.lock not found at {$lockFile}\n");
+	exit(1);
+}
+if (!is_dir($vendorDir)) {
+	fwrite(STDERR, "ERROR: vendor/ not found at {$vendorDir}\n");
+	exit(1);
+}
+
+$lock = json_decode((string)file_get_contents($lockFile), true, 512, JSON_THROW_ON_ERROR);
+$allowed = array_column($lock['packages'] ?? [], 'name');
+
+// composer's own bookkeeping dirs are not packages.
+$ignored = ['composer', 'bin'];
+
+$found = [];
+$unexpected = [];
+foreach (scandir($vendorDir) ?: [] as $ns) {
+	if ($ns === '.' || $ns === '..' || in_array($ns, $ignored, true)) {
+		continue;
+	}
+	$nsPath = $vendorDir . '/' . $ns;
+	if (!is_dir($nsPath)) {
+		continue;
+	}
+	foreach (scandir($nsPath) ?: [] as $pkg) {
+		if ($pkg === '.' || $pkg === '..' || !is_dir($nsPath . '/' . $pkg)) {
+			continue;
+		}
+		$name = $ns . '/' . $pkg;
+		$found[] = $name;
+		if (!in_array($name, $allowed, true)) {
+			$unexpected[] = $name;
+		}
+	}
+}
+
+if ($unexpected !== []) {
+	sort($unexpected);
+	fwrite(STDERR, "ERROR: vendor/ contains " . count($unexpected) . " package(s) that are not production dependencies:\n");
+	foreach ($unexpected as $name) {
+		fwrite(STDERR, "  - {$name}\n");
+	}
+	fwrite(STDERR, "\nRun: rm -rf vendor && composer install --no-dev --optimize-autoloader\n");
+	exit(1);
+}
+
+$missing = array_diff($allowed, $found);
+if ($missing !== []) {
+	fwrite(STDERR, "ERROR: vendor/ is missing production package(s): " . implode(', ', $missing) . "\n");
+	exit(1);
+}
+
+echo 'OK: vendor/ is production-only (' . count($found) . " packages)\n";


### PR DESCRIPTION
Closes #453

## Root cause

Not a scoping problem — **none of the colliding packages are production dependencies.**
`symfony/console`, `amphp/*` and `doctrine/dbal` come in only via `vimeo/psalm` and the
dev-only `doctrine/dbal` requirement.

The bug is step ordering in `.github/workflows/nc-release.yml`:

1. `Install PHP dependencies` → `composer install --no-dev --optimize-autoloader` ✅
2. `Run tests` → plain `composer install`, **re-adding every dev dependency to `vendor/`**
3. `Create app package` → `cp -r nextcloud-app/vendor ${TEMP_DIR}/`

Confirmed against the published artifact: `nc-v0.3.34/aiquila.tar.gz` (8.6 MB) contains
`vendor/amphp/amp/src/functions.php`, `vendor/symfony/console`, `vendor/doctrine/dbal`,
`vendor/vimeo/psalm`.

The local build path (`docker/scripts/build-tarball.sh`) was already correct, which is why
this never reproduced in `docker/installation`.

php-scoper is therefore not needed. The production set is 13 packages and collision-free:
`anthropic-ai/sdk`, `nyholm/psr7`, `php-http/discovery`, `psr/*`,
`standard-webhooks/standard-webhooks`, `symfony/http-client` (+ contracts).

## Changes

- **`nc-release.yml`**: restore a `--no-dev --optimize-autoloader` vendor tree after the
  test step, before packaging. Also dropped `|| echo "Tests completed"` — a release should
  not be cut from a red test run.
- **`nextcloud-app/tests/check-vendor-prod-only.php`** (new): fails the build if `vendor/`
  contains anything outside `composer.lock`'s `packages` array (allowlist derived from the
  lock file, so it can't go stale), or if a production package is missing. Wired into both
  the release workflow and `docker/scripts/build-tarball.sh` so the two paths can't drift.
- Version bump to **0.3.35** across both components.

## Verification

Tarball shrinks **8.6 MB → 1.7 MB**, containing exactly the 13 production packages:

```
$ tar -tzf aiquila.tar.gz | grep -E "vendor/(symfony/console|amphp|doctrine|vimeo|phpunit)/"
(no output)
```

Guard behaves: exit 1 listing all 71 dev packages on a dev `vendor/`, exit 0 on `--no-dev`.

Runtime check in `docker/installation` (NC 33.0.0.16, aiquila 0.3.35):

- `occ status` / `occ app:list` work — regression #1 gone
- `occ app:install mail` succeeds and `occ` still works with both apps enabled — #2 gone
- 15× `GET /login` → all `200`, 10× `PROPFIND /remote.php/dav/files/testuser/` → all `207`;
  zero `Cannot redeclare` / `must be compatible with` / `undefined method Symfony` in
  `nextcloud.log` or the Apache error log — #3 gone

`composer psalm` clean, `composer test` 453 tests / 1362 assertions passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)