### PR TITLE
feat(nextcloud): live status light on provider cards

### DIFF
--- a/nextcloud-app/appinfo/routes.php
+++ b/nextcloud-app/appinfo/routes.php
@@ -41,6 +41,11 @@ return [
         ['name' => 'provider_settings#adminIndex',  'url' => '/api/admin/providers',                  'verb' => 'GET'],
         ['name' => 'provider_settings#adminUpdate', 'url' => '/api/admin/providers/{providerId}',     'verb' => 'POST'],
         ['name' => 'provider_settings#test',        'url' => '/api/admin/providers/{providerId}/test', 'verb' => 'POST'],
+        // Live health behind the status light on a provider card. The user-scope
+        // route probes what that user actually gets, so the personal page shows
+        // the same four states the admin page does.
+        ['name' => 'provider_settings#status',      'url' => '/api/providers/{providerId}/status',       'verb' => 'GET'],
+        ['name' => 'provider_settings#adminStatus', 'url' => '/api/admin/providers/{providerId}/status', 'verb' => 'GET'],
         // Backs the user/group pickers on the per-provider access lists.
         ['name' => 'provider_settings#principals',  'url' => '/api/admin/principals',                 'verb' => 'GET'],
         ['name' => 'occ#execute', 'url' => '/api/occ', 'verb' => 'POST'],

--- a/nextcloud-app/lib/Controller/ProviderSettingsController.php
+++ b/nextcloud-app/lib/Controller/ProviderSettingsController.php
@@ -221,6 +221,65 @@ class ProviderSettingsController extends Controller {
     }
 
     /**
+     * Report whether a provider is reachable and serving the configured model
+     *
+     * Backs the status light on the personal settings page: the light describes
+     * what *this user* gets, so the probe runs against their own key when they
+     * have one and the inherited instance key otherwise.
+     *
+     * @param string $providerId Provider to check
+     *
+     * 200: Current provider health
+     * 400: Unknown provider
+     * 403: The provider is not permitted for this user
+     *
+     * @return JSONResponse<Http::STATUS_OK, array{providerId: string, state: string, reason: string, message: string, model: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{status: string, message: string}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{status: string, message: string}, array{}>
+     *
+     * @NoAdminRequired
+     */
+    #[NoAdminRequired]
+    #[OpenAPI]
+    public function status(string $providerId): JSONResponse {
+        if (!$this->providerFactory->isKnownProviderId($providerId)) {
+            return $this->unknownProvider($providerId);
+        }
+
+        $userId = $this->requireUserId();
+        if (!$this->providerFactory->isAllowedForUser($providerId, $userId)) {
+            return $this->forbiddenProvider($providerId, $userId);
+        }
+
+        return new JSONResponse($this->providerSettings->status(
+            $this->providerFactory->getProviderById($providerId),
+            $userId,
+            admin: false,
+        ));
+    }
+
+    /**
+     * Report whether a provider is reachable and serving the instance model
+     *
+     * @param string $providerId Provider to check
+     *
+     * 200: Current provider health
+     * 400: Unknown provider
+     *
+     * @return JSONResponse<Http::STATUS_OK, array{providerId: string, state: string, reason: string, message: string, model: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{status: string, message: string}, array{}>
+     */
+    #[OpenAPI(scope: OpenAPI::SCOPE_ADMINISTRATION)]
+    public function adminStatus(string $providerId): JSONResponse {
+        if (!$this->providerFactory->isKnownProviderId($providerId)) {
+            return $this->unknownProvider($providerId);
+        }
+
+        return new JSONResponse($this->providerSettings->status(
+            $this->providerFactory->getProviderById($providerId),
+            null,
+            admin: true,
+        ));
+    }
+
+    /**
      * Send a live request to a provider to confirm it is reachable and authorised
      *
      * Optionally accepts a key that has not been saved yet, so an admin can

--- a/nextcloud-app/lib/Service/ClaudeSDKService.php
+++ b/nextcloud-app/lib/Service/ClaudeSDKService.php
@@ -25,6 +25,7 @@ use Anthropic\Messages\Message;
 use Anthropic\Messages\Usage;
 use Anthropic\Models\ModelInfo;
 use OCA\AIquila\Service\Provider\LLMProviderInterface;
+use OCA\AIquila\Service\Provider\ProviderProbe;
 use OCA\AIquila\Service\Provider\ProviderSettingsSchema;
 use OCP\ICache;
 use OCP\ICacheFactory;
@@ -545,6 +546,37 @@ class ClaudeSDKService implements LLMProviderInterface {
             ]);
             return null;
         }
+    }
+
+    public function probe(?string $userId = null): array {
+        $model = $this->getModel($userId);
+        if (!$this->isConfigured($userId)) {
+            return ProviderProbe::unconfigured('No Anthropic API key configured', $model);
+        }
+        try {
+            $client = $this->getClient($userId);
+            $items = $this->callListModels($client, ['limit' => 1000]);
+            return ProviderProbe::fromModels(array_map(fn (ModelInfo $m) => $m->id, $items), $model);
+        } catch (AuthenticationException|PermissionDeniedException $e) {
+            // The SDK types these, so no message sniffing is needed here.
+            return ProviderProbe::unauthorized('The Anthropic API rejected the key: ' . self::probeDetail($e), $model);
+        } catch (RateLimitException $e) {
+            return ProviderProbe::rateLimited('Anthropic is rate-limiting this key: ' . self::probeDetail($e), $model);
+        } catch (APIConnectionException|APITimeoutException $e) {
+            return ProviderProbe::unreachable('Could not reach the Anthropic API: ' . self::probeDetail($e), $model);
+        } catch (\Throwable $e) {
+            return ProviderProbe::fromThrowable($e, 'Anthropic API error: ' . self::probeDetail($e), $model);
+        }
+    }
+
+    /**
+     * The SDK renders its exceptions as a headline plus a pretty-printed JSON
+     * body. Only the headline belongs in a tooltip; the full text is already in
+     * the log line the status endpoint writes.
+     */
+    private static function probeDetail(\Throwable $e): string {
+        $first = strtok($e->getMessage(), "\n");
+        return $first === false ? $e->getMessage() : trim($first);
     }
 
     /**

--- a/nextcloud-app/lib/Service/Provider/AbstractOpenAiCompatibleProvider.php
+++ b/nextcloud-app/lib/Service/Provider/AbstractOpenAiCompatibleProvider.php
@@ -151,24 +151,50 @@ abstract class AbstractOpenAiCompatibleProvider implements LLMProviderInterface 
             return null;
         }
         try {
-            $client = $this->clientService->newClient();
-            $response = $client->get($this->apiBase() . '/models', $this->requestOptions($userId, [
-                'timeout' => 15,
-            ]));
-            $data = json_decode((string)$response->getBody(), true);
-            $items = is_array($data) ? ($data['data'] ?? []) : [];
-            $ids = [];
-            foreach ($items as $m) {
-                if (isset($m['id']) && is_string($m['id'])) {
-                    $ids[] = $m['id'];
-                }
-            }
-            sort($ids);
+            $ids = $this->fetchModelIds($userId);
             return $ids !== [] ? $ids : null;
         } catch (\Throwable $e) {
             $this->logger->warning('AIquila ' . $this->getLabel() . ': Could not list models', ['error' => $e->getMessage()]);
             return null;
         }
+    }
+
+    public function probe(?string $userId = null): array {
+        $model = $this->getModel($userId);
+        if (!$this->isConfigured($userId)) {
+            return ProviderProbe::unconfigured($this->notConfiguredMessage(), $model);
+        }
+        try {
+            return ProviderProbe::fromModels($this->fetchModelIds($userId), $model);
+        } catch (\Throwable $e) {
+            return ProviderProbe::fromThrowable($e, $this->errorMessage($e), $model);
+        }
+    }
+
+    /**
+     * The /models listing, letting failures out.
+     *
+     * listModels() swallows them to keep its ?array contract; probe() needs the
+     * exception itself to tell a rejected key from a dead endpoint, so the call
+     * lives here and each caller decides what to do with a throw.
+     *
+     * @return list<string>
+     */
+    protected function fetchModelIds(?string $userId): array {
+        $client = $this->clientService->newClient();
+        $response = $client->get($this->apiBase() . '/models', $this->requestOptions($userId, [
+            'timeout' => 15,
+        ]));
+        $data = json_decode((string)$response->getBody(), true);
+        $items = is_array($data) ? ($data['data'] ?? []) : [];
+        $ids = [];
+        foreach ($items as $m) {
+            if (isset($m['id']) && is_string($m['id'])) {
+                $ids[] = $m['id'];
+            }
+        }
+        sort($ids);
+        return $ids;
     }
 
     // ── Non-streaming entry points ──────────────────────────────────────────

--- a/nextcloud-app/lib/Service/Provider/LLMProviderInterface.php
+++ b/nextcloud-app/lib/Service/Provider/LLMProviderInterface.php
@@ -74,6 +74,19 @@ interface LLMProviderInterface {
      */
     public function listModels(?string $userId = null): ?array;
 
+    /**
+     * Cheap liveness check for the settings UI: can this key reach this
+     * endpoint, and is the configured model actually on offer?
+     *
+     * Unlike listModels(), which flattens every failure to null, a probe
+     * distinguishes a rejected key from an unreachable host from a provider
+     * that is merely rate-limiting — that is what the four-state light on a
+     * provider card needs. Build the return value with ProviderProbe.
+     *
+     * @return array{state: string, reason: string, message: string, model: string}
+     */
+    public function probe(?string $userId = null): array;
+
     /** @return array{response: string, usage?: array, citations?: array}|array{error: string} */
     public function ask(string $prompt, string $context = '', ?string $userId = null, array $options = []): array;
 

--- a/nextcloud-app/lib/Service/Provider/MistralProvider.php
+++ b/nextcloud-app/lib/Service/Provider/MistralProvider.php
@@ -117,30 +117,52 @@ class MistralProvider implements LLMProviderInterface {
     }
 
     public function listModels(?string $userId = null): ?array {
-        $apiKey = $this->getApiKey($userId);
-        if ($apiKey === '') {
+        if ($this->getApiKey($userId) === '') {
             return null;
         }
         try {
-            $client = $this->clientService->newClient();
-            $response = $client->get(self::API_BASE . '/models', [
-                'headers' => $this->headers($apiKey),
-                'timeout' => 15,
-            ]);
-            $data = json_decode((string)$response->getBody(), true);
-            $items = $data['data'] ?? [];
-            $ids = [];
-            foreach ($items as $m) {
-                if (isset($m['id']) && is_string($m['id'])) {
-                    $ids[] = $m['id'];
-                }
-            }
-            sort($ids);
+            $ids = $this->fetchModelIds($userId);
             return $ids !== [] ? $ids : null;
         } catch (\Throwable $e) {
             $this->logger->warning('AIquila Mistral: Could not list models', ['error' => $e->getMessage()]);
             return null;
         }
+    }
+
+    public function probe(?string $userId = null): array {
+        $model = $this->getModel($userId);
+        if ($this->getApiKey($userId) === '') {
+            return ProviderProbe::unconfigured('No Mistral API key configured', $model);
+        }
+        try {
+            return ProviderProbe::fromModels($this->fetchModelIds($userId), $model);
+        } catch (\Throwable $e) {
+            return ProviderProbe::fromThrowable($e, $this->errorMessage($e), $model);
+        }
+    }
+
+    /**
+     * The /models listing, letting failures out — see the note on
+     * AbstractOpenAiCompatibleProvider::fetchModelIds().
+     *
+     * @return list<string>
+     */
+    private function fetchModelIds(?string $userId): array {
+        $client = $this->clientService->newClient();
+        $response = $client->get(self::API_BASE . '/models', [
+            'headers' => $this->headers($this->getApiKey($userId)),
+            'timeout' => 15,
+        ]);
+        $data = json_decode((string)$response->getBody(), true);
+        $items = is_array($data) ? ($data['data'] ?? []) : [];
+        $ids = [];
+        foreach ($items as $m) {
+            if (isset($m['id']) && is_string($m['id'])) {
+                $ids[] = $m['id'];
+            }
+        }
+        sort($ids);
+        return $ids;
     }
 
     // ── Non-streaming entry points ──────────────────────────────────────────

--- a/nextcloud-app/lib/Service/Provider/ProviderProbe.php
+++ b/nextcloud-app/lib/Service/Provider/ProviderProbe.php
@@ -1,0 +1,120 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Service\Provider;
+
+/**
+ * Classification helper behind LLMProviderInterface::probe().
+ *
+ * A probe answers two questions the stored configuration cannot: does this key
+ * reach this endpoint at all, and is the configured model actually on offer.
+ * The four states map straight onto the light on a provider card — grey, red,
+ * orange, green — and `reason` is the stable token that ends up in the log line
+ * accompanying a red or orange light.
+ *
+ * Providers have no typed exception hierarchy to lean on: both the SDK and the
+ * OpenAI-compatible HTTP path surface failures as arbitrary \Throwables whose
+ * messages carry the status code. The sniffing here mirrors what the existing
+ * errorMessage() implementations already do for chat errors, kept in one place
+ * so every provider classifies identically.
+ */
+final class ProviderProbe {
+    public const STATE_UNCONFIGURED = 'unconfigured';
+    public const STATE_ERROR = 'error';
+    public const STATE_DEGRADED = 'degraded';
+    public const STATE_OK = 'ok';
+
+    public const REASON_NOT_CONFIGURED = 'not_configured';
+    public const REASON_UNAUTHORIZED = 'unauthorized';
+    public const REASON_RATE_LIMITED = 'rate_limited';
+    public const REASON_UNREACHABLE = 'unreachable';
+    public const REASON_MODEL_MISSING = 'model_missing';
+    public const REASON_OK = 'ok';
+
+    /** @return array{state: string, reason: string, message: string, model: string} */
+    public static function unconfigured(string $message, string $model = ''): array {
+        return self::result(self::STATE_UNCONFIGURED, self::REASON_NOT_CONFIGURED, $message, $model);
+    }
+
+    /**
+     * Outcome of a successful listing: green when the configured model is among
+     * the ids the provider returned, orange when it is not. A provider that
+     * answers with an empty list is reachable but cannot serve anything, which
+     * is the same practical situation.
+     *
+     * @param list<string> $models
+     * @return array{state: string, reason: string, message: string, model: string}
+     */
+    public static function fromModels(array $models, string $model): array {
+        if ($models === []) {
+            return self::result(
+                self::STATE_DEGRADED,
+                self::REASON_MODEL_MISSING,
+                'The provider answered but offers no models.',
+                $model,
+            );
+        }
+        if ($model !== '' && !in_array($model, $models, true)) {
+            return self::result(
+                self::STATE_DEGRADED,
+                self::REASON_MODEL_MISSING,
+                'The provider is reachable but does not offer "' . $model . '". Pick another model.',
+                $model,
+            );
+        }
+        return self::result(self::STATE_OK, self::REASON_OK, 'Reachable, and the configured model is available.', $model);
+    }
+
+    /** @return array{state: string, reason: string, message: string, model: string} */
+    public static function unauthorized(string $message, string $model = ''): array {
+        return self::result(self::STATE_ERROR, self::REASON_UNAUTHORIZED, $message, $model);
+    }
+
+    /** @return array{state: string, reason: string, message: string, model: string} */
+    public static function unreachable(string $message, string $model = ''): array {
+        return self::result(self::STATE_ERROR, self::REASON_UNREACHABLE, $message, $model);
+    }
+
+    /** @return array{state: string, reason: string, message: string, model: string} */
+    public static function rateLimited(string $message, string $model = ''): array {
+        return self::result(self::STATE_DEGRADED, self::REASON_RATE_LIMITED, $message, $model);
+    }
+
+    /**
+     * Outcome of a failed listing. $message is the provider's own human-readable
+     * rendering of the error (errorMessage()), so the wording stays per-provider
+     * while the classification stays shared.
+     *
+     * Rate limiting is orange rather than red: the key is valid and the endpoint
+     * answered, the request just has to wait.
+     *
+     * @return array{state: string, reason: string, message: string, model: string}
+     */
+    public static function fromThrowable(\Throwable $e, string $message, string $model = ''): array {
+        $raw = $e->getMessage();
+        if (self::mentions($raw, ['401', '403', 'unauthorized', 'forbidden', 'invalid api key', 'authentication'])) {
+            return self::result(self::STATE_ERROR, self::REASON_UNAUTHORIZED, $message, $model);
+        }
+        if (self::mentions($raw, ['429', 'rate limit', 'too many requests', 'quota'])) {
+            return self::result(self::STATE_DEGRADED, self::REASON_RATE_LIMITED, $message, $model);
+        }
+        return self::result(self::STATE_ERROR, self::REASON_UNREACHABLE, $message, $model);
+    }
+
+    /** @param list<string> $needles */
+    private static function mentions(string $haystack, array $needles): bool {
+        foreach ($needles as $needle) {
+            if (stripos($haystack, $needle) !== false) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** @return array{state: string, reason: string, message: string, model: string} */
+    private static function result(string $state, string $reason, string $message, string $model): array {
+        return ['state' => $state, 'reason' => $reason, 'message' => $message, 'model' => $model];
+    }
+}

--- a/nextcloud-app/lib/Service/Provider/ProviderSettingsService.php
+++ b/nextcloud-app/lib/Service/Provider/ProviderSettingsService.php
@@ -229,6 +229,41 @@ class ProviderSettingsService {
         return $models;
     }
 
+    /**
+     * Live health of one provider, for the status light on its settings card.
+     *
+     * Deliberately uncached: the light is fetched lazily per card, and a stale
+     * green after a key was revoked would be worse than no light at all. The
+     * probe is a single /models call, which is the cheapest thing a provider
+     * answers.
+     *
+     * @param bool $admin true to probe the instance configuration, false to
+     *                    probe what this user actually gets (personal key or
+     *                    inherited instance key)
+     * @return array{providerId: string, state: string, reason: string, message: string, model: string}
+     */
+    public function status(LLMProviderInterface $provider, ?string $userId, bool $admin): array {
+        $id = $provider->getId();
+        $result = $provider->probe($admin ? null : $userId);
+
+        $context = [
+            'provider' => $id,
+            'reason' => $result['reason'],
+            'scope' => $admin ? 'admin' : 'user',
+            'model' => $result['model'],
+        ];
+        // A red or orange light always has a log line explaining it; a green one
+        // stays at debug so a settings page full of healthy providers does not
+        // fill the log.
+        match ($result['state']) {
+            ProviderProbe::STATE_ERROR => $this->logger->warning('AIquila: provider status ' . $id . ' is unhealthy: ' . $result['message'], $context),
+            ProviderProbe::STATE_DEGRADED => $this->logger->info('AIquila: provider status ' . $id . ' is degraded: ' . $result['message'], $context),
+            default => $this->logger->debug('AIquila: provider status ' . $id . ' is ' . $result['state'], $context),
+        };
+
+        return ['providerId' => $id] + $result;
+    }
+
     /** Drop the cached model list for a provider (or all of them). */
     public function forgetModels(?string $providerId = null): void {
         $cache = $this->cacheFactory->createDistributed('aiquila-models');

--- a/nextcloud-app/openapi-administration.json
+++ b/nextcloud-app/openapi-administration.json
@@ -718,6 +718,139 @@
                 }
             }
         },
+        "/index.php/apps/aiquila/api/admin/providers/{providerId}/status": {
+            "get": {
+                "operationId": "provider_settings-admin-status",
+                "summary": "Report whether a provider is reachable and serving the instance model",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "provider_settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "providerId",
+                        "in": "path",
+                        "description": "Provider to check",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Current provider health",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "providerId",
+                                        "state",
+                                        "reason",
+                                        "message",
+                                        "model"
+                                    ],
+                                    "properties": {
+                                        "providerId": {
+                                            "type": "string"
+                                        },
+                                        "state": {
+                                            "type": "string"
+                                        },
+                                        "reason": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "model": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Unknown provider",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "status",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "status": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Logged in account must be an admin",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/index.php/apps/aiquila/api/admin/principals": {
             "get": {
                 "operationId": "provider_settings-principals",

--- a/nextcloud-app/openapi-full.json
+++ b/nextcloud-app/openapi-full.json
@@ -3604,6 +3604,143 @@
                 }
             }
         },
+        "/index.php/apps/aiquila/api/providers/{providerId}/status": {
+            "get": {
+                "operationId": "provider_settings-status",
+                "summary": "Report whether a provider is reachable and serving the configured model",
+                "description": "Backs the status light on the personal settings page: the light describes what *this user* gets, so the probe runs against their own key when they have one and the inherited instance key otherwise.",
+                "tags": [
+                    "provider_settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "providerId",
+                        "in": "path",
+                        "description": "Provider to check",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Current provider health",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "providerId",
+                                        "state",
+                                        "reason",
+                                        "message",
+                                        "model"
+                                    ],
+                                    "properties": {
+                                        "providerId": {
+                                            "type": "string"
+                                        },
+                                        "state": {
+                                            "type": "string"
+                                        },
+                                        "reason": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "model": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Unknown provider",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "status",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "status": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "The provider is not permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "status",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "status": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/index.php/apps/aiquila/api/coworkers": {
             "get": {
                 "operationId": "coworker-index",
@@ -6735,6 +6872,139 @@
                                     "properties": {
                                         "success": {
                                             "type": "boolean"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Logged in account must be an admin",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/aiquila/api/admin/providers/{providerId}/status": {
+            "get": {
+                "operationId": "provider_settings-admin-status",
+                "summary": "Report whether a provider is reachable and serving the instance model",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "provider_settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "providerId",
+                        "in": "path",
+                        "description": "Provider to check",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Current provider health",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "providerId",
+                                        "state",
+                                        "reason",
+                                        "message",
+                                        "model"
+                                    ],
+                                    "properties": {
+                                        "providerId": {
+                                            "type": "string"
+                                        },
+                                        "state": {
+                                            "type": "string"
+                                        },
+                                        "reason": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "model": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Unknown provider",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "status",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "status": {
+                                            "type": "string"
                                         },
                                         "message": {
                                             "type": "string"

--- a/nextcloud-app/openapi.json
+++ b/nextcloud-app/openapi.json
@@ -3604,6 +3604,143 @@
                 }
             }
         },
+        "/index.php/apps/aiquila/api/providers/{providerId}/status": {
+            "get": {
+                "operationId": "provider_settings-status",
+                "summary": "Report whether a provider is reachable and serving the configured model",
+                "description": "Backs the status light on the personal settings page: the light describes what *this user* gets, so the probe runs against their own key when they have one and the inherited instance key otherwise.",
+                "tags": [
+                    "provider_settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "providerId",
+                        "in": "path",
+                        "description": "Provider to check",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Current provider health",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "providerId",
+                                        "state",
+                                        "reason",
+                                        "message",
+                                        "model"
+                                    ],
+                                    "properties": {
+                                        "providerId": {
+                                            "type": "string"
+                                        },
+                                        "state": {
+                                            "type": "string"
+                                        },
+                                        "reason": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "model": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Unknown provider",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "status",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "status": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "The provider is not permitted for this user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "status",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "status": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/index.php/apps/aiquila/api/coworkers": {
             "get": {
                 "operationId": "coworker-index",

--- a/nextcloud-app/src/components/settings/ProviderCard.vue
+++ b/nextcloud-app/src/components/settings/ProviderCard.vue
@@ -20,6 +20,11 @@
 		</div>
 
 		<div class="provider-card__summary">
+			<span class="provider-card__light"
+				:class="`provider-card__light--${light.tone}`"
+				:title="light.title"
+				:aria-label="light.title"
+				role="img" />
 			<span class="provider-card__status" :class="`provider-card__status--${status.kind}`">
 				{{ status.label }}
 			</span>
@@ -65,7 +70,7 @@
 				<NcButton type="primary" :disabled="saving || !dirty" @click="save">
 					{{ saving ? t('aiquila', 'Saving…') : t('aiquila', 'Save') }}
 				</NcButton>
-				<NcButton v-if="scope === 'admin'" type="secondary" :disabled="testing" @click="test">
+				<NcButton type="secondary" :disabled="testing" @click="test">
 					{{ testing ? t('aiquila', 'Testing…') : t('aiquila', 'Test connection') }}
 				</NcButton>
 				<NcButton type="tertiary" :disabled="refreshing" @click="$emit('refresh-models')">
@@ -83,7 +88,7 @@ import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwit
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 
 import SchemaField from './SchemaField.vue'
-import { saveAdminProvider, saveUserProvider, testProvider } from '../../settings-api.js'
+import { getProviderStatus, saveAdminProvider, saveUserProvider, testProvider } from '../../settings-api.js'
 
 /** Capability flag → chip label. Flags absent from here are not worth a chip. */
 const CAPABILITY_LABELS = {
@@ -93,6 +98,17 @@ const CAPABILITY_LABELS = {
 	effort: 'effort',
 	native_mcp: 'native MCP',
 	documents: 'documents',
+}
+
+/**
+ * Probe state → light colour. Grey covers both "not configured" and "still
+ * checking": neither says anything is wrong.
+ */
+const STATE_TONES = {
+	unconfigured: 'grey',
+	error: 'red',
+	degraded: 'orange',
+	ok: 'green',
 }
 
 export default {
@@ -133,6 +149,9 @@ export default {
 			message: '',
 			messageType: 'success',
 			draft: {},
+			// null until the first probe answers — the light stays grey and the
+			// card renders immediately rather than waiting on an outbound call.
+			health: null,
 		}
 	},
 	computed: {
@@ -153,6 +172,22 @@ export default {
 			return Object.keys(CAPABILITY_LABELS)
 				.filter(key => caps[key])
 				.map(key => CAPABILITY_LABELS[key])
+		},
+		/**
+		 * Does it actually work? A separate question from `status`, which says
+		 * which configuration applies — a provider can be the default, on the
+		 * instance key, and still be answering 401.
+		 */
+		light() {
+			if (this.health === null) {
+				return { tone: 'grey', title: t('aiquila', 'Checking the provider…') }
+			}
+			return {
+				tone: STATE_TONES[this.health.state] || 'grey',
+				// The message is the only non-colour carrier of the state, so it
+				// doubles as the tooltip and the accessible label.
+				title: this.health.message || '',
+			}
 		},
 		/**
 		 * The personal page cares whether *this user* can talk to the provider,
@@ -180,8 +215,25 @@ export default {
 			},
 		},
 	},
+	mounted() {
+		this.refreshHealth()
+	},
 	methods: {
 		t,
+		/** One probe per card, fired lazily so the page never waits on providers. */
+		async refreshHealth() {
+			try {
+				const { data } = await getProviderStatus(this.provider.id, this.scope)
+				this.health = data
+			} catch (err) {
+				this.health = {
+					state: 'error',
+					reason: 'unreachable',
+					message: err.response?.data?.message || err.message,
+				}
+			}
+			return this.health
+		},
 		resetDraft() {
 			const draft = {}
 			for (const field of this.fields) {
@@ -234,6 +286,7 @@ export default {
 					this.messageType = 'success'
 					this.message = t('aiquila', 'Saved.')
 				}
+				this.refreshHealth()
 				this.$emit('saved')
 			} catch (err) {
 				this.messageType = 'error'
@@ -242,8 +295,23 @@ export default {
 				this.saving = false
 			}
 		},
-		/** Tests the typed key when there is one, so it can be checked before saving. */
+		/**
+		 * Admin scope sends a real completion and can check a key typed into the
+		 * form before it is saved. User scope re-runs the probe instead: it is
+		 * read-only, costs no tokens, and — unlike the admin test — never swaps
+		 * the stored key out from under a concurrent request.
+		 */
 		async test() {
+			if (this.scope !== 'admin') {
+				this.testing = true
+				this.message = ''
+				const health = await this.refreshHealth()
+				this.messageType = health.state === 'ok' ? 'success' : (health.state === 'degraded' ? 'warning' : 'error')
+				this.message = health.message || t('aiquila', 'No answer from the provider.')
+				this.testing = false
+				return
+			}
+
 			this.testing = true
 			this.message = ''
 			try {
@@ -257,6 +325,7 @@ export default {
 				this.message = err.response?.data?.message || err.message
 			} finally {
 				this.testing = false
+				this.refreshHealth()
 			}
 		},
 	},
@@ -296,6 +365,27 @@ export default {
 	gap: 8px;
 	margin: 4px 0 0 4px;
 	font-size: 0.9em;
+}
+
+.provider-card__light {
+	flex: none;
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	align-self: center;
+	background-color: var(--color-text-maxcontrast);
+}
+
+.provider-card__light--green {
+	background-color: var(--color-success);
+}
+
+.provider-card__light--orange {
+	background-color: var(--color-warning);
+}
+
+.provider-card__light--red {
+	background-color: var(--color-error);
 }
 
 .provider-card__status--default {

--- a/nextcloud-app/src/settings-api.js
+++ b/nextcloud-app/src/settings-api.js
@@ -57,6 +57,23 @@ export function testProvider(providerId, apiKey = '') {
 }
 
 /**
+ * Live health of one provider, behind the status light on its card.
+ *
+ * The user-scope route reports what this user actually gets (their own key, or
+ * the inherited instance one); the admin route reports the instance config.
+ *
+ * @param {string} providerId - provider to check
+ * @param {string} scope - 'admin' or 'user'
+ * @return {Promise} resolving to `{providerId, state, reason, message, model}`
+ */
+export function getProviderStatus(providerId, scope) {
+	const path = scope === 'admin'
+		? `/api/admin/providers/${providerId}/status`
+		: `/api/providers/${providerId}/status`
+	return axios.get(url(path))
+}
+
+/**
  * Search users and groups for the per-provider access lists (admin only).
  *
  * @param {string} search - substring to match against user and group names

--- a/nextcloud-app/tests/Unit/DeepSeekProviderTest.php
+++ b/nextcloud-app/tests/Unit/DeepSeekProviderTest.php
@@ -3,7 +3,9 @@
 namespace OCA\AIquila\Tests\Unit;
 
 use OCA\AIquila\Service\CredentialService;
+use OCA\AIquila\Service\DeepSeekModels;
 use OCA\AIquila\Service\Provider\DeepSeekProvider;
+use OCA\AIquila\Service\Provider\ProviderProbe;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
@@ -229,5 +231,71 @@ class DeepSeekProviderTest extends TestCase {
         $models = $this->provider->listModels('u');
         $this->assertContains('deepseek-chat', $models);
         $this->assertContains('deepseek-reasoner', $models);
+    }
+
+    /**
+     * The probe covers every OpenAI-compatible provider through the shared
+     * implementation in AbstractOpenAiCompatibleProvider.
+     */
+    public function testProbeIsGreenWhenTheConfiguredModelIsOffered(): void {
+        $this->client->method('get')->willReturn($this->jsonResponse([
+            'data' => [['id' => DeepSeekModels::DEFAULT_MODEL]],
+        ]));
+
+        $result = $this->provider->probe('u');
+
+        $this->assertSame(ProviderProbe::STATE_OK, $result['state']);
+        $this->assertSame(ProviderProbe::REASON_OK, $result['reason']);
+    }
+
+    public function testProbeIsOrangeWhenTheConfiguredModelIsGone(): void {
+        $this->client->method('get')->willReturn($this->jsonResponse([
+            'data' => [['id' => 'some-other-model']],
+        ]));
+
+        $result = $this->provider->probe('u');
+
+        $this->assertSame(ProviderProbe::STATE_DEGRADED, $result['state']);
+        $this->assertSame(ProviderProbe::REASON_MODEL_MISSING, $result['reason']);
+        $this->assertStringContainsString(DeepSeekModels::DEFAULT_MODEL, $result['message']);
+    }
+
+    public function testProbeIsRedWhenTheKeyIsRejected(): void {
+        $this->client->method('get')->willThrowException(new \RuntimeException('HTTP 401 Unauthorized'));
+
+        $result = $this->provider->probe('u');
+
+        $this->assertSame(ProviderProbe::STATE_ERROR, $result['state']);
+        $this->assertSame(ProviderProbe::REASON_UNAUTHORIZED, $result['reason']);
+    }
+
+    /** Rate limiting is orange: the key is fine, the request just has to wait. */
+    public function testProbeIsOrangeWhenRateLimited(): void {
+        $this->client->method('get')->willThrowException(new \RuntimeException('HTTP 429 Too Many Requests'));
+
+        $result = $this->provider->probe('u');
+
+        $this->assertSame(ProviderProbe::STATE_DEGRADED, $result['state']);
+        $this->assertSame(ProviderProbe::REASON_RATE_LIMITED, $result['reason']);
+    }
+
+    public function testProbeIsRedWhenTheEndpointIsUnreachable(): void {
+        $this->client->method('get')->willThrowException(new \RuntimeException('cURL error 7: connection refused'));
+
+        $result = $this->provider->probe('u');
+
+        $this->assertSame(ProviderProbe::STATE_ERROR, $result['state']);
+        $this->assertSame(ProviderProbe::REASON_UNREACHABLE, $result['reason']);
+    }
+
+    public function testProbeIsGreyWithoutAKey(): void {
+        $credentials = $this->createMock(CredentialService::class);
+        $credentials->method('getApiKey')->willReturn('');
+        $provider = new DeepSeekProvider($this->clientService, $this->config, $credentials, $this->logger);
+
+        $result = $provider->probe('u');
+
+        $this->assertSame(ProviderProbe::STATE_UNCONFIGURED, $result['state']);
+        $this->assertSame(ProviderProbe::REASON_NOT_CONFIGURED, $result['reason']);
     }
 }

--- a/nextcloud-app/tests/Unit/ProviderSettingsControllerTest.php
+++ b/nextcloud-app/tests/Unit/ProviderSettingsControllerTest.php
@@ -93,6 +93,31 @@ class ProviderSettingsControllerTest extends TestCase {
         $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
     }
 
+    public function testStatusReportsTheProbeResult(): void {
+        $this->factory->method('isAllowedForUser')->willReturn(true);
+        $this->settings->method('status')->willReturn([
+            'providerId' => 'anthropic',
+            'state' => 'degraded',
+            'reason' => 'model_missing',
+            'message' => 'not offered',
+            'model' => 'gone-1',
+        ]);
+
+        $response = $this->ctrl->status('anthropic');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame('degraded', $response->getData()['state']);
+    }
+
+    public function testStatusRefusesADeniedProvider(): void {
+        $this->factory->method('isAllowedForUser')->willReturn(false);
+        // A blocked provider must not be probed at all — the light would
+        // otherwise confirm a key the user may not use.
+        $this->settings->expects($this->never())->method('status');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $this->ctrl->status('anthropic')->getStatus());
+    }
+
     public function testUpdateAcceptsAPermittedProvider(): void {
         $this->factory->method('isAllowedForUser')->willReturn(true);
         $this->settings->method('writeUser')->willReturn([]);

--- a/nextcloud-app/tests/Unit/ProviderSettingsServiceTest.php
+++ b/nextcloud-app/tests/Unit/ProviderSettingsServiceTest.php
@@ -5,6 +5,7 @@ namespace OCA\AIquila\Tests\Unit;
 use OCA\AIquila\Service\CredentialService;
 use OCA\AIquila\Service\Provider\LLMProviderInterface;
 use OCA\AIquila\Service\Provider\ProviderAccessService;
+use OCA\AIquila\Service\Provider\ProviderProbe;
 use OCA\AIquila\Service\Provider\ProviderSettingsSchema;
 use OCA\AIquila\Service\Provider\ProviderSettingsService;
 use OCP\ICache;
@@ -219,6 +220,35 @@ class ProviderSettingsServiceTest extends TestCase {
     }
 
     // ── Model list caching ──────────────────────────────────────────────
+
+    public function testStatusPassesTheProbeThroughWithTheProviderId(): void {
+        $provider = $this->provider([]);
+        $provider->expects($this->once())->method('probe')->with('alice')->willReturn([
+            'state' => ProviderProbe::STATE_DEGRADED,
+            'reason' => ProviderProbe::REASON_MODEL_MISSING,
+            'message' => 'not offered',
+            'model' => 'gone-1',
+        ]);
+
+        $status = $this->service->status($provider, 'alice', admin: false);
+
+        $this->assertSame('testprovider', $status['providerId']);
+        $this->assertSame(ProviderProbe::STATE_DEGRADED, $status['state']);
+        $this->assertSame('gone-1', $status['model']);
+    }
+
+    /** The admin card describes the instance, so its probe must ignore the caller. */
+    public function testAdminStatusProbesWithoutAUser(): void {
+        $provider = $this->provider([]);
+        $provider->expects($this->once())->method('probe')->with(null)->willReturn([
+            'state' => ProviderProbe::STATE_OK,
+            'reason' => ProviderProbe::REASON_OK,
+            'message' => 'fine',
+            'model' => 'm',
+        ]);
+
+        $this->service->status($provider, 'alice', admin: true);
+    }
 
     public function testCachedModelListSkipsTheProvider(): void {
         $provider = $this->provider([]);


### PR DESCRIPTION
## What

A four-state light on every provider card, on **both** the admin and the personal settings page:

- **grey** — not configured (or still checking)
- **red** — unreachable, or the key was rejected
- **orange** — reachable but degraded: the configured model is not in the provider's list, or the provider is rate-limiting
- **green** — reachable and the configured model is available

Until now the chip was derived purely from stored config, so "Ready" only meant "a key is stored" — a revoked key looked exactly like a working one until a chat failed. A regular user got no feedback at all, since `test()` is admin-only.

## How

- **`ProviderProbe`** (new) holds the classification in one place: 401/403 → red, 429 → orange (the key is valid, the request just has to wait), anything else → red.
- **`LLMProviderInterface::probe()`** implemented in `AbstractOpenAiCompatibleProvider` (DeepSeek, Hetzner, Local), `MistralProvider`, and `ClaudeSDKService`. The abstract one factors the `/models` call out of `listModels()` into a rethrowing `fetchModelIds()`, so `listModels()` keeps its `?array` contract while the probe still sees the exception. Anthropic uses the SDK's typed exceptions instead of message sniffing.
- **`ProviderSettingsService::status()`** probes and logs — `warning` for red, `info` for orange, `debug` for green — so a red light always has a matching log line (per the #462 note).
- **Two routes**: `GET /api/providers/{id}/status` (`#[NoAdminRequired]`, probes what *that user* gets, 403 for a provider blocked by #465) and `GET /api/admin/providers/{id}/status`.
- **`ProviderCard.vue`** fetches its own status lazily on mount and after save/test. The probe message doubles as the tooltip and `aria-label`, so the state is never carried by colour alone. The Test button now renders in both scopes: admin keeps the real-completion test (it can validate a key typed into the form before saving), user scope re-runs the read-only probe instead — that path never swaps the stored key out from under a concurrent request, unlike the admin one.

## Notes

- The probe is deliberately **uncached**: a stale green after a key was revoked is worse than no light. Cost is one `/models` call per provider, issued lazily from the browser, not a fan-out at page-render time. The hourly model-list cache is untouched.
- The SetupCheck generalisation from the issue's third bullet (`AnthropicApiReachable` covers Anthropic only) is **not** in this PR — worth a follow-up now that `probe()` exists to drive it.

## Testing

- `composer psalm` clean; 509 unit tests pass. New coverage: probe classification per state, `status()` scope handling, and the status endpoint's 403 on a blocked provider.
- OpenAPI specs regenerated.
- Verified live against the dev stack: grey (no key), red/`unreachable` (Local endpoint down), red/`unauthorized` (bogus Anthropic key, real 401 from the API), each with the matching log line. Orange is unit-tested only — no valid key on hand to drive it live.

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)