### PR TITLE
fix(nextcloud): load entry CSS, register personal section, log provider settings

### DIFF
--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -61,6 +61,7 @@ Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](htt
         <admin>OCA\AIquila\Settings\AdminSettings</admin>
         <admin-section>OCA\AIquila\Settings\AdminSection</admin-section>
         <personal>OCA\AIquila\Settings\UserSettings</personal>
+        <personal-section>OCA\AIquila\Settings\PersonalSection</personal-section>
     </settings>
     <repair-steps>
         <post-migration>

--- a/nextcloud-app/lib/Controller/ProviderSettingsController.php
+++ b/nextcloud-app/lib/Controller/ProviderSettingsController.php
@@ -16,6 +16,7 @@ use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IConfig;
 use OCP\IRequest;
+use Psr\Log\LoggerInterface;
 
 /**
  * Schema-driven read/write of provider configuration for the settings pages.
@@ -42,6 +43,7 @@ class ProviderSettingsController extends Controller {
         private readonly LLMProviderFactory $providerFactory,
         private readonly ProviderSettingsService $providerSettings,
         private readonly CredentialService $credentials,
+        private readonly LoggerInterface $logger,
     ) {
         parent::__construct($appName, $request);
     }
@@ -108,14 +110,23 @@ class ProviderSettingsController extends Controller {
                 $values,
             );
         } catch (\InvalidArgumentException $e) {
+            $this->logger->warning('AIquila: rejected user settings for ' . $providerId . ': ' . $e->getMessage(), [
+                'provider' => $providerId,
+                'user' => $userId,
+            ]);
             return new JSONResponse(['status' => 'error', 'message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
         }
 
         if ($makeDefault === '1') {
             $this->config->setUserValue($userId, $this->appName, 'user_provider', $providerId);
+            $this->logger->info('AIquila: user default provider set to ' . $providerId, [
+                'provider' => $providerId,
+                'user' => $userId,
+            ]);
         } elseif ($makeDefault === '') {
             // Explicit "follow the instance default" rather than "leave alone".
             $this->config->deleteUserValue($userId, $this->appName, 'user_provider');
+            $this->logger->info('AIquila: user default provider cleared', ['user' => $userId]);
         }
 
         return new JSONResponse(['status' => 'ok', 'rejected' => $rejected]);
@@ -162,11 +173,17 @@ class ProviderSettingsController extends Controller {
                 $values,
             );
         } catch (\InvalidArgumentException $e) {
+            $this->logger->warning('AIquila: rejected instance settings for ' . $providerId . ': ' . $e->getMessage(), [
+                'provider' => $providerId,
+            ]);
             return new JSONResponse(['status' => 'error', 'message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
         }
 
         if ($makeDefault === '1') {
             $this->config->setAppValue($this->appName, 'provider', $providerId);
+            $this->logger->info('AIquila: instance default provider set to ' . $providerId, [
+                'provider' => $providerId,
+            ]);
         }
 
         return new JSONResponse(['status' => 'ok', 'rejected' => $rejected]);
@@ -188,13 +205,19 @@ class ProviderSettingsController extends Controller {
      * @return JSONResponse<Http::STATUS_OK, array{success: bool, message: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{success: bool, message: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{success: bool, message: string}, array{}>
      */
     #[OpenAPI(scope: OpenAPI::SCOPE_ADMINISTRATION)]
-    public function test(string $providerId, string $api_key = ''): JSONResponse {
+    public function test(string $providerId, #[\SensitiveParameter] string $api_key = ''): JSONResponse {
         if (!$this->providerFactory->isKnownProviderId($providerId)) {
             return new JSONResponse(
                 ['success' => false, 'message' => 'Unknown provider: ' . $providerId],
                 Http::STATUS_BAD_REQUEST,
             );
         }
+
+        $this->logger->info('AIquila: testing connection for ' . $providerId, [
+            'provider' => $providerId,
+            // Whether the key came from the form or from storage; never the key.
+            'usingUnsavedKey' => $api_key !== '',
+        ]);
 
         $service = $this->providerFactory->getProviderById($providerId);
         $testKey = $api_key !== '' ? $api_key : $this->credentials->getApiKey(null, $providerId);
@@ -223,12 +246,24 @@ class ProviderSettingsController extends Controller {
             $this->restoreKey($providerId, $originalKey);
 
             if (isset($result['error'])) {
+                $this->logger->warning('AIquila: connection test for ' . $providerId . ' failed', [
+                    'provider' => $providerId,
+                    'error' => $result['error'],
+                ]);
                 return new JSONResponse(['success' => false, 'message' => $result['error']], Http::STATUS_BAD_REQUEST);
             }
+
+            $this->logger->info('AIquila: connection test for ' . $providerId . ' succeeded', [
+                'provider' => $providerId,
+            ]);
 
             return new JSONResponse(['success' => true, 'message' => $result['response'] ?? '']);
         } catch (\Throwable $e) {
             $this->restoreKey($providerId, $originalKey);
+            $this->logger->error('AIquila: connection test for ' . $providerId . ' threw', [
+                'provider' => $providerId,
+                'exception' => $e,
+            ]);
             return new JSONResponse(
                 ['success' => false, 'message' => $e->getMessage()],
                 Http::STATUS_INTERNAL_SERVER_ERROR,
@@ -265,7 +300,7 @@ class ProviderSettingsController extends Controller {
      * original means there was none, so the slot is cleared rather than left
      * holding the test key.
      */
-    private function restoreKey(string $providerId, string $originalKey): void {
+    private function restoreKey(string $providerId, #[\SensitiveParameter] string $originalKey): void {
         if ($originalKey !== '') {
             $this->credentials->setApiKey(null, $originalKey, $providerId);
         } else {

--- a/nextcloud-app/lib/Dashboard/CoworkerOutputWidget.php
+++ b/nextcloud-app/lib/Dashboard/CoworkerOutputWidget.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 
 namespace OCA\AIquila\Dashboard;
 
-use OCP\App\IAppManager;
-use OCP\Server;
-use OCP\Util;
+use OCA\AIquila\Template\ViteAssets;
 
 /**
  * Configurable dashboard widget that renders the latest run summary of a
@@ -37,17 +35,6 @@ class CoworkerOutputWidget extends AbstractAIquilaWidget {
     }
 
     public function load(): void {
-        // The Vite build emits ES modules with code-split chunks, so the bundle
-        // must load as `type="module"` — Util::addScript would emit a classic
-        // <script> tag that cannot resolve the chunk imports. Mirror the SPA
-        // bootstrap in templates/main.php and inject a module header instead.
-        $version = Server::get(IAppManager::class)->getAppVersion(self::APP_ID);
-        $src = $this->urlGenerator->linkTo(self::APP_ID, 'js/dist/' . self::APP_ID . '-dashboard.js')
-            . '?v=' . $version;
-        Util::addHeader('script', [
-            'type' => 'module',
-            'src' => $src,
-            'nonce' => \OC::$server->getContentSecurityPolicyNonceManager()->getNonce(),
-        ], '');
+        ViteAssets::load(self::APP_ID . '-dashboard');
     }
 }

--- a/nextcloud-app/lib/Service/CredentialService.php
+++ b/nextcloud-app/lib/Service/CredentialService.php
@@ -87,9 +87,13 @@ class CredentialService {
     /**
      * Store API key in secure storage, removing any plaintext leftover.
      */
-    public function setApiKey(?string $userId, string $key, string $provider = self::DEFAULT_PROVIDER): void {
+    public function setApiKey(?string $userId, #[\SensitiveParameter] string $key, string $provider = self::DEFAULT_PROVIDER): void {
         $credUserId = $userId ?? '';
         $this->credentialsManager->store($credUserId, $this->credentialKey($provider), $key);
+        $this->logger->info('AIquila: API key stored for ' . $provider, [
+            'provider' => $provider,
+            'scope' => $userId === null ? 'admin' : 'user',
+        ]);
 
         // Clean up plaintext leftovers (legacy key only).
         if ($provider === self::DEFAULT_PROVIDER) {
@@ -107,6 +111,10 @@ class CredentialService {
     public function deleteApiKey(?string $userId, string $provider = self::DEFAULT_PROVIDER): void {
         $credUserId = $userId ?? '';
         $this->credentialsManager->delete($credUserId, $this->credentialKey($provider));
+        $this->logger->info('AIquila: API key cleared for ' . $provider, [
+            'provider' => $provider,
+            'scope' => $userId === null ? 'admin' : 'user',
+        ]);
 
         if ($provider === self::DEFAULT_PROVIDER) {
             if ($userId !== null) {

--- a/nextcloud-app/lib/Service/Provider/ProviderSettingsService.php
+++ b/nextcloud-app/lib/Service/Provider/ProviderSettingsService.php
@@ -8,6 +8,7 @@ namespace OCA\AIquila\Service\Provider;
 use OCA\AIquila\Service\CredentialService;
 use OCP\ICacheFactory;
 use OCP\IConfig;
+use Psr\Log\LoggerInterface;
 
 /**
  * Reads and writes provider configuration through the descriptors returned by
@@ -41,6 +42,7 @@ class ProviderSettingsService {
         private readonly IConfig $config,
         private readonly CredentialService $credentials,
         private readonly ICacheFactory $cacheFactory,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -126,6 +128,8 @@ class ProviderSettingsService {
             }
         }
 
+        $this->logWrite($provider->getId(), 'user', $plan, $rejected, $userId);
+
         return $rejected;
     }
 
@@ -173,6 +177,8 @@ class ProviderSettingsService {
         // An endpoint or key change invalidates whatever model list we cached.
         $this->forgetModels($provider->getId());
 
+        $this->logWrite($provider->getId(), 'admin', $plan, $rejected, null);
+
         return $rejected;
     }
 
@@ -195,6 +201,9 @@ class ProviderSettingsService {
 
         $models = $provider->listModels($userId);
         if ($models === null || $models === []) {
+            $this->logger->warning('AIquila: no live model list from ' . $provider->getId() . ', using the static registry', [
+                'provider' => $provider->getId(),
+            ]);
             // Do not cache the fallback: it is static anyway, and caching it
             // would keep a transient outage pinned for an hour.
             return $this->staticModels($provider);
@@ -215,6 +224,37 @@ class ProviderSettingsService {
     }
 
     // ── Internals ───────────────────────────────────────────────────────────
+
+    /**
+     * Record which fields a settings save touched. Values are deliberately
+     * absent: a plan entry with a null key is an API key, and even the
+     * non-sensitive ones can carry endpoint URLs an admin would not expect in
+     * the log. A rejection is logged at warning level because it means the UI
+     * offered a field the scope rules refuse — either a schema bug or an
+     * attempt to write an admin-only field from the personal page.
+     *
+     * @param list<array{key: ?string, value: string}> $plan
+     * @param list<string> $rejected
+     */
+    private function logWrite(string $providerId, string $scope, array $plan, array $rejected, ?string $userId): void {
+        $written = [];
+        foreach ($plan as $write) {
+            $written[] = $write['key'] ?? 'api_key';
+        }
+
+        $context = ['provider' => $providerId, 'scope' => $scope, 'fields' => $written];
+        if ($userId !== null) {
+            $context['user'] = $userId;
+        }
+
+        if ($written !== []) {
+            $this->logger->info('AIquila: ' . $scope . ' settings saved for ' . $providerId, $context);
+        }
+
+        if ($rejected !== []) {
+            $this->logger->warning('AIquila: rejected out-of-scope fields for ' . $providerId, $context + ['rejected' => $rejected]);
+        }
+    }
 
     /** @return array<string, array<string, mixed>> */
     private function indexSchema(LLMProviderInterface $provider): array {
@@ -284,7 +324,7 @@ class ProviderSettingsService {
         return $raw === '' ? '' : $this->decode($field, $raw);
     }
 
-    private function writeApiKey(string $providerId, ?string $userId, string $value): void {
+    private function writeApiKey(string $providerId, ?string $userId, #[\SensitiveParameter] string $value): void {
         if ($value === '') {
             $this->credentials->deleteApiKey($userId, $providerId);
             return;

--- a/nextcloud-app/lib/Settings/PersonalSection.php
+++ b/nextcloud-app/lib/Settings/PersonalSection.php
@@ -1,0 +1,44 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Settings;
+
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\Settings\IIconSection;
+
+/**
+ * Personal counterpart of {@see AdminSection}.
+ *
+ * Nextcloud keeps admin and personal sections in separate registries, so the
+ * `aiquila` id registered for the admin area does not place the personal form —
+ * without this class /settings/user/aiquila 404s and the entry never shows up
+ * in the personal settings navigation.
+ */
+class PersonalSection implements IIconSection {
+    private IL10N $l;
+    private IURLGenerator $urlGenerator;
+
+    public function __construct(IL10N $l, IURLGenerator $urlGenerator) {
+        $this->l = $l;
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public function getID(): string {
+        return 'aiquila';
+    }
+
+    public function getName(): string {
+        return $this->l->t('AIquila');
+    }
+
+    public function getPriority(): int {
+        return 80;
+    }
+
+    public function getIcon(): string {
+        return $this->urlGenerator->imagePath('aiquila', 'app-dark.svg');
+    }
+}

--- a/nextcloud-app/lib/Template/ViteAssets.php
+++ b/nextcloud-app/lib/Template/ViteAssets.php
@@ -1,0 +1,153 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Template;
+
+use OCA\AIquila\AppInfo\Application;
+use OCP\App\IAppManager;
+use OCP\IURLGenerator;
+use OCP\Server;
+use OCP\Util;
+
+/**
+ * Loads a Vite entry (module script + its stylesheets) into the page.
+ *
+ * Two things make this necessary instead of Util::addScript():
+ *
+ *  - The build emits ES modules with code-split chunks, and addScript() writes a
+ *    classic <script> tag under which those chunk imports never resolve.
+ *  - Vite only injects CSS automatically for *dynamically* imported chunks. The
+ *    stylesheet of an entry (and of the static chunks it pulls in, notably
+ *    vendor-nextcloud-vue) has to be linked by the host page, which is why the
+ *    settings pages rendered unstyled before this existed.
+ *
+ * The entry -> asset mapping comes from Vite's build manifest.
+ */
+final class ViteAssets {
+    private const MANIFEST = 'js/dist/manifest.json';
+
+    /** @var array<string, array<string, mixed>>|null */
+    private static ?array $manifest = null;
+
+    /**
+     * Emit the module script for $entry plus every stylesheet it depends on.
+     *
+     * @param string $entry Vite entry name, e.g. `aiquila-admin`.
+     */
+    public static function load(string $entry): void {
+        $urlGenerator = Server::get(IURLGenerator::class);
+        $version = Server::get(IAppManager::class)->getAppVersion(Application::APP_ID);
+
+        $url = static function (string $path) use ($urlGenerator, $version): string {
+            return $urlGenerator->linkTo(Application::APP_ID, 'js/dist/' . $path) . '?v=' . $version;
+        };
+
+        $manifest = self::manifest();
+        $key = self::manifestKey($manifest, $entry);
+
+        // Stylesheets first so the page never paints an unstyled frame.
+        foreach (self::stylesheets($manifest, $key) as $css) {
+            Util::addHeader('link', [
+                'rel' => 'stylesheet',
+                'href' => $url($css),
+            ], '');
+        }
+
+        // A build without a manifest still resolves because entryFileNames is
+        // `[name].js`; going unstyled beats a fatal error on a half-built tree.
+        $file = $key !== null && isset($manifest[$key]['file']) && is_string($manifest[$key]['file'])
+            ? $manifest[$key]['file']
+            : $entry . '.js';
+
+        Util::addHeader('script', [
+            'type' => 'module',
+            'src' => $url($file),
+            'nonce' => \OC::$server->getContentSecurityPolicyNonceManager()->getNonce(),
+        ], '');
+    }
+
+    /**
+     * CSS emitted for the entry and for the static chunks it imports, in
+     * dependency order (dependencies first) and de-duplicated.
+     *
+     * @param array<string, array<string, mixed>> $manifest
+     * @return list<string>
+     */
+    private static function stylesheets(array $manifest, ?string $key): array {
+        if ($key === null) {
+            return [];
+        }
+
+        $css = [];
+        self::collect($manifest, $key, $css, []);
+
+        return array_values(array_unique($css));
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $manifest
+     * @param list<string> $css
+     * @param list<string> $seen
+     * @param-out list<string> $css
+     */
+    private static function collect(array $manifest, string $key, array &$css, array $seen): void {
+        if (in_array($key, $seen, true) || !isset($manifest[$key])) {
+            return;
+        }
+        $seen[] = $key;
+        $chunk = $manifest[$key];
+
+        // Depth first: a chunk's imports are its dependencies, so their styles
+        // must come before its own for cascade order to match the module graph.
+        if (isset($chunk['imports']) && is_array($chunk['imports'])) {
+            foreach ($chunk['imports'] as $import) {
+                if (is_string($import)) {
+                    self::collect($manifest, $import, $css, $seen);
+                }
+            }
+        }
+
+        if (isset($chunk['css']) && is_array($chunk['css'])) {
+            foreach ($chunk['css'] as $file) {
+                if (is_string($file)) {
+                    $css[] = $file;
+                }
+            }
+        }
+    }
+
+    /**
+     * Manifest keys are source paths (`src/admin.js`), so match on the chunk
+     * name rather than guessing the path.
+     *
+     * @param array<string, array<string, mixed>> $manifest
+     */
+    private static function manifestKey(array $manifest, string $entry): ?string {
+        foreach ($manifest as $key => $chunk) {
+            if (($chunk['isEntry'] ?? false) === true && ($chunk['name'] ?? null) === $entry) {
+                return $key;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private static function manifest(): array {
+        if (self::$manifest !== null) {
+            return self::$manifest;
+        }
+
+        $path = Server::get(IAppManager::class)->getAppPath(Application::APP_ID) . '/' . self::MANIFEST;
+        $raw = is_readable($path) ? file_get_contents($path) : false;
+        $decoded = $raw === false ? null : json_decode($raw, true);
+
+        self::$manifest = is_array($decoded) ? $decoded : [];
+
+        return self::$manifest;
+    }
+}

--- a/nextcloud-app/templates/admin.php
+++ b/nextcloud-app/templates/admin.php
@@ -1,19 +1,6 @@
 <?php
 /** @var array $_ */
-$appId = OCA\AIquila\AppInfo\Application::APP_ID;
-
-// The page is a Vue app; everything it renders comes from the provider settings
-// schema over /api/admin/providers, so there is nothing to build server-side.
-//
-// Loaded as an ES module like templates/main.php: `Util::addScript` emits a
-// classic <script> tag, under which the bundle's chunk imports never resolve.
-$scriptUrl = \OC::$server->getURLGenerator()->linkTo($appId, 'js/dist/aiquila-admin.js')
-    . '?v=' . \OCP\Server::get(\OCP\App\IAppManager::class)->getAppVersion($appId);
-\OCP\Util::addHeader('script', [
-    'type' => 'module',
-    'src' => $scriptUrl,
-    'nonce' => \OC::$server->getContentSecurityPolicyNonceManager()->getNonce(),
-], '');
+\OCA\AIquila\Template\ViteAssets::load('aiquila-admin');
 ?>
 
 <div id="aiquila-admin-settings"

--- a/nextcloud-app/templates/main.php
+++ b/nextcloud-app/templates/main.php
@@ -1,15 +1,5 @@
 <?php
-$appId = OCA\AIquila\AppInfo\Application::APP_ID;
-
-// Load the Vite entry as an ES module so its emitted chunk imports work.
-// `Util::addScript` emits a classic <script> tag and cannot load modules.
-$scriptUrl = \OC::$server->getURLGenerator()->linkTo($appId, 'js/dist/aiquila-main.js')
-    . '?v=' . \OCP\Server::get(\OCP\App\IAppManager::class)->getAppVersion($appId);
-\OCP\Util::addHeader('script', [
-    'type' => 'module',
-    'src' => $scriptUrl,
-    'nonce' => \OC::$server->getContentSecurityPolicyNonceManager()->getNonce(),
-], '');
+\OCA\AIquila\Template\ViteAssets::load('aiquila-main');
 ?>
 
 <div id="aiquila-app"></div>

--- a/nextcloud-app/templates/user.php
+++ b/nextcloud-app/templates/user.php
@@ -1,16 +1,6 @@
 <?php
 /** @var array $_ */
-$appId = OCA\AIquila\AppInfo\Application::APP_ID;
-
-// See templates/admin.php: the bundle is an ES module, so it needs a
-// type="module" tag rather than Util::addScript's classic one.
-$scriptUrl = \OC::$server->getURLGenerator()->linkTo($appId, 'js/dist/aiquila-personal.js')
-    . '?v=' . \OCP\Server::get(\OCP\App\IAppManager::class)->getAppVersion($appId);
-\OCP\Util::addHeader('script', [
-    'type' => 'module',
-    'src' => $scriptUrl,
-    'nonce' => \OC::$server->getContentSecurityPolicyNonceManager()->getNonce(),
-], '');
+\OCA\AIquila\Template\ViteAssets::load('aiquila-personal');
 ?>
 
 <div id="aiquila-personal-settings" class="section"></div>

--- a/nextcloud-app/tests/Unit/ProviderSettingsServiceTest.php
+++ b/nextcloud-app/tests/Unit/ProviderSettingsServiceTest.php
@@ -10,6 +10,7 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class ProviderSettingsServiceTest extends TestCase {
     private $config;
@@ -25,7 +26,12 @@ class ProviderSettingsServiceTest extends TestCase {
         $this->cache = $this->createMock(ICache::class);
         $this->cacheFactory->method('createDistributed')->willReturn($this->cache);
 
-        $this->service = new ProviderSettingsService($this->config, $this->credentials, $this->cacheFactory);
+        $this->service = new ProviderSettingsService(
+            $this->config,
+            $this->credentials,
+            $this->cacheFactory,
+            $this->createMock(LoggerInterface::class),
+        );
     }
 
     /**

--- a/nextcloud-app/vite.config.js
+++ b/nextcloud-app/vite.config.js
@@ -19,6 +19,12 @@ export default defineConfig({
 	build: {
 		outDir: 'js/dist',
 		emptyOutDir: true,
+		// Vite auto-injects CSS only for dynamically imported chunks; entry
+		// stylesheets have to be linked by the host page. The manifest is how
+		// lib/Template/ViteAssets.php finds them. Written to js/dist/manifest.json
+		// rather than Vite's default js/dist/.vite/ so packaging cannot drop it
+		// as a dotfile.
+		manifest: 'manifest.json',
 		// `vendor-nextcloud-vue` alone is ~800 KB and is the floor we can't shrink
 		// without dropping @nextcloud/vue; raise the warning so other regressions
 		// stay visible.


### PR DESCRIPTION
## Why

Three defects on the settings surface, found while looking into "tabs and cards render wrong":

1. **Both settings pages rendered unstyled.** Vite only auto-injects CSS for *dynamically* imported chunks. An entry's stylesheet — and that of the static chunks it pulls in, notably `vendor-nextcloud-vue` (140 KB) — must be linked by the host page, and nothing ever did. All four bundles (`main`, `dashboard`, `admin`, `personal`) loaded with zero styles, which is why the tab bar collapsed into plain stacked radios and the provider cards lost their card lhttps://cloud.witiko.de/settings/user/aiquilaayout.
2. **`/settings/user/aiquila` 404'd and never appeared in the personal settings nav.** `info.xml` registered a `<personal>` form pointing at section id `aiquila`, but Nextcloud keeps admin and personal sections in separate registries and only the admin section was registered.
3. **Provider settings paths were silent.** The controller, `ProviderSettingsService` and `CredentialService` logged nothing — saves, rejected out-of-scope fields, credential writes and connection tests left no trace.

## What changed

- `vite.config.js` emits a build manifest (at `js/dist/manifest.json` rather than Vite's default dotfile directory, so packaging cannot drop it).
- New `lib/Template/ViteAssets.php` resolves an entry's full CSS dependency graph from that manifest, depth-first so dependency styles come first, and emits the stylesheet links plus the module script. It also absorbs the module-script boilerplate that was duplicated across three templates and the dashboard widget. A build with no manifest degrades to script-only rather than fataling.
- New `lib/Settings/PersonalSection.php` mirroring `AdminSection`, wired via `<personal-section>` in `info.xml`.
- Logging at info/warning across the provider settings paths — provider id, scope and *field names*, never values.
- **Incidental security fix:** while checking the new logs for leaks, PHP stack traces turned out to carry the raw API key as a function argument. The key parameters are now marked `#[\SensitiveParameter]`, and traces print `Object(SensitiveParameterValue)` instead.

## Verification

Psalm clean, 477 tests pass, OpenAPI spec unchanged. Deployed to `docker/installation` and checked against the live stack:

- `/settings/user/aiquila` → **200** (was 404) and renders in the personal nav as `data-section-type="personal"`.
- Both settings pages and the main app now emit their `<link rel="stylesheet">` tags; every referenced CSS file serves 200.
- Saving settings, changing the default provider and running a connection test each produce the expected log lines.
- A test with key `sk-leaktest-9988776655` yields **0** occurrences of the key in `nextcloud.log`, with `Object(SensitiveParameterValue)` in its place. Before the fix the same probe leaked the key twice.

## Not included

Filed separately: per-user/group provider assignment, and live status lights on the provider cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
