### PR TITLE
fix(mcp): call occ aiquila:configure --show in aiquila_show_config

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Nextcloud MCP server — files, calendar, contacts, mail, maps, notes, tasks & 120+ more tools",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,7 +18,7 @@
       ]
     }
   ],
-  "version": "0.4.0",
+  "version": "0.4.1",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "remotes": [
     {
@@ -36,7 +36,7 @@
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -64,7 +64,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.4.0",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.4.1",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/__tests__/tools-aiquila.test.ts
+++ b/mcp-server/src/__tests__/tools-aiquila.test.ts
@@ -35,7 +35,7 @@ describe('AIquila Internal Tools', () => {
 
       expect(result.content[0].text).toContain('api_key');
       expect(result.content[0].text).toContain('model');
-      expect(mockExecuteOCC).toHaveBeenCalledWith('aiquila:show', []);
+      expect(mockExecuteOCC).toHaveBeenCalledWith('aiquila:configure', ['--show']);
     });
 
     it('should handle OCC failure', async () => {

--- a/mcp-server/src/tools/apps/aiquila.ts
+++ b/mcp-server/src/tools/apps/aiquila.ts
@@ -38,7 +38,7 @@ export const showConfigTool = {
   inputSchema: z.object({}),
   handler: async () => {
     try {
-      const output = await runOCC('aiquila:show');
+      const output = await runOCC('aiquila:configure', ['--show']);
       return {
         content: [
           {

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.4.0</version>
+    <version>0.4.1</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
## Problem

`aiquila_show_config` invoked `occ aiquila:show`, which does not exist. The AIquila app registers only `aiquila:configure`, `aiquila:doctor`, `aiquila:mcp:add` and `aiquila:test`; `show` is an **option** of `aiquila:configure` (`nextcloud-app/lib/Command/ConfigureCommand.php:87`, handled at `:96`). The tool failed for every user.

The unit test at `mcp-server/src/__tests__/tools-aiquila.test.ts:38` mocks `executeOCC` and asserted `toHaveBeenCalledWith('aiquila:show', [])`, so CI passed regardless.

## Changes

- `mcp-server/src/tools/apps/aiquila.ts:41` → `runOCC('aiquila:configure', ['--show'])`
- Corrected the test assertion so it locks in the right invocation
- Patch bump 0.4.0 → 0.4.1 across `mcp-server/package.json`, `server.json` (both version fields + ghcr.io image tag), `nextcloud-app/appinfo/info.xml`, `nextcloud-app/package.json`, lockfile synced

## Verification

`npm test` (869 passed / 55 files), `npm run lint` (0 errors), `npx prettier --check src/`, `npm run build` all pass.

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA1E1sXzYNHH5Nhvu2traU