### PR TITLE
feat(nextcloud): per-user/group provider access control

### DIFF
--- a/docs/dev/provider-settings.md
+++ b/docs/dev/provider-settings.md
@@ -35,10 +35,25 @@ The descriptor carries its own config keys, so key naming stays with the
 provider that owns it — `ProviderSettingsService` reads and writes purely from
 the descriptor and never names a provider.
 
-Types: `text`, `number`, `password`, `select`, `checkbox`, `url`.
+Types: `text`, `number`, `password`, `select`, `checkbox`, `url`, `multiselect`.
 Groups: `basic` renders inline on the card, `advanced` behind a disclosure.
 A select whose `options` is the sentinel `@models` is expanded to the provider's
-live model list (cached, with the static registry as fallback).
+live model list (cached, with the static registry as fallback); a `multiselect`
+whose `options` is `@principals` is a user/group picker that queries
+`/api/admin/principals` as the admin types.
+
+## Fields no provider declares
+
+The four access lists — allowed/blocked users and groups — are not part of any
+provider's `getSettingsSchema()`. Access control is a property of the app, not of
+a provider, so `ProviderSettingsService::schemaFor()` appends
+`ProviderSettingsSchema::accessLists()` to every provider's schema. A new
+provider gets them automatically and cannot forget them.
+
+They carry `storage => 'access'` instead of a config key: `describe()` fills
+their value from `ProviderAccessService::getLists()` and `writeAdmin()` routes
+them to `setLists()` rather than `IConfig`. Being `SCOPE_ADMIN`, they are
+filtered off the personal page by the ordinary scope rules.
 
 ## Scope is a security boundary
 

--- a/docs/internal-api.md
+++ b/docs/internal-api.md
@@ -286,6 +286,36 @@ guard to use before acting on any provider id that came from a request —
 `getProviderById()` deliberately falls back to Anthropic for unknown ids, which
 is right for a stale config value but would mask a bad request.
 
+### Provider access control
+
+Each provider carries four lists an admin edits under **Access** on its card in
+the admin settings: allowed users, allowed groups, blocked users, blocked
+groups. They are stored in `aiquila_provider_access` (one row per principal) and
+interpreted by `ProviderAccessService`:
+
+- An empty allow-list means **everyone**.
+- **A block always wins**, whether it names the user or one of their groups.
+- A `null` user id — CLI, background job, admin settings — is unrestricted.
+
+Every level of provider resolution runs through the check, including the
+instance default: if the default is blocked for a user, resolution falls through
+to the first provider they may actually use rather than handing back one they
+cannot. If nothing is left, `getActiveProviderId()` throws
+`NoPermittedProviderException` and the endpoints answer **403** — provider
+resolution fails closed rather than serving a blocked provider.
+
+Two methods matter for callers:
+
+- `isAllowedForUser($id, $userId)` — check before persisting a provider id that
+  came from a request (conversation pin, coworker pin, personal settings).
+- `getProviderForUser($userId, $pinnedId)` — resolve a *stored* pin. Permissions
+  can be revoked after a pin is made, so a pin the user may no longer use
+  degrades to their current provider instead of continuing to be honoured. Use
+  this rather than `getProviderById()` on any stored id.
+
+`GET /api/admin/principals?search=` backs the user/group pickers; it is
+admin-only.
+
 ## Error Handling
 
 Always check for errors in the response:

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Nextcloud MCP server — files, calendar, contacts, mail, maps, notes, tasks & 120+ more tools",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,7 +18,7 @@
       ]
     }
   ],
-  "version": "0.4.1",
+  "version": "0.4.2",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "remotes": [
     {
@@ -36,7 +36,7 @@
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -64,7 +64,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.4.1",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.4.2",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.4.1</version>
+    <version>0.4.2</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/appinfo/routes.php
+++ b/nextcloud-app/appinfo/routes.php
@@ -41,6 +41,8 @@ return [
         ['name' => 'provider_settings#adminIndex',  'url' => '/api/admin/providers',                  'verb' => 'GET'],
         ['name' => 'provider_settings#adminUpdate', 'url' => '/api/admin/providers/{providerId}',     'verb' => 'POST'],
         ['name' => 'provider_settings#test',        'url' => '/api/admin/providers/{providerId}/test', 'verb' => 'POST'],
+        // Backs the user/group pickers on the per-provider access lists.
+        ['name' => 'provider_settings#principals',  'url' => '/api/admin/principals',                 'verb' => 'GET'],
         ['name' => 'occ#execute', 'url' => '/api/occ', 'verb' => 'POST'],
 
         // MCP Server Admin API

--- a/nextcloud-app/lib/Controller/ChatController.php
+++ b/nextcloud-app/lib/Controller/ChatController.php
@@ -18,6 +18,7 @@ use OCA\AIquila\Service\McpClientService;
 use OCA\AIquila\Service\NativeMcpService;
 use OCA\AIquila\Service\Provider\LLMProviderFactory;
 use OCA\AIquila\Service\Provider\LLMProviderInterface;
+use OCA\AIquila\Service\Provider\NoPermittedProviderException;
 
 class ChatController extends Controller {
     use RequiresUserIdTrait;
@@ -59,9 +60,30 @@ class ChatController extends Controller {
         $this->cache = $cacheFactory->createDistributed('aiquila_ratelimit');
     }
 
-    /** The LLM provider active for the current user. */
+    /**
+     * The LLM provider active for the current user.
+     *
+     * @throws NoPermittedProviderException when the admin has blocked every
+     *         provider for this user; each endpoint checks noProviderAvailable()
+     *         up front so this never escapes as a 500.
+     */
     private function provider(): LLMProviderInterface {
         return $this->providerFactory->getProvider($this->userId);
+    }
+
+    /**
+     * Fail closed when no provider is permitted, or null to carry on.
+     *
+     * @return JSONResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|null
+     */
+    private function noProviderAvailable(): ?JSONResponse {
+        if ($this->providerFactory->hasPermittedProvider($this->userId)) {
+            return null;
+        }
+        return new JSONResponse(
+            ['error' => NoPermittedProviderException::USER_MESSAGE],
+            Http::STATUS_FORBIDDEN,
+        );
     }
 
     /**
@@ -97,16 +119,21 @@ class ChatController extends Controller {
      * 400: No prompt was provided
      * 404: One of the attached files was not found
      * 413: Prompt or context exceeds the 5 MB content limit
+     * 403: No provider is permitted for this user
      * 429: Rate limit exceeded (10 requests per minute)
      * 500: An attached file could not be read
      *
-     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_TOO_MANY_REQUESTS, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_TOO_MANY_REQUESTS, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
      *
      * @NoAdminRequired
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function ask(string $prompt = '', string $context = '', array $files = []): JSONResponse {
+        if (($denied = $this->noProviderAvailable()) !== null) {
+            return $denied;
+        }
+
         if (!$this->checkRateLimit()) {
             return new JSONResponse([
                 'error' => 'Rate limit exceeded. Maximum ' . self::RATE_LIMIT_REQUESTS . ' requests per minute.'
@@ -137,7 +164,7 @@ class ChatController extends Controller {
      *
      * @param list<string> $files
      *
-     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
      */
     private function askWithFiles(string $prompt, array $files): JSONResponse {
         $fileDataList = [];
@@ -301,15 +328,20 @@ class ChatController extends Controller {
      * 200: Claude response with model info and token usage
      * 400: Messages array is missing or empty
      * 413: Combined message content exceeds the 5 MB content limit
+     * 403: No provider is permitted for this user
      * 429: Rate limit exceeded (10 requests per minute)
      *
-     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_TOO_MANY_REQUESTS, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_TOO_MANY_REQUESTS, array{error: string}, array{}>
      *
      * @NoAdminRequired
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function chat(array $messages = [], ?string $system = null, array $options = []): JSONResponse {
+        if (($denied = $this->noProviderAvailable()) !== null) {
+            return $denied;
+        }
+
         if (!$this->checkRateLimit()) {
             return new JSONResponse([
                 'error' => 'Rate limit exceeded. Maximum ' . self::RATE_LIMIT_REQUESTS . ' requests per minute.'
@@ -389,15 +421,20 @@ class ChatController extends Controller {
      * 200: Claude summary with model info and token usage
      * 400: No content was provided
      * 413: Content exceeds the 5 MB content limit
+     * 403: No provider is permitted for this user
      * 429: Rate limit exceeded (10 requests per minute)
      *
-     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_TOO_MANY_REQUESTS, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_TOO_MANY_REQUESTS, array{error: string}, array{}>
      *
      * @NoAdminRequired
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function summarize(string $content = ''): JSONResponse {
+        if (($denied = $this->noProviderAvailable()) !== null) {
+            return $denied;
+        }
+
         if (!$this->checkRateLimit()) {
             return new JSONResponse([
                 'error' => 'Rate limit exceeded. Maximum ' . self::RATE_LIMIT_REQUESTS . ' requests per minute.'
@@ -428,15 +465,20 @@ class ChatController extends Controller {
      * 400: No filePath provided or prompt is invalid
      * 404: File not found at the given path
      * 413: Prompt exceeds the 5 MB content limit
+     * 403: No provider is permitted for this user
      * 429: Rate limit exceeded (10 requests per minute)
      *
-     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_TOO_MANY_REQUESTS, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{response: string, model: string, usage: array{input_tokens: int, output_tokens: int}}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_REQUEST_ENTITY_TOO_LARGE, array{error: string}, array{}>|JSONResponse<Http::STATUS_TOO_MANY_REQUESTS, array{error: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
      *
      * @NoAdminRequired
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function analyzeFile(string $filePath = '', string $prompt = 'Analyze and describe this file.'): JSONResponse {
+        if (($denied = $this->noProviderAvailable()) !== null) {
+            return $denied;
+        }
+
         if (!$this->checkRateLimit()) {
             return new JSONResponse([
                 'error' => 'Rate limit exceeded. Maximum ' . self::RATE_LIMIT_REQUESTS . ' requests per minute.'

--- a/nextcloud-app/lib/Controller/ConversationController.php
+++ b/nextcloud-app/lib/Controller/ConversationController.php
@@ -22,6 +22,7 @@ use OCA\AIquila\Service\McpClientService;
 use OCA\AIquila\Service\NativeMcpService;
 use OCA\AIquila\Service\Provider\LLMProviderFactory;
 use OCA\AIquila\Service\Provider\LLMProviderInterface;
+use OCA\AIquila\Service\Provider\NoPermittedProviderException;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
@@ -124,8 +125,9 @@ class ConversationController extends Controller {
      *
      * 200: The created conversation
      * 400: Unknown provider
+     * 403: The provider is not permitted for this user
      *
-     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
@@ -136,12 +138,21 @@ class ConversationController extends Controller {
         if ($provider !== null && $provider !== '' && !$this->providerFactory->isKnownProviderId($provider)) {
             return new JSONResponse(['error' => 'Unknown provider: ' . $provider], 400);
         }
+        // Pinning is a provider-selecting path like any other, so it is subject
+        // to the same access rules as the settings pages.
+        if ($provider !== null && $provider !== '' && !$this->providerFactory->isAllowedForUser($provider, $this->userId)) {
+            return $this->forbiddenProvider($provider);
+        }
 
         $now = time();
         $pinned = ($provider !== null && $provider !== '') ? $provider : null;
-        $service = $pinned !== null
-            ? $this->providerFactory->getProviderById($pinned)
-            : $this->providerFactory->getProvider($this->userId);
+        try {
+            $service = $pinned !== null
+                ? $this->providerFactory->getProviderById($pinned)
+                : $this->providerFactory->getProvider($this->userId);
+        } catch (NoPermittedProviderException $e) {
+            return $this->noProviderAvailable();
+        }
 
         $conversation = new Conversation();
         $conversation->setUserId($this->requireUserId());
@@ -168,13 +179,17 @@ class ConversationController extends Controller {
      *
      * 200: Updated conversation
      * 400: Unknown provider
+     * 403: The provider is not permitted for this user
      * 404: Conversation not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function setModel(int $id, ?string $provider = null, ?string $model = null): JSONResponse {
+        if (!$this->providerFactory->hasPermittedProvider($this->userId)) {
+            return $this->noProviderAvailable();
+        }
         try {
             $conversation = $this->conversationMapper->findByIdAndUser($id, $this->requireUserId());
         } catch (DoesNotExistException $e) {
@@ -184,6 +199,9 @@ class ConversationController extends Controller {
         if ($provider !== null) {
             if ($provider !== '' && !$this->providerFactory->isKnownProviderId($provider)) {
                 return new JSONResponse(['error' => 'Unknown provider: ' . $provider], 400);
+            }
+            if ($provider !== '' && !$this->providerFactory->isAllowedForUser($provider, $this->userId)) {
+                return $this->forbiddenProvider($provider);
             }
             $conversation->setProvider($provider === '' ? null : $provider);
 
@@ -253,13 +271,17 @@ class ConversationController extends Controller {
      *
      * 200: Updated conversation
      * 400: Invalid effort or thinking value
+     * 403: No provider is permitted for this user
      * 404: Conversation not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string, allowed: list<string>}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string, allowed: list<string>}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function update(int $id, string $title = '', ?int $projectId = null, ?string $effort = null, ?string $thinking = null): JSONResponse {
+        if (!$this->providerFactory->hasPermittedProvider($this->userId)) {
+            return $this->noProviderAvailable();
+        }
         try {
             $conversation = $this->conversationMapper->findByIdAndUser($id, $this->requireUserId());
         } catch (DoesNotExistException $e) {
@@ -357,13 +379,17 @@ class ConversationController extends Controller {
      *
      * 200: User message and assistant response
      * 400: No prompt provided
+     * 403: No provider is permitted for this user
      * 404: Conversation not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{userMessage: array<string, mixed>, assistantMessage: array<string, mixed>, conversation: array<string, mixed>}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{userMessage: array<string, mixed>, assistantMessage: array<string, mixed>, conversation: array<string, mixed>}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function message(int $id, string $prompt = '', array $files = []): JSONResponse {
+        if (!$this->providerFactory->hasPermittedProvider($this->userId)) {
+            return $this->noProviderAvailable();
+        }
         if (!$prompt && empty($files)) {
             return new JSONResponse(['error' => 'No prompt provided'], 400);
         }
@@ -568,6 +594,9 @@ class ConversationController extends Controller {
     public function messageStream(int $id, string $prompt = '', array $files = []): Response {
         if (!$prompt && empty($files)) {
             return new JSONResponse(['error' => 'No prompt provided'], 400);
+        }
+        if (!$this->providerFactory->hasPermittedProvider($this->userId)) {
+            return $this->noProviderAvailable();
         }
         try {
             $this->conversationMapper->findByIdAndUser($id, $this->requireUserId());
@@ -816,8 +845,16 @@ class ConversationController extends Controller {
         $newConv->setTitle(($original->getTitle() ?? '') . ' (copy)');
         $newConv->setModel($original->getModel());
         // The copy must answer like the original: carry the pinned provider and
-        // the per-conversation overrides, not just the model.
-        $newConv->setProvider($original->getProvider());
+        // the per-conversation overrides, not just the model. A pin the user is
+        // no longer permitted to use is dropped rather than copied forward, so
+        // the copy follows their current setting instead of carrying a denied
+        // provider into a brand-new conversation.
+        $originalProvider = $original->getProvider();
+        $newConv->setProvider(
+            $originalProvider !== null && $this->providerFactory->isAllowedForUser($originalProvider, $this->userId)
+                ? $originalProvider
+                : null,
+        );
         $newConv->setEffort($original->getEffort());
         $newConv->setThinking($original->getThinking());
         $newConv->setProjectId($original->getProjectId());
@@ -988,19 +1025,38 @@ class ConversationController extends Controller {
     }
 
     /**
+     * @return JSONResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>
+     */
+    private function forbiddenProvider(string $providerId): JSONResponse {
+        return new JSONResponse(
+            ['error' => 'You are not permitted to use this provider: ' . $providerId],
+            Http::STATUS_FORBIDDEN,
+        );
+    }
+
+    /**
+     * @return JSONResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>
+     */
+    private function noProviderAvailable(): JSONResponse {
+        return new JSONResponse(
+            ['error' => NoPermittedProviderException::USER_MESSAGE],
+            Http::STATUS_FORBIDDEN,
+        );
+    }
+
+    /**
      * The provider that should serve a conversation.
      *
      * A pinned provider wins; null falls back to the user's current setting,
-     * which is what every pre-existing conversation does. getProviderById() is
-     * safe here because the stored id was validated on the way in — a value
-     * that later stops being registered degrades to Anthropic rather than
-     * breaking the conversation.
+     * which is what every pre-existing conversation does. getProviderForUser()
+     * degrades rather than fails: a pin that later stops being registered — or
+     * that the admin has since blocked for this user — falls back to the user's
+     * current provider instead of continuing to be honoured.
+     *
+     * @throws NoPermittedProviderException when every provider is blocked
      */
     private function resolveProvider(Conversation $conversation): LLMProviderInterface {
-        $pinned = $conversation->getProvider();
-        return $pinned !== null && $pinned !== ''
-            ? $this->providerFactory->getProviderById($pinned)
-            : $this->providerFactory->getProvider($this->userId);
+        return $this->providerFactory->getProviderForUser($this->userId, $conversation->getProvider());
     }
 
     /**

--- a/nextcloud-app/lib/Controller/PageController.php
+++ b/nextcloud-app/lib/Controller/PageController.php
@@ -8,6 +8,7 @@ namespace OCA\AIquila\Controller;
 use OCA\AIquila\Db\Conversation;
 use OCA\AIquila\Db\ConversationMapper;
 use OCA\AIquila\Service\Provider\LLMProviderFactory;
+use OCA\AIquila\Service\Provider\NoPermittedProviderException;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
@@ -46,15 +47,28 @@ class PageController extends Controller {
      */
     public function index(): TemplateResponse {
         // Inject initial state for JavaScript, reflecting the active provider.
-        $provider = $this->providerFactory->getProvider($this->userId);
-        $config = $provider->getConfiguration();
+        // An admin can block every provider for a user; the page still has to
+        // render, so it reports the empty state rather than failing, and the
+        // frontend shows the message instead of a chat box.
+        try {
+            $provider = $this->providerFactory->getProvider($this->userId);
+            $config = $provider->getConfiguration();
 
-        $this->initialState->provideInitialState('config', [
-            'provider'    => $provider->getId(),
-            'model'       => $provider->getModel($this->userId),
-            'max_tokens'  => $config['max_tokens'],
-            'has_api_key' => $provider->isConfigured($this->userId),
-        ]);
+            $this->initialState->provideInitialState('config', [
+                'provider'    => $provider->getId(),
+                'model'       => $provider->getModel($this->userId),
+                'max_tokens'  => $config['max_tokens'],
+                'has_api_key' => $provider->isConfigured($this->userId),
+            ]);
+        } catch (NoPermittedProviderException $e) {
+            $this->initialState->provideInitialState('config', [
+                'provider'    => '',
+                'model'       => '',
+                'max_tokens'  => 0,
+                'has_api_key' => false,
+                'no_provider' => NoPermittedProviderException::USER_MESSAGE,
+            ]);
+        }
 
         $this->initialState->provideInitialState('conversations',
             array_map(

--- a/nextcloud-app/lib/Controller/ProviderSettingsController.php
+++ b/nextcloud-app/lib/Controller/ProviderSettingsController.php
@@ -8,6 +8,7 @@ namespace OCA\AIquila\Controller;
 use OCA\AIquila\Service\CredentialService;
 use OCA\AIquila\Service\Provider\LLMProviderFactory;
 use OCA\AIquila\Service\Provider\LocalProvider;
+use OCA\AIquila\Service\Provider\NoPermittedProviderException;
 use OCA\AIquila\Service\Provider\ProviderSettingsService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -15,7 +16,9 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IConfig;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -31,6 +34,10 @@ use Psr\Log\LoggerInterface;
  * is not user-writable. That second check is what keeps endpoint URLs — which
  * decide where the server sends outbound requests — out of reach of the
  * personal page even if a route were ever mis-annotated.
+ *
+ * Provider *access* is enforced on top of that: index() only describes providers
+ * the current user is permitted to use, and update() refuses one they are not,
+ * so the personal page can neither see nor select a provider an admin blocked.
  */
 class ProviderSettingsController extends Controller {
     use RequiresUserIdTrait;
@@ -43,6 +50,8 @@ class ProviderSettingsController extends Controller {
         private readonly LLMProviderFactory $providerFactory,
         private readonly ProviderSettingsService $providerSettings,
         private readonly CredentialService $credentials,
+        private readonly IUserManager $userManager,
+        private readonly IGroupManager $groupManager,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct($appName, $request);
@@ -67,8 +76,22 @@ class ProviderSettingsController extends Controller {
     #[NoAdminRequired]
     #[OpenAPI]
     public function index(?string $refresh = null): JSONResponse {
+        try {
+            $defaultProvider = $this->providerFactory->getActiveProviderId($this->userId);
+        } catch (NoPermittedProviderException $e) {
+            // Every provider is blocked for this user. Report that honestly —
+            // an empty list with no default — rather than naming one they
+            // cannot use.
+            return new JSONResponse([
+                'defaultProvider' => '',
+                'userProvider' => '',
+                'adminProvider' => '',
+                'providers' => [],
+            ]);
+        }
+
         return new JSONResponse([
-            'defaultProvider' => $this->providerFactory->getActiveProviderId($this->userId),
+            'defaultProvider' => $defaultProvider,
             'userProvider' => $this->config->getUserValue((string)$this->userId, $this->appName, 'user_provider', ''),
             'adminProvider' => $this->config->getAppValue($this->appName, 'provider', LLMProviderFactory::DEFAULT_PROVIDER),
             'providers' => $this->describeAll(admin: false, refresh: $refresh === '1'),
@@ -89,8 +112,9 @@ class ProviderSettingsController extends Controller {
      *
      * 200: Settings saved
      * 400: Unknown provider or invalid value
+     * 403: The provider is not permitted for this user
      *
-     * @return JSONResponse<Http::STATUS_OK, array{status: string, rejected: list<string>}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{status: string, message: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{status: string, rejected: list<string>}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{status: string, message: string}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{status: string, message: string}, array{}>
      *
      * @NoAdminRequired
      */
@@ -102,6 +126,13 @@ class ProviderSettingsController extends Controller {
         }
 
         $userId = $this->requireUserId();
+
+        // Access is checked before anything is written, and before the provider
+        // can be made the user's default — the personal page never offers a
+        // blocked provider, so reaching here means a hand-made request.
+        if (!$this->providerFactory->isAllowedForUser($providerId, $userId)) {
+            return $this->forbiddenProvider($providerId, $userId);
+        }
 
         try {
             $rejected = $this->providerSettings->writeUser(
@@ -271,12 +302,55 @@ class ProviderSettingsController extends Controller {
         }
     }
 
+    /**
+     * Search users and groups for the provider access lists
+     *
+     * Backs the principal pickers on the admin settings page. Admin-only: the
+     * personal page has no access fields, and an unprivileged user has no reason
+     * to enumerate the user directory through this app.
+     *
+     * @param string $search Substring to match against user and group names
+     * @param int $limit Maximum results per kind (clamped to 100)
+     *
+     * 200: Matching users and groups
+     *
+     * @return JSONResponse<Http::STATUS_OK, array{users: list<array{id: string, label: string}>, groups: list<array{id: string, label: string}>}, array{}>
+     */
+    #[OpenAPI(scope: OpenAPI::SCOPE_ADMINISTRATION)]
+    public function principals(string $search = '', int $limit = 25): JSONResponse {
+        $limit = max(1, min($limit, 100));
+
+        $users = [];
+        foreach ($this->userManager->searchDisplayName($search, $limit) as $user) {
+            $users[] = ['id' => $user->getUID(), 'label' => $user->getDisplayName()];
+        }
+
+        $groups = [];
+        foreach ($this->groupManager->search($search, $limit) as $group) {
+            $groups[] = ['id' => $group->getGID(), 'label' => $group->getDisplayName()];
+        }
+
+        return new JSONResponse(['users' => $users, 'groups' => $groups]);
+    }
+
     // ── Internals ───────────────────────────────────────────────────────────
 
-    /** @return list<array<string, mixed>> */
+    /**
+     * Describe every provider the caller may configure.
+     *
+     * The admin page sees all of them — an admin has to be able to edit the
+     * access lists of a provider they themselves are blocked from. The personal
+     * page sees only the ones the user is permitted to use.
+     *
+     * @return list<array<string, mixed>>
+     */
     private function describeAll(bool $admin, bool $refresh): array {
+        $ids = $admin
+            ? $this->providerFactory->getProviderIds()
+            : $this->providerFactory->getProviderIdsForUser($this->userId);
+
         $out = [];
-        foreach ($this->providerFactory->getProviderIds() as $id) {
+        foreach ($ids as $id) {
             $out[] = $this->providerSettings->describe(
                 $this->providerFactory->getProviderById($id),
                 $this->userId,
@@ -285,6 +359,18 @@ class ProviderSettingsController extends Controller {
             );
         }
         return $out;
+    }
+
+    /** @return JSONResponse<Http::STATUS_FORBIDDEN, array{status: string, message: string}, array{}> */
+    private function forbiddenProvider(string $providerId, string $userId): JSONResponse {
+        $this->logger->warning('AIquila: denied provider access for ' . $providerId, [
+            'provider' => $providerId,
+            'user' => $userId,
+        ]);
+        return new JSONResponse(
+            ['status' => 'error', 'message' => 'You are not permitted to use this provider.'],
+            Http::STATUS_FORBIDDEN,
+        );
     }
 
     /** @return JSONResponse<Http::STATUS_BAD_REQUEST, array{status: string, message: string}, array{}> */

--- a/nextcloud-app/lib/Controller/SettingsController.php
+++ b/nextcloud-app/lib/Controller/SettingsController.php
@@ -10,6 +10,7 @@ use OCA\AIquila\Service\HetznerModels;
 use OCA\AIquila\Service\MistralModels;
 use OCA\AIquila\Service\NativeMcpService;
 use OCA\AIquila\Service\Provider\LLMProviderFactory;
+use OCA\AIquila\Service\Provider\NoPermittedProviderException;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -68,24 +69,46 @@ class SettingsController extends Controller {
     }
 
     /**
+     * Every provider is blocked for this user.
+     *
+     * Fails closed with a message the UI can show verbatim, rather than
+     * describing a provider the admin has denied.
+     *
+     * @return JSONResponse<Http::STATUS_FORBIDDEN, array{status: string, message: string}, array{}>
+     */
+    private function noProviderAvailable(): JSONResponse {
+        return new JSONResponse(
+            ['status' => 'error', 'message' => NoPermittedProviderException::USER_MESSAGE],
+            Http::STATUS_FORBIDDEN,
+        );
+    }
+
+    /**
      * Get current user settings and available Claude models
      *
      * 200: User settings and available models
+     * 403: No provider is permitted for this user
      *
-     * @return JSONResponse<Http::STATUS_OK, array{provider: string, userProvider: string, providers: list<array{id: string, label: string, configured: bool, hasUserKey: bool, userModel: string, availableModels: list<string>}>, hasUserKey: bool, userModel: string, availableModels: list<string>, defaultSystemPrompt: string, defaultVerbose: bool, nativeMcpUserOverride: string, nativeMcpAdminDefault: bool, nativeMcpEffective: bool}, array{}>
+     * @return JSONResponse<Http::STATUS_FORBIDDEN, array{status: string, message: string}, array{}>|JSONResponse<Http::STATUS_OK, array{provider: string, userProvider: string, providers: list<array{id: string, label: string, configured: bool, hasUserKey: bool, userModel: string, availableModels: list<string>}>, hasUserKey: bool, userModel: string, availableModels: list<string>, defaultSystemPrompt: string, defaultVerbose: bool, nativeMcpUserOverride: string, nativeMcpAdminDefault: bool, nativeMcpEffective: bool}, array{}>
      *
      * @NoAdminRequired
      */
     #[NoAdminRequired]
     #[OpenAPI]
     public function get(): JSONResponse {
-        $activeProviderId = $this->providerFactory->getActiveProviderId($this->userId);
+        try {
+            $activeProviderId = $this->providerFactory->getActiveProviderId($this->userId);
+        } catch (NoPermittedProviderException $e) {
+            return $this->noProviderAvailable();
+        }
         $userProvider     = $this->config->getUserValue($this->userId, $this->appName, 'user_provider', '');
 
         // Per-provider metadata: label, whether a personal key exists, the user's
         // preferred model, and the available model list (live with static fallback).
+        // Only providers this user is permitted to use — the picker must not
+        // offer one the server would then refuse.
         $providers = [];
-        foreach ($this->providerFactory->getProviderIds() as $id) {
+        foreach ($this->providerFactory->getProviderIdsForUser($this->userId) as $id) {
             $provider = $this->providerFactory->getProviderById($id);
             $liveModels = $provider->listModels($this->userId);
             $providers[] = [
@@ -137,8 +160,10 @@ class SettingsController extends Controller {
      * @param string|null $native_mcp_enabled User override for native-MCP ('1' opt in, '0' opt out, '' clears override, null keeps unchanged)
      *
      * 200: Settings saved successfully
+     * 400: Unknown provider
+     * 403: The provider is not permitted for this user
      *
-     * @return JSONResponse<Http::STATUS_OK, array{status: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{status: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{status: string, message: string}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{status: string, message: string}, array{}>
      *
      * @NoAdminRequired
      */
@@ -153,6 +178,21 @@ class SettingsController extends Controller {
         ?string $native_mcp_enabled = null
     ): JSONResponse {
         // Provider override: '' clears (inherit admin default), non-empty sets it.
+        // A named provider must be one the user is actually permitted to use —
+        // this endpoint also scopes the API key and model below, so an
+        // unvalidated id would let a blocked provider be configured and selected.
+        if ($provider !== null && $provider !== '') {
+            if (!$this->providerFactory->isKnownProviderId($provider)) {
+                return new JSONResponse(['status' => 'error', 'message' => 'Unknown provider: ' . $provider], Http::STATUS_BAD_REQUEST);
+            }
+            if (!$this->providerFactory->isAllowedForUser($provider, $this->userId)) {
+                return new JSONResponse(
+                    ['status' => 'error', 'message' => 'You are not permitted to use this provider.'],
+                    Http::STATUS_FORBIDDEN,
+                );
+            }
+        }
+
         if ($provider !== null) {
             if ($provider === '') {
                 $this->config->deleteUserValue($this->requireUserId(), $this->appName, 'user_provider');
@@ -163,9 +203,13 @@ class SettingsController extends Controller {
 
         // api_key and model are scoped to the provider being edited (the one named
         // in this call, falling back to the now-active provider).
-        $scopeProvider = ($provider !== null && $provider !== '')
-            ? $provider
-            : $this->providerFactory->getActiveProviderId($this->userId);
+        try {
+            $scopeProvider = ($provider !== null && $provider !== '')
+                ? $provider
+                : $this->providerFactory->getActiveProviderId($this->userId);
+        } catch (NoPermittedProviderException $e) {
+            return $this->noProviderAvailable();
+        }
 
         // null = leave the key untouched (e.g. when only switching provider/model);
         // '' = explicitly clear; non-empty = set.

--- a/nextcloud-app/lib/Cowork/AbstractVisionTaskType.php
+++ b/nextcloud-app/lib/Cowork/AbstractVisionTaskType.php
@@ -61,8 +61,10 @@ abstract class AbstractVisionTaskType implements CoworkerTaskType {
         $options = $this->decodeOptions($coworker);
         // A pinned provider keeps a routine task on a cheap model while chat
         // runs on a strong one; null falls back to the owner's current setting.
-        $providerId = $coworker->getProvider() ?: $this->providerFactory->getActiveProviderId($userId);
-        $provider = $this->providerFactory->getProviderById($providerId);
+        // A pin the owner may no longer use degrades to their current provider
+        // rather than running the task on a provider the admin has blocked.
+        $provider = $this->providerFactory->getProviderForUser($userId, $coworker->getProvider());
+        $providerId = $provider->getId();
         $prompt = $this->buildPrompt($options);
 
         $files = $this->collectFiles($coworker, $options);

--- a/nextcloud-app/lib/Db/ProviderAccessRule.php
+++ b/nextcloud-app/lib/Db/ProviderAccessRule.php
@@ -1,0 +1,51 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * One access rule for one provider.
+ *
+ * A rule is a single (provider, allow|block, user|group, principal) tuple; the
+ * four lists an admin edits — allowed_users, allowed_groups, blocked_users,
+ * blocked_groups — are just the rows of this table grouped by rule/principal
+ * type. Storing one row per principal rather than a serialised list keeps
+ * "which providers may this user use" answerable in SQL and avoids re-encoding
+ * a whole list to add one name.
+ *
+ * @method string getProviderId()
+ * @method void setProviderId(string $providerId)
+ * @method string getRuleType()
+ * @method void setRuleType(string $ruleType)
+ * @method string getPrincipalType()
+ * @method void setPrincipalType(string $principalType)
+ * @method string getPrincipalId()
+ * @method void setPrincipalId(string $principalId)
+ */
+class ProviderAccessRule extends Entity {
+    public const RULE_ALLOW = 'allow';
+    public const RULE_BLOCK = 'block';
+    public const PRINCIPAL_USER = 'user';
+    public const PRINCIPAL_GROUP = 'group';
+
+    // All four start empty on purpose. Entity's magic setter only marks a field
+    // updated when the value actually changes, and QBMapper::insert() writes
+    // only updated fields — so a property defaulted to 'allow' would be dropped
+    // from the INSERT whenever the caller set it to 'allow', and the column
+    // would go in as NULL.
+    protected string $providerId = '';
+    protected string $ruleType = '';
+    protected string $principalType = '';
+    protected string $principalId = '';
+
+    public function __construct() {
+        $this->addType('providerId', 'string');
+        $this->addType('ruleType', 'string');
+        $this->addType('principalType', 'string');
+        $this->addType('principalId', 'string');
+    }
+}

--- a/nextcloud-app/lib/Db/ProviderAccessRuleMapper.php
+++ b/nextcloud-app/lib/Db/ProviderAccessRuleMapper.php
@@ -1,0 +1,88 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Db;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * @template-extends QBMapper<ProviderAccessRule>
+ */
+class ProviderAccessRuleMapper extends QBMapper {
+    public function __construct(IDBConnection $db) {
+        parent::__construct($db, 'aiquila_provider_access', ProviderAccessRule::class);
+    }
+
+    /**
+     * Every rule for every provider.
+     *
+     * The whole table is read at once because the access check needs all four
+     * lists of one provider anyway and the row count is bounded by how many
+     * principals an admin names — ProviderAccessService caches the result.
+     *
+     * @return list<ProviderAccessRule>
+     */
+    public function findAll(): array {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')->from($this->getTableName());
+
+        return $this->findEntities($qb);
+    }
+
+    /**
+     * @return list<ProviderAccessRule>
+     */
+    public function findByProvider(string $providerId): array {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('provider_id', $qb->createNamedParameter($providerId)));
+
+        return $this->findEntities($qb);
+    }
+
+    /**
+     * Make one list of one provider exactly $principalIds.
+     *
+     * Delete-then-insert rather than a diff: the lists are short, and replacing
+     * wholesale is what the settings form submits.
+     *
+     * @param list<string> $principalIds
+     */
+    public function replaceList(string $providerId, string $ruleType, string $principalType, array $principalIds): void {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('provider_id', $qb->createNamedParameter($providerId)))
+            ->andWhere($qb->expr()->eq('rule_type', $qb->createNamedParameter($ruleType)))
+            ->andWhere($qb->expr()->eq('principal_type', $qb->createNamedParameter($principalType)));
+        $qb->executeStatement();
+
+        foreach (array_unique($principalIds) as $principalId) {
+            if ($principalId === '') {
+                continue;
+            }
+            $rule = new ProviderAccessRule();
+            $rule->setProviderId($providerId);
+            $rule->setRuleType($ruleType);
+            $rule->setPrincipalType($principalType);
+            $rule->setPrincipalId($principalId);
+            $this->insert($rule);
+        }
+    }
+
+    /**
+     * Drop every rule naming a principal — used when a user or group is deleted,
+     * so a later principal reusing the id does not inherit its permissions.
+     */
+    public function deleteByPrincipal(string $principalType, string $principalId): void {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('principal_type', $qb->createNamedParameter($principalType)))
+            ->andWhere($qb->expr()->eq('principal_id', $qb->createNamedParameter($principalId)));
+        $qb->executeStatement();
+    }
+}

--- a/nextcloud-app/lib/Migration/Version0011Date20260814000000.php
+++ b/nextcloud-app/lib/Migration/Version0011Date20260814000000.php
@@ -1,0 +1,60 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Per-provider access rules (allowed/blocked users and groups).
+ *
+ * One row per (provider, allow|block, user|group, principal). An empty table
+ * means every provider is open to everyone, so an existing instance keeps
+ * behaving exactly as before the upgrade.
+ */
+class Version0011Date20260814000000 extends SimpleMigrationStep {
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+        $schema = $schemaClosure();
+
+        if ($schema->hasTable('aiquila_provider_access')) {
+            return null;
+        }
+
+        $table = $schema->createTable('aiquila_provider_access');
+        $table->addColumn('id', Types::INTEGER, [
+            'autoincrement' => true,
+            'notnull' => true,
+        ]);
+        $table->addColumn('provider_id', Types::STRING, [
+            'notnull' => true,
+            'length' => 64,
+        ]);
+        $table->addColumn('rule_type', Types::STRING, [
+            'notnull' => true,
+            'length' => 8,
+        ]);
+        $table->addColumn('principal_type', Types::STRING, [
+            'notnull' => true,
+            'length' => 8,
+        ]);
+        $table->addColumn('principal_id', Types::STRING, [
+            'notnull' => true,
+            'length' => 64,
+        ]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(
+            ['provider_id', 'rule_type', 'principal_type', 'principal_id'],
+            'aiq_provacc_rule_idx',
+        );
+        $table->addIndex(['principal_type', 'principal_id'], 'aiq_provacc_principal_idx');
+
+        return $schema;
+    }
+}

--- a/nextcloud-app/lib/Service/CoworkerService.php
+++ b/nextcloud-app/lib/Service/CoworkerService.php
@@ -271,6 +271,12 @@ class CoworkerService {
             if ($provider !== '' && !$this->providerFactory->isKnownProviderId($provider)) {
                 throw new \InvalidArgumentException("Unknown provider: $provider");
             }
+            // Pinning a provider on a coworker is a provider-selecting path like
+            // any other: the owner has to be permitted to use it, or a blocked
+            // provider could be reached through a scheduled run.
+            if ($provider !== '' && !$this->providerFactory->isAllowedForUser($provider, $coworker->getUserId())) {
+                throw new \InvalidArgumentException("You are not permitted to use this provider: $provider");
+            }
             $coworker->setProvider($provider !== '' ? $provider : null);
         }
         if (array_key_exists('task_type', $data)) {

--- a/nextcloud-app/lib/Service/Provider/LLMProviderFactory.php
+++ b/nextcloud-app/lib/Service/Provider/LLMProviderFactory.php
@@ -14,6 +14,17 @@ use OCP\IConfig;
  * Precedence: a per-user override (`user_provider`) wins over the admin default
  * (`provider`), which defaults to Anthropic. Unknown ids fall back to Anthropic
  * so a misconfiguration never breaks chat.
+ *
+ * ## Access control
+ *
+ * Every candidate at every level is run through ProviderAccessService, so an
+ * admin's per-user/group rules apply to the user override, the instance default
+ * and any pinned id alike. A denied candidate falls through to the next one
+ * rather than being served; if nothing is left the resolution fails closed with
+ * NoPermittedProviderException instead of quietly handing back Anthropic.
+ *
+ * A null user id means a system context (CLI, background job, admin settings)
+ * and is never restricted.
  */
 class LLMProviderFactory {
     private const APP_NAME = 'aiquila';
@@ -26,6 +37,7 @@ class LLMProviderFactory {
         private readonly DeepSeekProvider $deepseek,
         private readonly HetznerProvider $hetzner,
         private readonly LocalProvider $local,
+        private readonly ProviderAccessService $access,
     ) {
     }
 
@@ -40,33 +52,90 @@ class LLMProviderFactory {
         ];
     }
 
-    /** Stable list of provider ids in display order. */
+    /**
+     * Stable list of provider ids in display order.
+     *
+     * @return list<string>
+     */
     public function getProviderIds(): array {
         return array_keys($this->providers());
     }
 
     /**
+     * The provider ids the given user is permitted to use, in display order.
+     *
+     * @return list<string>
+     */
+    public function getProviderIdsForUser(?string $userId = null): array {
+        return $this->access->filterAllowed($this->getProviderIds(), $userId);
+    }
+
+    /** Whether the user is permitted at least one provider. */
+    public function hasPermittedProvider(?string $userId = null): bool {
+        return $this->getProviderIdsForUser($userId) !== [];
+    }
+
+    /** Whether the given user may use the named provider. */
+    public function isAllowedForUser(string $id, ?string $userId = null): bool {
+        return $this->isKnownProviderId($id) && $this->access->isAllowed($id, $userId);
+    }
+
+    /**
      * The provider id that should serve the given user.
+     *
+     * @throws NoPermittedProviderException when every provider is denied
      */
     public function getActiveProviderId(?string $userId = null): string {
-        $providers = $this->providers();
+        $permitted = $this->getProviderIdsForUser($userId);
+        if ($permitted === []) {
+            throw new NoPermittedProviderException($userId);
+        }
 
         if ($userId !== null) {
             $userProvider = $this->config->getUserValue($userId, self::APP_NAME, 'user_provider', '');
-            if ($userProvider !== '' && isset($providers[$userProvider])) {
+            if ($userProvider !== '' && in_array($userProvider, $permitted, true)) {
                 return $userProvider;
             }
         }
 
         $adminDefault = $this->config->getAppValue(self::APP_NAME, 'provider', self::DEFAULT_PROVIDER);
-        return isset($providers[$adminDefault]) ? $adminDefault : self::DEFAULT_PROVIDER;
+        if (in_array($adminDefault, $permitted, true)) {
+            return $adminDefault;
+        }
+
+        // The instance default is denied for this user (or unknown): fall
+        // through to the first provider they may actually use rather than
+        // handing back one they cannot.
+        if (in_array(self::DEFAULT_PROVIDER, $permitted, true)) {
+            return self::DEFAULT_PROVIDER;
+        }
+        return $permitted[0];
     }
 
     /**
      * The provider that should serve the given user.
+     *
+     * @throws NoPermittedProviderException when every provider is denied
      */
     public function getProvider(?string $userId = null): LLMProviderInterface {
         return $this->getProviderById($this->getActiveProviderId($userId));
+    }
+
+    /**
+     * The provider that should serve a specific request for a user.
+     *
+     * Use this — not getProviderById() — wherever the id comes from a pin
+     * (conversation, coworker) that was stored earlier: permissions can be
+     * revoked after the pin was made, and a revoked pin has to degrade to the
+     * user's current provider rather than continue to be honoured.
+     *
+     * @throws NoPermittedProviderException when every provider is denied
+     */
+    public function getProviderForUser(?string $userId, ?string $requestedId): LLMProviderInterface {
+        if ($requestedId !== null && $requestedId !== '' && $this->isAllowedForUser($requestedId, $userId)) {
+            return $this->getProviderById($requestedId);
+        }
+        return $this->getProvider($userId);
     }
 
     /**

--- a/nextcloud-app/lib/Service/Provider/NoPermittedProviderException.php
+++ b/nextcloud-app/lib/Service/Provider/NoPermittedProviderException.php
@@ -1,0 +1,25 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Service\Provider;
+
+/**
+ * Thrown when a user is denied every registered provider.
+ *
+ * Provider resolution fails closed: rather than handing back a provider the
+ * admin has blocked, the factory raises this and the caller turns it into a 403.
+ * Callers that render a page catch it and show the "no provider available" state.
+ */
+class NoPermittedProviderException extends \RuntimeException {
+    public const USER_MESSAGE = 'No AI provider is available for your account. Ask your administrator for access.';
+
+    public function __construct(?string $userId = null) {
+        parent::__construct(
+            $userId === null
+                ? self::USER_MESSAGE
+                : self::USER_MESSAGE . ' (user: ' . $userId . ')',
+        );
+    }
+}

--- a/nextcloud-app/lib/Service/Provider/ProviderAccessService.php
+++ b/nextcloud-app/lib/Service/Provider/ProviderAccessService.php
@@ -1,0 +1,230 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Service\Provider;
+
+use OCA\AIquila\Db\ProviderAccessRule;
+use OCA\AIquila\Db\ProviderAccessRuleMapper;
+use OCP\ICacheFactory;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Decides which providers a given user may use.
+ *
+ * An admin gives each provider four lists — allowed users, allowed groups,
+ * blocked users, blocked groups — and this service is the only place that
+ * interprets them:
+ *
+ *  1. A null user id is a system context (CLI, background job, admin settings
+ *     page) and is never restricted.
+ *  2. A block wins over any allow. Being named in `blocked_users`, or in a group
+ *     named in `blocked_groups`, is final.
+ *  3. Empty allow-lists mean everyone.
+ *  4. Otherwise the user must be named in `allowed_users` or be in a group named
+ *     in `allowed_groups`.
+ *
+ * This is an authorization boundary, not a display filter: LLMProviderFactory
+ * routes every provider resolution through it, so filtering a provider out of a
+ * settings page is a consequence of the check rather than the check itself.
+ */
+class ProviderAccessService {
+    /**
+     * The rule set is consulted on nearly every request that touches a provider,
+     * so the whole (small) table is cached under one key and dropped wholesale on
+     * write — the same approach ProviderSettingsService takes for model lists.
+     */
+    private const CACHE_KEY = 'rules';
+    private const CACHE_TTL = 3600;
+
+    /** @var array<string, array<string, list<string>>>|null in-request memo */
+    private ?array $memo = null;
+
+    /** @var array<string, list<string>> in-request memo of uid => group ids */
+    private array $groupMemo = [];
+
+    public function __construct(
+        private readonly ProviderAccessRuleMapper $mapper,
+        private readonly IGroupManager $groupManager,
+        private readonly IUserManager $userManager,
+        private readonly ICacheFactory $cacheFactory,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Whether $userId may use $providerId. A null user id is unrestricted.
+     */
+    public function isAllowed(string $providerId, ?string $userId): bool {
+        if ($userId === null || $userId === '') {
+            return true;
+        }
+
+        $lists = $this->getLists($providerId);
+        $groupIds = $this->groupIds($userId);
+
+        if (in_array($userId, $lists['blocked_users'], true)) {
+            return false;
+        }
+        if (array_intersect($groupIds, $lists['blocked_groups']) !== []) {
+            return false;
+        }
+
+        if ($lists['allowed_users'] === [] && $lists['allowed_groups'] === []) {
+            return true;
+        }
+
+        return in_array($userId, $lists['allowed_users'], true)
+            || array_intersect($groupIds, $lists['allowed_groups']) !== [];
+    }
+
+    /**
+     * Keep only the providers $userId may use, preserving the given order.
+     *
+     * @param list<string> $providerIds
+     * @return list<string>
+     */
+    public function filterAllowed(array $providerIds, ?string $userId): array {
+        if ($userId === null || $userId === '') {
+            return $providerIds;
+        }
+        return array_values(array_filter(
+            $providerIds,
+            fn (string $id): bool => $this->isAllowed($id, $userId),
+        ));
+    }
+
+    /**
+     * The four lists of one provider, always with all four keys present.
+     *
+     * @return array{allowed_users: list<string>, allowed_groups: list<string>, blocked_users: list<string>, blocked_groups: list<string>}
+     */
+    public function getLists(string $providerId): array {
+        $all = $this->allLists();
+        /** @var array{allowed_users: list<string>, allowed_groups: list<string>, blocked_users: list<string>, blocked_groups: list<string>} $lists */
+        $lists = $all[$providerId] ?? self::emptyLists();
+        return $lists;
+    }
+
+    /**
+     * Replace whichever of the four lists are present in $lists. Keys that are
+     * absent are left alone, so a partial settings save cannot silently clear a
+     * list the form did not render.
+     *
+     * @param array<string, list<string>> $lists
+     */
+    public function setLists(string $providerId, array $lists): void {
+        foreach ($lists as $listId => $principalIds) {
+            $spec = self::listSpec($listId);
+            if ($spec === null) {
+                continue;
+            }
+            $this->mapper->replaceList($providerId, $spec[0], $spec[1], array_values($principalIds));
+            $this->logger->info('AIquila: provider access list updated', [
+                'provider' => $providerId,
+                'list' => $listId,
+                'count' => count($principalIds),
+            ]);
+        }
+        $this->forget();
+    }
+
+    /** Drop the cached rule set. */
+    public function forget(): void {
+        $this->memo = null;
+        $this->cacheFactory->createDistributed('aiquila-provider-access')->remove(self::CACHE_KEY);
+    }
+
+    /** The list ids an admin can edit, in display order. */
+    public static function listIds(): array {
+        return ['allowed_users', 'allowed_groups', 'blocked_users', 'blocked_groups'];
+    }
+
+    /** True when the id names one of the four access lists. */
+    public static function isListId(string $id): bool {
+        return self::listSpec($id) !== null;
+    }
+
+    // ── Internals ───────────────────────────────────────────────────────────
+
+    /**
+     * The user's group ids, memoised for the request.
+     *
+     * A uid with no backing account resolves to no groups rather than an error:
+     * the caller is asking an authorization question, and "unknown principal" has
+     * to answer like a user in no groups, not like a user in every group.
+     *
+     * @return list<string>
+     */
+    private function groupIds(string $userId): array {
+        if (isset($this->groupMemo[$userId])) {
+            return $this->groupMemo[$userId];
+        }
+        $user = $this->userManager->get($userId);
+        $ids = $user === null ? [] : $this->groupManager->getUserGroupIds($user);
+        $this->groupMemo[$userId] = $ids;
+        return $ids;
+    }
+
+    /**
+     * @return array{0: string, 1: string}|null rule type and principal type
+     */
+    private static function listSpec(string $listId): ?array {
+        return match ($listId) {
+            'allowed_users' => [ProviderAccessRule::RULE_ALLOW, ProviderAccessRule::PRINCIPAL_USER],
+            'allowed_groups' => [ProviderAccessRule::RULE_ALLOW, ProviderAccessRule::PRINCIPAL_GROUP],
+            'blocked_users' => [ProviderAccessRule::RULE_BLOCK, ProviderAccessRule::PRINCIPAL_USER],
+            'blocked_groups' => [ProviderAccessRule::RULE_BLOCK, ProviderAccessRule::PRINCIPAL_GROUP],
+            default => null,
+        };
+    }
+
+    /** @return array<string, list<string>> */
+    private static function emptyLists(): array {
+        return [
+            'allowed_users' => [],
+            'allowed_groups' => [],
+            'blocked_users' => [],
+            'blocked_groups' => [],
+        ];
+    }
+
+    /**
+     * Every provider's lists, keyed by provider id.
+     *
+     * @return array<string, array<string, list<string>>>
+     */
+    private function allLists(): array {
+        if ($this->memo !== null) {
+            return $this->memo;
+        }
+
+        $cache = $this->cacheFactory->createDistributed('aiquila-provider-access');
+        $cached = $cache->get(self::CACHE_KEY);
+        if (is_array($cached)) {
+            /** @var array<string, array<string, list<string>>> $cached */
+            $this->memo = $cached;
+            return $cached;
+        }
+
+        $byProvider = [];
+        foreach ($this->mapper->findAll() as $rule) {
+            $listId = $rule->getRuleType() === ProviderAccessRule::RULE_BLOCK
+                ? ($rule->getPrincipalType() === ProviderAccessRule::PRINCIPAL_GROUP ? 'blocked_groups' : 'blocked_users')
+                : ($rule->getPrincipalType() === ProviderAccessRule::PRINCIPAL_GROUP ? 'allowed_groups' : 'allowed_users');
+
+            $providerId = $rule->getProviderId();
+            if (!isset($byProvider[$providerId])) {
+                $byProvider[$providerId] = self::emptyLists();
+            }
+            $byProvider[$providerId][$listId][] = $rule->getPrincipalId();
+        }
+
+        $cache->set(self::CACHE_KEY, $byProvider, self::CACHE_TTL);
+        $this->memo = $byProvider;
+        return $byProvider;
+    }
+}

--- a/nextcloud-app/lib/Service/Provider/ProviderSettingsSchema.php
+++ b/nextcloud-app/lib/Service/Provider/ProviderSettingsSchema.php
@@ -46,6 +46,8 @@ final class ProviderSettingsSchema {
     public const TYPE_CHECKBOX = 'checkbox';
     public const TYPE_URL = 'url';
     public const TYPE_NUMBER = 'number';
+    /** Multiple values from an async lookup; the value is a list of ids. */
+    public const TYPE_MULTISELECT = 'multiselect';
 
     /**
      * Placeholder for the `options` of a model select. The API expands it to the
@@ -53,10 +55,27 @@ final class ProviderSettingsSchema {
      */
     public const OPTIONS_MODELS = '@models';
 
+    /**
+     * Placeholder for the `options` of a principal picker. There is no fixed
+     * option list — the client queries the principals endpoint as the admin
+     * types, scoped by `principal_type`.
+     */
+    public const OPTIONS_PRINCIPALS = '@principals';
+
+    /** Which side of the principals endpoint a picker queries. */
+    public const PRINCIPAL_USER = 'user';
+    public const PRINCIPAL_GROUP = 'group';
+
     /** Shown inline on the card. */
     public const GROUP_BASIC = 'basic';
     /** Hidden behind a disclosure on the card. */
     public const GROUP_ADVANCED = 'advanced';
+
+    /**
+     * Not stored in IConfig at all: the value is a list of principals held in
+     * `aiquila_provider_access` and written through ProviderAccessService.
+     */
+    public const STORAGE_ACCESS = 'access';
 
     /** Booleans stored as the literal strings 'yes'/'no' (local provider legacy). */
     public const STORAGE_YESNO = 'yesno';
@@ -236,6 +255,62 @@ final class ProviderSettingsSchema {
             'documents' => false,
         ], $overrides);
         return $merged;
+    }
+
+    /**
+     * The four access-control lists every provider carries.
+     *
+     * These are not declared by the providers themselves — access control is a
+     * property of the app, not of any one provider — so ProviderSettingsService
+     * appends them to every admin-scope description. They are SCOPE_ADMIN, which
+     * is what keeps them off the personal settings page: isUserWritable() already
+     * filters them out there, and writeUser() would reject them anyway.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public static function accessLists(): array {
+        return [
+            self::principalList(
+                'allowed_users',
+                self::PRINCIPAL_USER,
+                'Allowed users',
+                'Only these users may use this provider. Leave empty to allow everyone.',
+            ),
+            self::principalList(
+                'allowed_groups',
+                self::PRINCIPAL_GROUP,
+                'Allowed groups',
+                'Only members of these groups may use this provider. Leave empty to allow everyone.',
+            ),
+            self::principalList(
+                'blocked_users',
+                self::PRINCIPAL_USER,
+                'Blocked users',
+                'These users may never use this provider, even if an allow list names them.',
+            ),
+            self::principalList(
+                'blocked_groups',
+                self::PRINCIPAL_GROUP,
+                'Blocked groups',
+                'Members of these groups may never use this provider, even if an allow list names them.',
+            ),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private static function principalList(string $id, string $principalType, string $title, string $description): array {
+        return [
+            'id' => $id,
+            'title' => $title,
+            'description' => $description,
+            'type' => self::TYPE_MULTISELECT,
+            'scope' => self::SCOPE_ADMIN,
+            'storage' => self::STORAGE_ACCESS,
+            'principal_type' => $principalType,
+            'options' => self::OPTIONS_PRINCIPALS,
+            'default' => [],
+            'group' => self::GROUP_ADVANCED,
+        ];
     }
 
     /** True when the field may be written from the personal settings page. */

--- a/nextcloud-app/lib/Service/Provider/ProviderSettingsService.php
+++ b/nextcloud-app/lib/Service/Provider/ProviderSettingsService.php
@@ -8,6 +8,8 @@ namespace OCA\AIquila\Service\Provider;
 use OCA\AIquila\Service\CredentialService;
 use OCP\ICacheFactory;
 use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -41,6 +43,9 @@ class ProviderSettingsService {
     public function __construct(
         private readonly IConfig $config,
         private readonly CredentialService $credentials,
+        private readonly ProviderAccessService $access,
+        private readonly IUserManager $userManager,
+        private readonly IGroupManager $groupManager,
         private readonly ICacheFactory $cacheFactory,
         private readonly LoggerInterface $logger,
     ) {
@@ -56,7 +61,7 @@ class ProviderSettingsService {
     public function describe(LLMProviderInterface $provider, ?string $userId, bool $admin, bool $refreshModels = false): array {
         $id = $provider->getId();
         $fields = [];
-        foreach ($provider->getSettingsSchema() as $field) {
+        foreach ($this->schemaFor($provider) as $field) {
             if (!$admin && !ProviderSettingsSchema::isUserWritable($field)) {
                 continue;
             }
@@ -144,6 +149,8 @@ class ProviderSettingsService {
         $schema = $this->indexSchema($provider);
         $rejected = [];
         $plan = [];
+        /** @var array<string, list<string>> $accessLists */
+        $accessLists = [];
 
         foreach ($values as $fieldId => $value) {
             $field = $schema[$fieldId] ?? null;
@@ -154,6 +161,11 @@ class ProviderSettingsService {
 
             if (!empty($field['sensitive'])) {
                 $plan[] = ['key' => null, 'value' => (string)$value];
+                continue;
+            }
+
+            if (($field['storage'] ?? null) === ProviderSettingsSchema::STORAGE_ACCESS) {
+                $accessLists[(string)$fieldId] = $this->principalIds($field, $value);
                 continue;
             }
 
@@ -172,6 +184,10 @@ class ProviderSettingsService {
                 continue;
             }
             $this->config->setAppValue(self::APP_NAME, $write['key'], $write['value']);
+        }
+
+        if ($accessLists !== []) {
+            $this->access->setLists($provider->getId(), $accessLists);
         }
 
         // An endpoint or key change invalidates whatever model list we cached.
@@ -259,10 +275,26 @@ class ProviderSettingsService {
     /** @return array<string, array<string, mixed>> */
     private function indexSchema(LLMProviderInterface $provider): array {
         $indexed = [];
-        foreach ($provider->getSettingsSchema() as $field) {
+        foreach ($this->schemaFor($provider) as $field) {
             $indexed[$field['id']] = $field;
         }
         return $indexed;
+    }
+
+    /**
+     * The provider's own schema plus the access lists every provider carries.
+     *
+     * Appending here rather than in each provider's getSettingsSchema() means
+     * access control cannot be forgotten when a provider is added, and the four
+     * descriptors exist in exactly one place.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function schemaFor(LLMProviderInterface $provider): array {
+        return array_merge(
+            $provider->getSettingsSchema(),
+            ProviderSettingsSchema::accessLists(),
+        );
     }
 
     /**
@@ -282,6 +314,14 @@ class ProviderSettingsService {
 
         if (($field['options'] ?? null) === ProviderSettingsSchema::OPTIONS_MODELS) {
             $out['options'] = $this->listModels($provider, $admin ? null : $userId, $refreshModels);
+        }
+
+        // Access lists live in their own table, not IConfig, and only ever have
+        // an instance value — there is no user scope to inherit from.
+        if (($field['storage'] ?? null) === ProviderSettingsSchema::STORAGE_ACCESS) {
+            $out['options'] = [];
+            $out['value'] = $this->access->getLists($providerId)[$field['id']] ?? [];
+            return $out;
         }
 
         if (!empty($field['sensitive'])) {
@@ -332,6 +372,51 @@ class ProviderSettingsService {
         $this->credentials->setApiKey($userId, $value, $providerId);
         // A new key can unlock a different model list.
         $this->forgetModels($providerId);
+    }
+
+    /**
+     * Validate a submitted principal list.
+     *
+     * Every id must name an account or group that exists right now. Storing an
+     * id that does not resolve would be a silent trap: an allow-list entry for a
+     * typo'd uid looks like access was granted while granting nothing, and a
+     * block-list entry for a group that is later created would start denying
+     * people nobody deliberately denied.
+     *
+     * @return list<string>
+     * @throws \InvalidArgumentException when an id does not resolve
+     */
+    private function principalIds(array $field, mixed $value): array {
+        if ($value === '' || $value === null) {
+            return [];
+        }
+        if (!is_array($value)) {
+            throw new \InvalidArgumentException(($field['title'] ?? $field['id']) . ': expected a list.');
+        }
+
+        $isGroup = ($field['principal_type'] ?? ProviderSettingsSchema::PRINCIPAL_USER)
+            === ProviderSettingsSchema::PRINCIPAL_GROUP;
+
+        $ids = [];
+        foreach ($value as $entry) {
+            // NcSelect hands back either the reduced id or the whole option.
+            $id = is_array($entry) ? (string)($entry['id'] ?? '') : (string)$entry;
+            $id = trim($id);
+            if ($id === '') {
+                continue;
+            }
+            $exists = $isGroup
+                ? $this->groupManager->groupExists($id)
+                : $this->userManager->userExists($id);
+            if (!$exists) {
+                throw new \InvalidArgumentException(
+                    ($field['title'] ?? $field['id']) . ': no such ' . ($isGroup ? 'group' : 'user') . ' "' . $id . '".'
+                );
+            }
+            $ids[] = $id;
+        }
+
+        return array_values(array_unique($ids));
     }
 
     /**

--- a/nextcloud-app/lib/TaskProcessing/ClaudeImageToTextProvider.php
+++ b/nextcloud-app/lib/TaskProcessing/ClaudeImageToTextProvider.php
@@ -121,10 +121,12 @@ class ClaudeImageToTextProvider implements ISynchronousProvider {
 
         $reportProgress(0.5);
 
-        $providerId = !empty($input['provider']) && is_string($input['provider'])
-            ? $input['provider']
-            : $this->providerFactory->getActiveProviderId($userId);
-        $provider = $this->providerFactory->getProviderById($providerId);
+        $requested = !empty($input['provider']) && is_string($input['provider']) ? $input['provider'] : null;
+        // getProviderForUser() applies the admin's access rules: a provider the
+        // user may not use falls through to the one they may, rather than being
+        // reachable through the task-processing API.
+        $provider = $this->providerFactory->getProviderForUser($userId, $requested);
+        $providerId = $provider->getId();
 
         $result = $provider->askWithImage(
             $prompt,

--- a/nextcloud-app/openapi-administration.json
+++ b/nextcloud-app/openapi-administration.json
@@ -718,6 +718,145 @@
                 }
             }
         },
+        "/index.php/apps/aiquila/api/admin/principals": {
+            "get": {
+                "operationId": "provider_settings-principals",
+                "summary": "Search users and groups for the provider access lists",
+                "description": "Backs the principal pickers on the admin settings page. Admin-only: the personal page has no access fields, and an unprivileged user has no reason to enumerate the user directory through this app.\nThis endpoint requires admin access",
+                "tags": [
+                    "provider_settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Substring to match against user and group names",
+                        "schema": {
+                            "type": "string",
+                            "default": ""
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Maximum results per kind (clamped to 100)",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64",
+                            "default": 25
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Matching users and groups",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "users",
+                                        "groups"
+                                    ],
+                                    "properties": {
+                                        "users": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "id",
+                                                    "label"
+                                                ],
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string"
+                                                    },
+                                                    "label": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "groups": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "id",
+                                                    "label"
+                                                ],
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string"
+                                                    },
+                                                    "label": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Logged in account must be an admin",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/index.php/apps/aiquila/api/occ": {
             "post": {
                 "operationId": "occ-execute",
@@ -1887,7 +2026,7 @@
         },
         {
             "name": "provider_settings",
-            "description": "Schema-driven read/write of provider configuration for the settings pages. Both the admin and the personal page render whatever LLMProviderInterface::getSettingsSchema() describes, so this controller never names a provider or a config key — adding a provider requires no change here. The admin/user split is enforced twice over: the admin routes carry no #[NoAdminRequired] (so Nextcloud requires an admin), and ProviderSettingsService::writeUser() additionally drops any field whose scope is not user-writable. That second check is what keeps endpoint URLs — which decide where the server sends outbound requests — out of reach of the personal page even if a route were ever mis-annotated."
+            "description": "Schema-driven read/write of provider configuration for the settings pages. Both the admin and the personal page render whatever LLMProviderInterface::getSettingsSchema() describes, so this controller never names a provider or a config key — adding a provider requires no change here. The admin/user split is enforced twice over: the admin routes carry no #[NoAdminRequired] (so Nextcloud requires an admin), and ProviderSettingsService::writeUser() additionally drops any field whose scope is not user-writable. That second check is what keeps endpoint URLs — which decide where the server sends outbound requests — out of reach of the personal page even if a route were ever mis-annotated. Provider *access* is enforced on top of that: index() only describes providers the current user is permitted to use, and update() refuses one they are not, so the personal page can neither see nor select a provider an admin blocked."
         },
         {
             "name": "coworker",

--- a/nextcloud-app/openapi-full.json
+++ b/nextcloud-app/openapi-full.json
@@ -269,6 +269,24 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "The provider is not permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -727,6 +745,24 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "No provider is permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -978,6 +1014,24 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "No provider is permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -1127,6 +1181,24 @@
                     },
                     "400": {
                         "description": "Unknown provider",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "The provider is not permitted for this user",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2227,6 +2299,24 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "No provider is permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "400": {
                         "description": "No prompt was provided",
                         "content": {
@@ -2452,6 +2542,24 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "No provider is permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "400": {
                         "description": "Messages array is missing or empty",
                         "content": {
@@ -2606,6 +2714,24 @@
                                                     "format": "int64"
                                                 }
                                             }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "No provider is permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
                                         }
                                     }
                                 }
@@ -2771,6 +2897,24 @@
                                                     "format": "int64"
                                                 }
                                             }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "No provider is permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
                                         }
                                     }
                                 }
@@ -2981,6 +3125,50 @@
                             }
                         }
                     },
+                    "400": {
+                        "description": "Unknown provider",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "status",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "status": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "The provider is not permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "status",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "status": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -3028,6 +3216,28 @@
                     }
                 ],
                 "responses": {
+                    "403": {
+                        "description": "No provider is permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "status",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "status": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "200": {
                         "description": "User settings and available models",
                         "content": {
@@ -3331,6 +3541,28 @@
                     },
                     "400": {
                         "description": "Unknown provider or invalid value",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "status",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "status": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "The provider is not permitted for this user",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -6551,6 +6783,145 @@
                 }
             }
         },
+        "/index.php/apps/aiquila/api/admin/principals": {
+            "get": {
+                "operationId": "provider_settings-principals",
+                "summary": "Search users and groups for the provider access lists",
+                "description": "Backs the principal pickers on the admin settings page. Admin-only: the personal page has no access fields, and an unprivileged user has no reason to enumerate the user directory through this app.\nThis endpoint requires admin access",
+                "tags": [
+                    "provider_settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Substring to match against user and group names",
+                        "schema": {
+                            "type": "string",
+                            "default": ""
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Maximum results per kind (clamped to 100)",
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64",
+                            "default": 25
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Matching users and groups",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "users",
+                                        "groups"
+                                    ],
+                                    "properties": {
+                                        "users": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "id",
+                                                    "label"
+                                                ],
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string"
+                                                    },
+                                                    "label": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "groups": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "id",
+                                                    "label"
+                                                ],
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string"
+                                                    },
+                                                    "label": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Logged in account must be an admin",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/index.php/apps/aiquila/api/occ": {
             "post": {
                 "operationId": "occ-execute",
@@ -7720,7 +8091,7 @@
         },
         {
             "name": "provider_settings",
-            "description": "Schema-driven read/write of provider configuration for the settings pages. Both the admin and the personal page render whatever LLMProviderInterface::getSettingsSchema() describes, so this controller never names a provider or a config key — adding a provider requires no change here. The admin/user split is enforced twice over: the admin routes carry no #[NoAdminRequired] (so Nextcloud requires an admin), and ProviderSettingsService::writeUser() additionally drops any field whose scope is not user-writable. That second check is what keeps endpoint URLs — which decide where the server sends outbound requests — out of reach of the personal page even if a route were ever mis-annotated."
+            "description": "Schema-driven read/write of provider configuration for the settings pages. Both the admin and the personal page render whatever LLMProviderInterface::getSettingsSchema() describes, so this controller never names a provider or a config key — adding a provider requires no change here. The admin/user split is enforced twice over: the admin routes carry no #[NoAdminRequired] (so Nextcloud requires an admin), and ProviderSettingsService::writeUser() additionally drops any field whose scope is not user-writable. That second check is what keeps endpoint URLs — which decide where the server sends outbound requests — out of reach of the personal page even if a route were ever mis-annotated. Provider *access* is enforced on top of that: index() only describes providers the current user is permitted to use, and update() refuses one they are not, so the personal page can neither see nor select a provider an admin blocked."
         },
         {
             "name": "coworker",

--- a/nextcloud-app/openapi.json
+++ b/nextcloud-app/openapi.json
@@ -269,6 +269,24 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "The provider is not permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -727,6 +745,24 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "No provider is permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -978,6 +1014,24 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "No provider is permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -1127,6 +1181,24 @@
                     },
                     "400": {
                         "description": "Unknown provider",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "The provider is not permitted for this user",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2227,6 +2299,24 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "No provider is permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "400": {
                         "description": "No prompt was provided",
                         "content": {
@@ -2452,6 +2542,24 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "No provider is permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "400": {
                         "description": "Messages array is missing or empty",
                         "content": {
@@ -2606,6 +2714,24 @@
                                                     "format": "int64"
                                                 }
                                             }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "No provider is permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
                                         }
                                     }
                                 }
@@ -2771,6 +2897,24 @@
                                                     "format": "int64"
                                                 }
                                             }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "No provider is permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
                                         }
                                     }
                                 }
@@ -2981,6 +3125,50 @@
                             }
                         }
                     },
+                    "400": {
+                        "description": "Unknown provider",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "status",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "status": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "The provider is not permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "status",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "status": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {
@@ -3028,6 +3216,28 @@
                     }
                 ],
                 "responses": {
+                    "403": {
+                        "description": "No provider is permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "status",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "status": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "200": {
                         "description": "User settings and available models",
                         "content": {
@@ -3331,6 +3541,28 @@
                     },
                     "400": {
                         "description": "Unknown provider or invalid value",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "status",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "status": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "The provider is not permitted for this user",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -5863,7 +6095,7 @@
         },
         {
             "name": "provider_settings",
-            "description": "Schema-driven read/write of provider configuration for the settings pages. Both the admin and the personal page render whatever LLMProviderInterface::getSettingsSchema() describes, so this controller never names a provider or a config key — adding a provider requires no change here. The admin/user split is enforced twice over: the admin routes carry no #[NoAdminRequired] (so Nextcloud requires an admin), and ProviderSettingsService::writeUser() additionally drops any field whose scope is not user-writable. That second check is what keeps endpoint URLs — which decide where the server sends outbound requests — out of reach of the personal page even if a route were ever mis-annotated."
+            "description": "Schema-driven read/write of provider configuration for the settings pages. Both the admin and the personal page render whatever LLMProviderInterface::getSettingsSchema() describes, so this controller never names a provider or a config key — adding a provider requires no change here. The admin/user split is enforced twice over: the admin routes carry no #[NoAdminRequired] (so Nextcloud requires an admin), and ProviderSettingsService::writeUser() additionally drops any field whose scope is not user-writable. That second check is what keeps endpoint URLs — which decide where the server sends outbound requests — out of reach of the personal page even if a route were ever mis-annotated. Provider *access* is enforced on top of that: index() only describes providers the current user is permitted to use, and update() refuses one they are not, so the personal page can neither see nor select a provider an admin blocked."
         },
         {
             "name": "coworker",

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",

--- a/nextcloud-app/src/App.vue
+++ b/nextcloud-app/src/App.vue
@@ -42,6 +42,15 @@
 		</NcAppNavigation>
 		<NcAppContent>
 			<div class="app-content-inner">
+				<!--
+					An admin can block every provider for this user. Say so once,
+					up front: without this the app looks fully functional and the
+					first message just fails.
+				-->
+				<NcNoteCard v-if="noProviderMessage" type="warning">
+					{{ noProviderMessage }}
+				</NcNoteCard>
+
 				<div class="tab-content">
 					<router-view v-slot="{ Component }">
 						<component :is="Component"
@@ -93,6 +102,7 @@ import NcContent from '@nextcloud/vue/components/NcContent'
 import NcAppNavigation from '@nextcloud/vue/components/NcAppNavigation'
 import NcAppNavigationItem from '@nextcloud/vue/components/NcAppNavigationItem'
 import NcAppContent from '@nextcloud/vue/components/NcAppContent'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcDialog from '@nextcloud/vue/components/NcDialog'
 
@@ -119,6 +129,7 @@ export default {
 		NcAppNavigationItem,
 		NcAppContent,
 		NcButton,
+		NcNoteCard,
 		CogIcon,
 		NcDialog,
 		SectionNav,
@@ -126,6 +137,7 @@ export default {
 	data() {
 		return {
 			conversations: loadState('aiquila', 'conversations', []),
+			noProviderMessage: loadState('aiquila', 'config', {}).no_provider || '',
 			activeConversation: null,
 			loading: false,
 			projects: [],

--- a/nextcloud-app/src/components/ChatView.vue
+++ b/nextcloud-app/src/components/ChatView.vue
@@ -267,7 +267,14 @@ export default {
 				try {
 					await this.sendNonStreaming(prompt, filePaths)
 				} catch (err2) {
+					// Both paths are gone, so there is no reply coming. Say why —
+					// this used to reset the draft and leave the message looking
+					// like it vanished, which is what a blocked provider (403)
+					// or an expired session looks like from the user's side.
 					console.error('aiquila: non-streaming fallback also failed', err2)
+					this.noticeIsError = true
+					this.notice = err2.response?.data?.error
+						|| t('aiquila', 'Your message could not be sent.')
 				}
 			} finally {
 				this.resetDraft()

--- a/nextcloud-app/src/components/settings/ProviderCard.vue
+++ b/nextcloud-app/src/components/settings/ProviderCard.vue
@@ -188,7 +188,15 @@ export default {
 				// Sensitive fields never carry a value from the server; an empty
 				// box means "leave the stored key alone", so they start blank
 				// and are only submitted when the admin types something.
-				draft[field.id] = field.sensitive ? '' : (field.value ?? '')
+				if (field.sensitive) {
+					draft[field.id] = ''
+				} else if (field.type === 'multiselect') {
+					// A list field is always a list, so an untouched card submits
+					// the same shape the backend validates.
+					draft[field.id] = Array.isArray(field.value) ? [...field.value] : []
+				} else {
+					draft[field.id] = field.value ?? ''
+				}
 			}
 			this.draft = draft
 			this.dirty = false

--- a/nextcloud-app/src/components/settings/SchemaField.vue
+++ b/nextcloud-app/src/components/settings/SchemaField.vue
@@ -15,7 +15,25 @@
 		<template v-else>
 			<label class="schema-field__label" :for="inputId">{{ field.title }}</label>
 
-			<NcSelect v-if="field.type === 'select'"
+			<!--
+				Principal picker for the per-provider access lists. There is no
+				fixed option list — the backend answers as the admin types — so
+				this branch owns its own async search, unlike the plain select
+				whose options arrive with the schema.
+			-->
+			<NcSelect v-if="field.type === 'multiselect'"
+				:model-value="selectedPrincipals"
+				:input-id="inputId"
+				:options="principalOptions"
+				:placeholder="field.placeholder || t('aiquila', 'Search users and groups…')"
+				:loading="principalsLoading"
+				:multiple="true"
+				:close-on-select="false"
+				label="label"
+				@search="onPrincipalSearch"
+				@update:model-value="emitPrincipals" />
+
+			<NcSelect v-else-if="field.type === 'select'"
 				:model-value="modelValue || null"
 				:input-id="inputId"
 				:options="field.options || []"
@@ -48,6 +66,7 @@
 
 <script>
 import { translate as t } from '@nextcloud/l10n'
+import { searchPrincipals } from '../../settings-api.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcPasswordField from '@nextcloud/vue/components/NcPasswordField'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
@@ -68,7 +87,7 @@ export default {
 			required: true,
 		},
 		modelValue: {
-			type: [String, Number, Boolean, null],
+			type: [String, Number, Boolean, Array, null],
 			default: '',
 		},
 		/** Provider id, used only to keep input ids unique across cards. */
@@ -83,9 +102,28 @@ export default {
 		},
 	},
 	emits: ['update:modelValue'],
+	data() {
+		return {
+			/** Options for the principal picker, refreshed as the admin types. */
+			principalOptions: [],
+			principalsLoading: false,
+			/** Labels learned from earlier searches, so stored ids render as names. */
+			principalLabels: {},
+			searchTimer: null,
+		}
+	},
 	computed: {
 		inputId() {
 			return `aiquila-${this.providerId}-${this.field.id}`
+		},
+		/**
+		 * NcSelect works in option objects; the field's value is a list of ids.
+		 * An id whose display name we have not seen yet renders as the id, which
+		 * is still unambiguous.
+		 */
+		selectedPrincipals() {
+			const ids = Array.isArray(this.modelValue) ? this.modelValue : []
+			return ids.map((id) => ({ id, label: this.principalLabels[id] || id }))
 		},
 		stringValue() {
 			return this.modelValue === null || this.modelValue === undefined ? '' : String(this.modelValue)
@@ -125,6 +163,44 @@ export default {
 		emit(value) {
 			this.$emit('update:modelValue', value)
 		},
+		/** Emit ids, not option objects — that is what the API stores. */
+		emitPrincipals(options) {
+			const list = (options || []).map((option) => {
+				if (option && typeof option === 'object') {
+					this.principalLabels[option.id] = option.label || option.id
+					return option.id
+				}
+				return option
+			})
+			this.$emit('update:modelValue', list)
+		},
+		/**
+		 * Debounced so a burst of keystrokes makes one request. The field's
+		 * `principal_type` decides which half of the answer is offered, so a
+		 * "blocked groups" picker never lists users.
+		 */
+		onPrincipalSearch(query) {
+			clearTimeout(this.searchTimer)
+			this.searchTimer = setTimeout(() => this.loadPrincipals(query), 300)
+		},
+		async loadPrincipals(query) {
+			this.principalsLoading = true
+			try {
+				const { data } = await searchPrincipals(query || '')
+				const wanted = this.field.principal_type === 'group' ? data.groups : data.users
+				this.principalOptions = wanted || []
+				this.principalOptions.forEach((option) => {
+					this.principalLabels[option.id] = option.label || option.id
+				})
+			} catch (e) {
+				this.principalOptions = []
+			} finally {
+				this.principalsLoading = false
+			}
+		},
+	},
+	beforeUnmount() {
+		clearTimeout(this.searchTimer)
 	},
 }
 </script>

--- a/nextcloud-app/src/settings-api.js
+++ b/nextcloud-app/src/settings-api.js
@@ -56,6 +56,16 @@ export function testProvider(providerId, apiKey = '') {
 	return axios.post(url(`/api/admin/providers/${providerId}/test`), { api_key: apiKey })
 }
 
+/**
+ * Search users and groups for the per-provider access lists (admin only).
+ *
+ * @param {string} search - substring to match against user and group names
+ * @return {Promise} resolving to `{users: [{id, label}], groups: [{id, label}]}`
+ */
+export function searchPrincipals(search = '') {
+	return axios.get(url('/api/admin/principals'), { params: { search } })
+}
+
 // ── Non-provider settings ───────────────────────────────────────────────
 
 export function getSettings() {

--- a/nextcloud-app/src/views/PersonalSettings.vue
+++ b/nextcloud-app/src/views/PersonalSettings.vue
@@ -10,7 +10,16 @@
 
 		<SettingsTabs v-else v-model="tab" :tabs="tabs">
 			<template #providers>
-				<NcNoteCard type="info">
+				<!--
+					An admin can block every provider for a user. Say so plainly
+					rather than showing an empty page with a note about defaults
+					that no longer apply to anything.
+				-->
+				<NcNoteCard v-if="providers.length === 0" type="warning">
+					{{ t('aiquila', 'No AI provider is available for your account. Ask your administrator for access.') }}
+				</NcNoteCard>
+
+				<NcNoteCard v-else type="info">
 					{{ inheritNote }}
 				</NcNoteCard>
 
@@ -26,7 +35,7 @@
 						@saved="load(false)" />
 				</div>
 
-				<NcButton v-if="userProvider" type="tertiary" @click="followInstanceDefault">
+				<NcButton v-if="userProvider && providers.length > 0" type="tertiary" @click="followInstanceDefault">
 					{{ t('aiquila', 'Follow the instance default again') }}
 				</NcButton>
 			</template>

--- a/nextcloud-app/tests/Unit/ChatControllerTest.php
+++ b/nextcloud-app/tests/Unit/ChatControllerTest.php
@@ -31,6 +31,9 @@ class ChatControllerTest extends TestCase {
         $this->cacheFactory->method('createDistributed')->willReturn($this->cache);
         $this->claude      = $this->createMock(ClaudeSDKService::class);
         $this->factory     = $this->createMock(LLMProviderFactory::class);
+        // Access control is exercised in LLMProviderFactoryTest; here every
+        // provider is permitted so the endpoints reach their own logic.
+        $this->factory->method('hasPermittedProvider')->willReturn(true);
         $this->factory->method('getProvider')->willReturn($this->claude);
         $this->fileService = $this->createMock(FileService::class);
         $this->filesService = $this->createMock(FilesService::class);

--- a/nextcloud-app/tests/Unit/LLMProviderFactoryTest.php
+++ b/nextcloud-app/tests/Unit/LLMProviderFactoryTest.php
@@ -8,6 +8,8 @@ use OCA\AIquila\Service\Provider\HetznerProvider;
 use OCA\AIquila\Service\Provider\LLMProviderFactory;
 use OCA\AIquila\Service\Provider\LocalProvider;
 use OCA\AIquila\Service\Provider\MistralProvider;
+use OCA\AIquila\Service\Provider\NoPermittedProviderException;
+use OCA\AIquila\Service\Provider\ProviderAccessService;
 use OCP\IConfig;
 use PHPUnit\Framework\TestCase;
 
@@ -18,6 +20,7 @@ class LLMProviderFactoryTest extends TestCase {
     private $deepseek;
     private $hetzner;
     private $local;
+    private $access;
     private LLMProviderFactory $factory;
 
     protected function setUp(): void {
@@ -33,7 +36,27 @@ class LLMProviderFactoryTest extends TestCase {
         $this->hetzner->method('getId')->willReturn('hetzner');
         $this->local->method('getId')->willReturn('local');
 
-        $this->factory = new LLMProviderFactory($this->config, $this->anthropic, $this->mistral, $this->deepseek, $this->hetzner, $this->local);
+        // Access control off by default: filterAllowed() returns everything, so
+        // these tests keep asserting the plain precedence rules.
+        $this->access = $this->createMock(ProviderAccessService::class);
+        $this->access->method('filterAllowed')->willReturnCallback(
+            static fn (array $ids, ?string $userId): array => $ids,
+        );
+        $this->access->method('isAllowed')->willReturn(true);
+
+        $this->factory = new LLMProviderFactory($this->config, $this->anthropic, $this->mistral, $this->deepseek, $this->hetzner, $this->local, $this->access);
+    }
+
+    /** Rebuild the factory with only $permitted allowed for every user. */
+    private function permitOnly(array $permitted): void {
+        $access = $this->createMock(ProviderAccessService::class);
+        $access->method('filterAllowed')->willReturnCallback(
+            static fn (array $ids, ?string $userId): array => array_values(array_intersect($ids, $permitted)),
+        );
+        $access->method('isAllowed')->willReturnCallback(
+            static fn (string $id, ?string $userId): bool => in_array($id, $permitted, true),
+        );
+        $this->factory = new LLMProviderFactory($this->config, $this->anthropic, $this->mistral, $this->deepseek, $this->hetzner, $this->local, $access);
     }
 
     public function testDefaultsToAnthropic(): void {
@@ -111,5 +134,54 @@ class LLMProviderFactoryTest extends TestCase {
         $this->assertFalse($described[3]['configured']);
         $this->assertSame('local', $described[4]['id']);
         $this->assertFalse($described[4]['configured']);
+    }
+
+    public function testDeniedUserOverrideFallsBackToTheInstanceDefault(): void {
+        // The user picked Mistral, but the admin has since blocked it for them.
+        $this->config->method('getUserValue')->willReturn('mistral');
+        $this->config->method('getAppValue')->willReturn('hetzner');
+        $this->permitOnly(['hetzner', 'local']);
+
+        $this->assertSame('hetzner', $this->factory->getActiveProviderId('u'));
+    }
+
+    public function testDeniedInstanceDefaultFallsThroughToAPermittedProvider(): void {
+        $this->config->method('getUserValue')->willReturn('');
+        $this->config->method('getAppValue')->willReturn('anthropic');
+        $this->permitOnly(['deepseek', 'local']);
+
+        // Display order decides, so deepseek wins over local.
+        $this->assertSame('deepseek', $this->factory->getActiveProviderId('u'));
+    }
+
+    public function testNoPermittedProviderFailsClosed(): void {
+        $this->config->method('getUserValue')->willReturn('');
+        $this->config->method('getAppValue')->willReturnArgument(2);
+        $this->permitOnly([]);
+
+        $this->expectException(NoPermittedProviderException::class);
+        $this->factory->getActiveProviderId('u');
+    }
+
+    public function testGetProviderForUserDegradesADeniedPin(): void {
+        $this->config->method('getUserValue')->willReturn('');
+        $this->config->method('getAppValue')->willReturn('local');
+        $this->permitOnly(['local']);
+
+        // The conversation is pinned to Mistral, which is now blocked.
+        $this->assertSame($this->local, $this->factory->getProviderForUser('u', 'mistral'));
+    }
+
+    public function testGetProviderForUserHonoursAPermittedPin(): void {
+        $this->config->method('getUserValue')->willReturn('');
+        $this->config->method('getAppValue')->willReturn('local');
+        $this->permitOnly(['local', 'mistral']);
+
+        $this->assertSame($this->mistral, $this->factory->getProviderForUser('u', 'mistral'));
+    }
+
+    public function testSystemContextIsUnrestricted(): void {
+        $this->config->method('getAppValue')->willReturn('mistral');
+        $this->assertSame('mistral', $this->factory->getActiveProviderId(null));
     }
 }

--- a/nextcloud-app/tests/Unit/ProviderAccessServiceTest.php
+++ b/nextcloud-app/tests/Unit/ProviderAccessServiceTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace OCA\AIquila\Tests\Unit;
+
+use OCA\AIquila\Db\ProviderAccessRule;
+use OCA\AIquila\Db\ProviderAccessRuleMapper;
+use OCA\AIquila\Service\Provider\ProviderAccessService;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The resolution matrix from GH #463: empty allow-list means everyone, a block
+ * always wins, and a null user id (CLI, background job) is never restricted.
+ */
+class ProviderAccessServiceTest extends TestCase {
+    private $mapper;
+    private $groupManager;
+    private $userManager;
+
+    protected function setUp(): void {
+        $this->mapper = $this->createMock(ProviderAccessRuleMapper::class);
+        $this->groupManager = $this->createMock(IGroupManager::class);
+        $this->userManager = $this->createMock(IUserManager::class);
+    }
+
+    /**
+     * @param list<array{0: string, 1: string, 2: string, 3: string}> $rules
+     *        provider, allow|block, user|group, principal
+     * @param list<string> $groupIds groups every user in the test belongs to
+     */
+    private function service(array $rules, array $groupIds = []): ProviderAccessService {
+        $entities = [];
+        foreach ($rules as [$providerId, $ruleType, $principalType, $principalId]) {
+            $rule = new ProviderAccessRule();
+            $rule->setProviderId($providerId);
+            $rule->setRuleType($ruleType);
+            $rule->setPrincipalType($principalType);
+            $rule->setPrincipalId($principalId);
+            $entities[] = $rule;
+        }
+        $this->mapper->method('findAll')->willReturn($entities);
+
+        $user = $this->createMock(IUser::class);
+        $this->userManager->method('get')->willReturn($user);
+        $this->groupManager->method('getUserGroupIds')->willReturn($groupIds);
+
+        // A cache that never hits, so every test reads the rules it declared.
+        $cache = $this->createMock(ICache::class);
+        $cache->method('get')->willReturn(null);
+        $cacheFactory = $this->createMock(ICacheFactory::class);
+        $cacheFactory->method('createDistributed')->willReturn($cache);
+
+        return new ProviderAccessService(
+            $this->mapper,
+            $this->groupManager,
+            $this->userManager,
+            $cacheFactory,
+            $this->createMock(LoggerInterface::class),
+        );
+    }
+
+    public function testNoRulesAllowsEveryone(): void {
+        $service = $this->service([]);
+        $this->assertTrue($service->isAllowed('anthropic', 'alice'));
+    }
+
+    public function testEmptyAllowListMeansEveryone(): void {
+        // Rules exist for another provider entirely; anthropic stays open.
+        $service = $this->service([['mistral', 'allow', 'user', 'bob']]);
+        $this->assertTrue($service->isAllowed('anthropic', 'alice'));
+        $this->assertFalse($service->isAllowed('mistral', 'alice'));
+        $this->assertTrue($service->isAllowed('mistral', 'bob'));
+    }
+
+    public function testAllowedGroupGrantsAccess(): void {
+        $service = $this->service([['hetzner', 'allow', 'group', 'marketing']], ['marketing']);
+        $this->assertTrue($service->isAllowed('hetzner', 'alice'));
+    }
+
+    public function testNonMemberOfAllowedGroupIsDenied(): void {
+        $service = $this->service([['hetzner', 'allow', 'group', 'marketing']], ['sales']);
+        $this->assertFalse($service->isAllowed('hetzner', 'alice'));
+    }
+
+    public function testBlockedUserWinsOverAllowedUser(): void {
+        $service = $this->service([
+            ['anthropic', 'allow', 'user', 'alice'],
+            ['anthropic', 'block', 'user', 'alice'],
+        ]);
+        $this->assertFalse($service->isAllowed('anthropic', 'alice'));
+    }
+
+    public function testBlockedGroupWinsOverAllowedUser(): void {
+        $service = $this->service([
+            ['anthropic', 'allow', 'user', 'alice'],
+            ['anthropic', 'block', 'group', 'contractors'],
+        ], ['contractors']);
+        $this->assertFalse($service->isAllowed('anthropic', 'alice'));
+    }
+
+    public function testBlockAppliesWithNoAllowListAtAll(): void {
+        $service = $this->service([['anthropic', 'block', 'group', 'contractors']], ['contractors']);
+        $this->assertFalse($service->isAllowed('anthropic', 'alice'));
+    }
+
+    public function testNullUserIsUnrestricted(): void {
+        $service = $this->service([['anthropic', 'block', 'user', 'alice']]);
+        $this->assertTrue($service->isAllowed('anthropic', null));
+        $this->assertSame(['anthropic'], $service->filterAllowed(['anthropic'], null));
+    }
+
+    public function testFilterAllowedPreservesDisplayOrder(): void {
+        $service = $this->service([
+            ['anthropic', 'block', 'user', 'alice'],
+            ['deepseek', 'allow', 'group', 'marketing'],
+        ], ['sales']);
+
+        $this->assertSame(
+            ['mistral', 'hetzner', 'local'],
+            $service->filterAllowed(['anthropic', 'mistral', 'deepseek', 'hetzner', 'local'], 'alice'),
+        );
+    }
+
+    public function testGetListsAlwaysReturnsAllFourKeys(): void {
+        $service = $this->service([['mistral', 'allow', 'group', 'marketing']]);
+
+        $this->assertSame([
+            'allowed_users' => [],
+            'allowed_groups' => ['marketing'],
+            'blocked_users' => [],
+            'blocked_groups' => [],
+        ], $service->getLists('mistral'));
+
+        $this->assertSame([
+            'allowed_users' => [],
+            'allowed_groups' => [],
+            'blocked_users' => [],
+            'blocked_groups' => [],
+        ], $service->getLists('anthropic'));
+    }
+
+    public function testSetListsReplacesOnlyTheNamedLists(): void {
+        $service = $this->service([]);
+
+        $written = [];
+        $this->mapper->method('replaceList')->willReturnCallback(
+            function (string $provider, string $rule, string $principal, array $ids) use (&$written): void {
+                $written[] = [$provider, $rule, $principal, $ids];
+            },
+        );
+
+        $service->setLists('mistral', [
+            'blocked_groups' => ['contractors'],
+            'not_a_list' => ['ignored'],
+        ]);
+
+        $this->assertSame([['mistral', 'block', 'group', ['contractors']]], $written);
+    }
+
+    /**
+     * QBMapper::insert() writes only the fields Entity marked as updated, and
+     * Entity marks a field updated only when the value changes. A property
+     * defaulted to 'allow'/'user' would therefore be omitted from the INSERT
+     * for exactly the rows that use those values, and the NOT NULL column would
+     * reject the row.
+     */
+    public function testEveryColumnIsMarkedUpdatedEvenAtItsMostCommonValue(): void {
+        $rule = new ProviderAccessRule();
+        $rule->setProviderId('anthropic');
+        $rule->setRuleType(ProviderAccessRule::RULE_ALLOW);
+        $rule->setPrincipalType(ProviderAccessRule::PRINCIPAL_USER);
+        $rule->setPrincipalId('alice');
+
+        $this->assertSame(
+            ['providerId', 'ruleType', 'principalType', 'principalId'],
+            array_keys($rule->getUpdatedFields()),
+        );
+    }
+}

--- a/nextcloud-app/tests/Unit/ProviderSettingsControllerTest.php
+++ b/nextcloud-app/tests/Unit/ProviderSettingsControllerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace OCA\AIquila\Tests\Unit;
+
+use OCA\AIquila\Controller\ProviderSettingsController;
+use OCA\AIquila\Service\CredentialService;
+use OCA\AIquila\Service\Provider\LLMProviderFactory;
+use OCA\AIquila\Service\Provider\LLMProviderInterface;
+use OCA\AIquila\Service\Provider\NoPermittedProviderException;
+use OCA\AIquila\Service\Provider\ProviderSettingsService;
+use OCP\AppFramework\Http;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUserManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The personal settings API must never describe — or accept a write for — a
+ * provider the admin has blocked for the caller.
+ */
+class ProviderSettingsControllerTest extends TestCase {
+    private $config;
+    private $factory;
+    private $settings;
+    private ProviderSettingsController $ctrl;
+
+    protected function setUp(): void {
+        $this->config = $this->createMock(IConfig::class);
+        $this->config->method('getUserValue')->willReturn('');
+        $this->config->method('getAppValue')->willReturnArgument(2);
+
+        $this->factory = $this->createMock(LLMProviderFactory::class);
+        $this->factory->method('getProviderIds')->willReturn(['anthropic', 'mistral']);
+        $this->factory->method('isKnownProviderId')->willReturn(true);
+        $this->factory->method('getProviderById')->willReturnCallback(
+            function (string $id): LLMProviderInterface {
+                $provider = $this->createMock(LLMProviderInterface::class);
+                $provider->method('getId')->willReturn($id);
+                return $provider;
+            },
+        );
+
+        $this->settings = $this->createMock(ProviderSettingsService::class);
+        $this->settings->method('describe')->willReturnCallback(
+            static fn (LLMProviderInterface $p): array => ['id' => $p->getId()],
+        );
+
+        $this->ctrl = new ProviderSettingsController(
+            'aiquila',
+            $this->createMock(IRequest::class),
+            'testuser',
+            $this->config,
+            $this->factory,
+            $this->settings,
+            $this->createMock(CredentialService::class),
+            $this->createMock(IUserManager::class),
+            $this->createMock(IGroupManager::class),
+            $this->createMock(LoggerInterface::class),
+        );
+    }
+
+    public function testIndexOmitsDeniedProviders(): void {
+        $this->factory->method('getActiveProviderId')->willReturn('mistral');
+        $this->factory->method('getProviderIdsForUser')->willReturn(['mistral']);
+
+        $data = $this->ctrl->index()->getData();
+
+        $this->assertSame([['id' => 'mistral']], $data['providers']);
+        $this->assertSame('mistral', $data['defaultProvider']);
+    }
+
+    public function testIndexReportsAnEmptyStateWhenEveryProviderIsDenied(): void {
+        $this->factory->method('getActiveProviderId')
+            ->willThrowException(new NoPermittedProviderException('testuser'));
+        $this->factory->method('getProviderIdsForUser')->willReturn([]);
+
+        $data = $this->ctrl->index()->getData();
+
+        $this->assertSame([], $data['providers']);
+        $this->assertSame('', $data['defaultProvider']);
+    }
+
+    public function testUpdateRefusesADeniedProvider(): void {
+        $this->factory->method('isAllowedForUser')->willReturn(false);
+        // The write must not happen at all, not merely be reported as rejected.
+        $this->settings->expects($this->never())->method('writeUser');
+        $this->config->expects($this->never())->method('setUserValue');
+
+        $response = $this->ctrl->update('anthropic', ['model' => 'x'], '1');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }
+
+    public function testUpdateAcceptsAPermittedProvider(): void {
+        $this->factory->method('isAllowedForUser')->willReturn(true);
+        $this->settings->method('writeUser')->willReturn([]);
+
+        $response = $this->ctrl->update('anthropic', ['model' => 'x']);
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame('ok', $response->getData()['status']);
+    }
+}

--- a/nextcloud-app/tests/Unit/ProviderSettingsServiceTest.php
+++ b/nextcloud-app/tests/Unit/ProviderSettingsServiceTest.php
@@ -4,11 +4,14 @@ namespace OCA\AIquila\Tests\Unit;
 
 use OCA\AIquila\Service\CredentialService;
 use OCA\AIquila\Service\Provider\LLMProviderInterface;
+use OCA\AIquila\Service\Provider\ProviderAccessService;
 use OCA\AIquila\Service\Provider\ProviderSettingsSchema;
 use OCA\AIquila\Service\Provider\ProviderSettingsService;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\IUserManager;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -17,6 +20,9 @@ class ProviderSettingsServiceTest extends TestCase {
     private $credentials;
     private $cacheFactory;
     private $cache;
+    private $access;
+    private $userManager;
+    private $groupManager;
     private ProviderSettingsService $service;
 
     protected function setUp(): void {
@@ -26,9 +32,22 @@ class ProviderSettingsServiceTest extends TestCase {
         $this->cache = $this->createMock(ICache::class);
         $this->cacheFactory->method('createDistributed')->willReturn($this->cache);
 
+        $this->access = $this->createMock(ProviderAccessService::class);
+        $this->access->method('getLists')->willReturn([
+            'allowed_users' => [],
+            'allowed_groups' => [],
+            'blocked_users' => [],
+            'blocked_groups' => [],
+        ]);
+        $this->userManager = $this->createMock(IUserManager::class);
+        $this->groupManager = $this->createMock(IGroupManager::class);
+
         $this->service = new ProviderSettingsService(
             $this->config,
             $this->credentials,
+            $this->access,
+            $this->userManager,
+            $this->groupManager,
             $this->cacheFactory,
             $this->createMock(LoggerInterface::class),
         );

--- a/nextcloud-app/tests/Unit/SettingsControllerTest.php
+++ b/nextcloud-app/tests/Unit/SettingsControllerTest.php
@@ -36,6 +36,9 @@ class SettingsControllerTest extends TestCase {
         $this->provider->method('isConfigured')->willReturn(false);
         $this->factory->method('getActiveProviderId')->willReturn('anthropic');
         $this->factory->method('getProviderIds')->willReturn(['anthropic']);
+        $this->factory->method('getProviderIdsForUser')->willReturn(['anthropic']);
+        $this->factory->method('isKnownProviderId')->willReturn(true);
+        $this->factory->method('isAllowedForUser')->willReturn(true);
         $this->factory->method('getProviderById')->willReturn($this->provider);
         $this->factory->method('getProvider')->willReturn($this->provider);
 


### PR DESCRIPTION
Closes #463

## What

Each provider now carries four access lists — allowed users, allowed groups, blocked users, blocked groups — editable per provider card on the admin settings page.

Semantics, exactly as the issue specifies:

- An **empty allow-list means everyone.**
- **A block always wins** over an allow, whether it names the user or one of their groups.
- The instance default is **itself resolved through the check**: if it is denied for a user, resolution falls through to the first provider they may actually use rather than handing them one they cannot.
- A `null` user id — CLI, background job, admin settings — is unrestricted.

## Enforcement is server-side on every provider-selecting path

Enforcement lives in `LLMProviderFactory`, not in the settings UI, so filtering a provider off a page is a *consequence* of the check rather than the check itself:

- `getActiveProviderId()` filters the user override and the instance default, falling through in display order. When nothing is left it throws `NoPermittedProviderException` and endpoints answer **403** — it fails closed rather than serving a blocked provider.
- `getProviderForUser($userId, $pinnedId)` is the new lookup for **stored** pins. Permissions can be revoked after a conversation or coworker is pinned, so a revoked pin degrades to the user's current provider instead of continuing to be honoured.
- Guarded call sites: both settings controllers, `ConversationController` (create / setModel / duplicate / message / stream), `ChatController`, `PageController`, `CoworkerService`, `AbstractVisionTaskType`, `ClaudeImageToTextProvider`.

The admin settings page is deliberately **not** filtered — an admin has to be able to edit the rules of a provider they are themselves blocked from, so a lockout is always reversible.

## Storage

New `aiquila_provider_access` table, one row per `(provider, allow|block, user|group, principal)`, with a mapper and migration. **An empty table means every provider is open to everyone, so an existing instance behaves exactly as before the upgrade.**

## Schema and UI

The four lists are **not** declared by any provider — access control is a property of the app, not of a provider — so `ProviderSettingsService::schemaFor()` appends them to every provider's schema. A new provider gets them automatically and cannot forget them.

They carry `storage => 'access'` instead of a config key: `describe()` fills them from `ProviderAccessService`, `writeAdmin()` routes them to `setLists()`. Being `SCOPE_ADMIN`, the existing scope rules already keep them off the personal page. New `TYPE_MULTISELECT` field type plus an admin-only `GET /api/admin/principals` search endpoint backs the pickers; submitted ids are validated against `IUserManager` / `IGroupManager` so a typo cannot be stored as a silent non-grant.

## Two frontend fixes for the blocked state

The blocked state was previously **invisible**, which made a correct 403 look like a broken app:

- `ChatView.vue` caught a failed send, logged to the console and reset the draft — the user's message appeared to vanish with no explanation. It now surfaces the server's message. This helps beyond this feature: an expired session or a dead provider used to fail the same silent way.
- `App.vue` shows a banner up front, so a blocked user learns why on arrival rather than on their first message. (The `no_provider` initial state was otherwise dead — nothing read `config`.)

## One bug worth flagging

Caught by the live DB round-trip, not by unit tests: `Entity`'s magic setter only marks a field updated when the value *changes*, and `QBMapper::insert()` writes only updated fields — so entity properties defaulted to `'allow'` / `'user'` were silently dropped from the INSERT and hit the NOT NULL constraint for exactly the rows using those values. Defaults are now empty strings, with a regression test asserting all four columns are marked updated.

## Testing

`composer psalm` clean, **499 unit tests pass**, OpenAPI spec regenerated, frontend builds.

New tests: `ProviderAccessServiceTest` (full resolution matrix — empty allow-list, deny-over-allow via user and via group, group-only allow, null user unrestricted, order preservation), `ProviderSettingsControllerTest` (`index()` omits denied providers, `update()` 403s and writes nothing), and new `LLMProviderFactoryTest` cases for denied override, denied default fall-through, fail-closed, and pin degradation.

Verified end-to-end against the dev stack (NC33 + Postgres):

| Scenario | Result |
|---|---|
| **Default — no rules** | all 5 providers, `/api/settings` 200 — unchanged by the upgrade |
| Block one provider for a group | user keeps the other 4, fully functional |
| Denied instance default | falls through; unaffected users still get it |
| Allow-list one provider to one user | others see everything except it |
| Deny beats allow (allow user + block their group) | denied |
| Unknown principal id | 400 with a clear message |
| Select / pin a denied provider | 403, nothing written |
| Every provider blocked | empty list, 403 on settings / create / message / stream / ask, banner served, page still renders, admin can still undo |
| Principals endpoint as a non-admin | 403 |

Test rules were cleared afterwards; the table is empty and full access restored.

## Note

I did **not** add an admin-side warning that a rule would leave someone with no provider at all. Computing it honestly means evaluating every user against every provider on each save and would be advisory only; the admin's protection is that the state is fully visible and reversible from their own page. Happy to add it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
