### PR TITLE
fix(nextcloud): offer all Hetzner models and make the model cache effective

### DIFF
--- a/docs/dev/hetzner-provider.md
+++ b/docs/dev/hetzner-provider.md
@@ -17,12 +17,29 @@ GPU of your own.
 | Base URL | `https://inference.hetzner.com/api/v1` |
 | Auth | `Authorization: Bearer <token>` — create tokens at [experiments.hetzner.com/inference](https://experiments.hetzner.com/inference) |
 | Endpoints used | `POST /chat/completions` (incl. SSE streaming and `tools` / `tool_calls`), `GET /models` |
-| Rate limits (per token) | 3M input / 60k output tokens per 60s; 500M input / 5M output per 24h — exceeding them returns HTTP 429 |
+| Token limits (per token) | 4M input / 100k output tokens per 60s; 500M input / 5M output per 24h |
+| Request limit (per token) | **10 requests per 60s** |
 
-The model line-up changes as the experiment evolves (Qwen3.6, DeepSeek-V4-Flash
-and GLM-5.2 families have all appeared). The settings UI therefore lists whatever
-`GET /models` currently returns and only falls back to `HetznerModels` when that
-call fails. Model ids can also be typed freely.
+Exceeding either limit returns HTTP 429. The request limit is the tight one for
+AIquila: every settings page render costs a `GET /models` per provider, so the
+model list and the provider status light are both cached — see
+[Provider settings](provider-settings.md).
+
+## Models
+
+| Model | Type | Context | Modalities |
+|---|---|---|---|
+| `Qwen/Qwen3.6-35B-A3B-FP8` | MoE, 35B total / 3B active | 262k | Text, Image |
+| `Kimi-K2.7-Code` | MoE, 1T total / 32B active | 262k | Text, Image |
+| `DeepSeek-V4-Flash-0731` | MoE, 304B total / 13B active | 512k | Text |
+| `GLM-5.2-NVFP4` | MoE, 744B total / 40B active | 512k | Text |
+
+The line-up changes as the experiment evolves, so the settings UI lists whatever
+`GET /models` currently returns and falls back to `HetznerModels` only when that
+call fails. Model ids can also be typed freely. Keep
+`nextcloud-app/lib/Service/HetznerModels.php` in step with the table above: it
+carries the fallback list, the per-model output-token ceilings and the
+text-only set.
 
 ## Implementation
 
@@ -31,7 +48,11 @@ extends `AbstractOpenAiCompatibleProvider`, the same base class `DeepSeekProvide
 and `LocalProvider` use, so all wire-format handling is shared. It only supplies:
 
 - identity (`hetzner`, "Hetzner Inference (EU)") and the base URL,
-- `supportsVisionInput() === true` — the served models are multimodal,
+- `supportsVisionInput()` — decided per model via `HetznerModels::supportsVision()`:
+  true for Qwen3.6 and Kimi-K2.7-Code, false for DeepSeek-V4-Flash and GLM-5.2.
+  An id the registry does not know is assumed vision-capable, so a model added to
+  the service after this release is not crippled by a stale list — the API
+  rejects an unsupported modality on its own,
 - error mapping for 401 (bad token), 429 (quota) and 502/503 (experiment down),
 - model / max-token resolution from the config keys below.
 
@@ -45,8 +66,18 @@ App config (`oc_appconfig`, app `aiquila`):
 | Key | Default | Meaning |
 |---|---|---|
 | `model_hetzner` | `Qwen/Qwen3.6-35B-A3B-FP8` | Admin default model |
-| `max_tokens_hetzner` | `8192` | Output token limit, clamped to the per-model ceiling |
+| `max_tokens_hetzner` | `8192` | Output token limit, clamped to the per-model ceiling below |
 | `hetzner_base_url` | *(unset → default endpoint)* | Endpoint override; admin-scope only (SSRF), validated by `HetznerProvider::normalizeBaseUrl()` |
+
+Per-model output ceilings applied by `HetznerModels::getMaxTokenCeiling()`
+(an unknown id falls back to the 8192 default):
+
+| Model | Ceiling |
+|---|---|
+| `Qwen/Qwen3.6-35B-A3B-FP8` | 32768 |
+| `Kimi-K2.7-Code` | 32768 |
+| `DeepSeek-V4-Flash-0731` | 65536 |
+| `GLM-5.2-NVFP4` | 65536 |
 
 User config: `user_model_hetzner` (per-user model override), `user_provider`
 (per-user provider override).
@@ -89,9 +120,40 @@ to `occ aiquila:configure` over SSH and redacted from all printed output. On
 `--stack mcp` the flag is ignored with a warning — there is no local Nextcloud to
 configure.
 
+## Troubleshooting
+
+**Only one model in the dropdown.** The live listing failed and the static
+registry rendered instead. `listModels()` swallows the failure to keep its
+contract, but it always logs the reason first:
+
+```bash
+grep 'Could not list models' data/nextcloud.log   # the provider's own error
+grep 'no live model list'    data/nextcloud.log   # the fallback that followed
+```
+
+The `error` field distinguishes the causes:
+
+| Error | Cause |
+|---|---|
+| `401 Unauthorized` | No token configured, or a revoked/mistyped one |
+| `429 Too Many Requests` | The 10 requests / 60s budget is exhausted |
+| `cURL error 28` / timeout | The experiment is unreachable |
+
+Check the token against the API directly:
+
+```bash
+curl -si https://inference.hetzner.com/api/v1/models \
+  -H "Authorization: Bearer $HETZNER_INFERENCE_TOKEN" | head -30
+```
+
+If `curl` lists the models but the UI does not, the cached failure marker is
+still live — click **Refresh models** on the provider card (it sends
+`?refresh=1`, which bypasses both the marker and the cached list), or wait out
+the 60s TTL.
+
 ## Tests
 
 `nextcloud-app/tests/Unit/HetznerProviderTest.php` covers endpoint targeting, the
 bearer header, base-URL override and its validation, model/max-token resolution,
-image input, the tool round-trip, streaming, `listModels()`, and the 401/429 error
-mapping.
+per-model vision support and the static registry, image input, the tool
+round-trip, streaming, `listModels()`, and the 401/429 error mapping.

--- a/docs/dev/provider-settings.md
+++ b/docs/dev/provider-settings.md
@@ -38,7 +38,8 @@ the descriptor and never names a provider.
 Types: `text`, `number`, `password`, `select`, `checkbox`, `url`, `multiselect`.
 Groups: `basic` renders inline on the card, `advanced` behind a disclosure.
 A select whose `options` is the sentinel `@models` is expanded to the provider's
-live model list (cached, with the static registry as fallback); a `multiselect`
+live model list (cached per credential, with the static registry as fallback —
+see [Model list caching](#model-list-caching)); a `multiselect`
 whose `options` is `@principals` is a user/group picker that queries
 `/api/admin/principals` as the admin types.
 
@@ -102,14 +103,43 @@ distinguishes your own key from an inherited instance one.
 ## Model list caching
 
 `listModels()` is a live HTTP call. Rendering a settings page used to make one
-per registered provider on every load. `ProviderSettingsService::listModels()`
-caches results for an hour in a distributed cache, and the pages pass
-`?refresh=1` behind the card's **Refresh models** button.
+per registered provider on every load, which matters more than it sounds: Hetzner
+allows only 10 requests per 60s per token, so an uncached settings page can spend
+the whole budget on model lists and then get 429s in chat.
+`ProviderSettingsService::listModels()` therefore caches, and both the personal
+(`SettingsController`) and provider (`ProviderSettingsController`) endpoints go
+through it. The pages pass `?refresh=1` behind the card's **Refresh models**
+button to bypass the cache entirely.
 
-The static fallback is deliberately *not* cached: it is static anyway, and
-caching it would pin a transient outage for the full TTL. Saving a key or an
-endpoint drops the provider's cached list, since either can change what it
-serves.
+| | TTL | Notes |
+|---|---|---|
+| Successful listing | 3600s | The line-up changes rarely |
+| Failed listing (marker) | 60s | Serves the static fallback without a request |
+| Status probe | 30s | The per-card status light |
+
+**Keyed per credential, not per provider.** The cache key is the *credential
+scope*: `user-<uid>` for a user with a personal key, `instance` for everyone
+inheriting the instance key. A personal key talks to the provider as that user
+and can see a different line-up — or a working endpoint where the instance key is
+revoked — so serving their list to other users would both leak what they have
+access to and show everyone else models they cannot reach.
+
+**Failures are cached, the fallback is not.** The static registry is static
+anyway, so there is nothing to cache; but re-asking an endpoint that just refused
+us on every page load keeps a rate-limited key pinned at its ceiling and turns
+one transient 429 into a permanent fallback. A short failure marker breaks that
+loop while still recovering on its own within a minute.
+
+**The status light is throttled, not cached.** `status()` stays live per call —
+a stale green after a key was revoked would be worse than no light at all — but
+each card costs its own `/models` probe on top of the model lists, so a result is
+reused for 30s. Short enough that a revoked key goes red almost immediately, long
+enough that a reload loop cannot exhaust the request budget on status lights.
+
+Each provider owns its own cache namespace (`aiquila-models-<id>`), because
+`ISimpleCache` cannot enumerate or glob keys and `forgetModels()` has to drop
+*every* scope of a provider at once. Saving a key or an endpoint calls it, since
+either can change what the provider serves.
 
 ## Where this is used
 

--- a/nextcloud-app/lib/Controller/SettingsController.php
+++ b/nextcloud-app/lib/Controller/SettingsController.php
@@ -3,14 +3,11 @@
 
 namespace OCA\AIquila\Controller;
 
-use OCA\AIquila\Service\ClaudeModels;
 use OCA\AIquila\Service\CredentialService;
-use OCA\AIquila\Service\DeepSeekModels;
-use OCA\AIquila\Service\HetznerModels;
-use OCA\AIquila\Service\MistralModels;
 use OCA\AIquila\Service\NativeMcpService;
 use OCA\AIquila\Service\Provider\LLMProviderFactory;
 use OCA\AIquila\Service\Provider\NoPermittedProviderException;
+use OCA\AIquila\Service\Provider\ProviderSettingsService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -27,6 +24,7 @@ class SettingsController extends Controller {
     private LLMProviderFactory $providerFactory;
     private CredentialService $credentials;
     private NativeMcpService $nativeMcp;
+    private ProviderSettingsService $providerSettings;
 
     public function __construct(
         string $appName,
@@ -35,7 +33,8 @@ class SettingsController extends Controller {
         ?string $userId,
         LLMProviderFactory $providerFactory,
         CredentialService $credentials,
-        NativeMcpService $nativeMcp
+        NativeMcpService $nativeMcp,
+        ProviderSettingsService $providerSettings
     ) {
         parent::__construct($appName, $request);
         $this->config = $config;
@@ -43,29 +42,12 @@ class SettingsController extends Controller {
         $this->providerFactory = $providerFactory;
         $this->credentials = $credentials;
         $this->nativeMcp = $nativeMcp;
+        $this->providerSettings = $providerSettings;
     }
 
     /** Config key holding a user's preferred model for a provider. */
     private function userModelKey(string $providerId): string {
         return $providerId === 'anthropic' ? 'user_model' : 'user_model_' . $providerId;
-    }
-
-    /**
-     * Static fallback model list for a provider id.
-     *
-     * @return list<string>
-     */
-    private function staticModels(string $providerId): array {
-        return match ($providerId) {
-            'mistral' => MistralModels::getAllModels(),
-            'deepseek' => DeepSeekModels::getAllModels(),
-            'hetzner' => HetznerModels::getAllModels(),
-            // Local model ids are arbitrary tags with no static registry; the
-            // live /v1/models listing is the real source, so fall back to
-            // whatever is currently configured.
-            'local' => [$this->providerFactory->getProviderById('local')->getModel($this->userId)],
-            default => ClaudeModels::getAllModels(),
-        };
     }
 
     /**
@@ -104,20 +86,23 @@ class SettingsController extends Controller {
         $userProvider     = $this->config->getUserValue($this->userId, $this->appName, 'user_provider', '');
 
         // Per-provider metadata: label, whether a personal key exists, the user's
-        // preferred model, and the available model list (live with static fallback).
+        // preferred model, and the available model list (cached live listing,
+        // with the static registry as fallback).
         // Only providers this user is permitted to use — the picker must not
         // offer one the server would then refuse.
         $providers = [];
+        /** @var array<string, list<string>> $models model lists, keyed by provider id, reused below */
+        $models = [];
         foreach ($this->providerFactory->getProviderIdsForUser($this->userId) as $id) {
             $provider = $this->providerFactory->getProviderById($id);
-            $liveModels = $provider->listModels($this->userId);
+            $models[$id] = $this->providerSettings->listModels($provider, $this->userId);
             $providers[] = [
                 'id'              => $id,
                 'label'          => $provider->getLabel(),
                 'configured'     => $provider->isConfigured($this->userId),
                 'hasUserKey'     => $this->credentials->hasApiKey($this->userId, $id),
                 'userModel'      => $this->config->getUserValue($this->userId, $this->appName, $this->userModelKey($id), ''),
-                'availableModels' => $liveModels ?? $this->staticModels($id),
+                'availableModels' => $models[$id],
             ];
         }
 
@@ -125,7 +110,10 @@ class SettingsController extends Controller {
         $active = $this->providerFactory->getProviderById($activeProviderId);
         $hasUserKey      = $this->credentials->hasApiKey($this->userId, $activeProviderId);
         $userModel       = $this->config->getUserValue($this->userId, $this->appName, $this->userModelKey($activeProviderId), '');
-        $availableModels = $active->listModels($this->userId) ?? $this->staticModels($activeProviderId);
+        // The loop above already resolved every permitted provider's list; the
+        // active one is always among them, so reuse it rather than paying for a
+        // second lookup.
+        $availableModels = $models[$activeProviderId] ?? $this->providerSettings->listModels($active, $this->userId);
 
         $defaultSystemPrompt = $this->config->getUserValue($this->userId, $this->appName, 'default_system_prompt', '');
         $defaultVerbose = $this->config->getUserValue($this->userId, $this->appName, 'default_verbose', '0') === '1';

--- a/nextcloud-app/lib/Service/HetznerModels.php
+++ b/nextcloud-app/lib/Service/HetznerModels.php
@@ -11,15 +11,25 @@ namespace OCA\AIquila\Service;
  * The Hetzner Experiments inference service rotates its open-weight model
  * line-up, so the authoritative list is the live `GET /models` call in
  * AbstractOpenAiCompatibleProvider::listModels(). This class only supplies the
- * fallback shown when that call fails (no key yet, endpoint down) and the
- * output-token ceilings used to clamp the configured max_tokens.
+ * fallback shown when that call fails (no key yet, endpoint down, HTTP 429), the
+ * output-token ceilings used to clamp the configured max_tokens, and which of
+ * the served models accept image input.
  */
 class HetznerModels {
 
     // ── Model ID constants ──────────────────────────────────────────────────
 
-    /** Qwen3.6 MoE, causal LM + vision, 262k context. */
+    /** Qwen3.6 MoE, 35B total / 3B active, causal LM + vision, 262k context. */
     public const QWEN3_6_35B = 'Qwen/Qwen3.6-35B-A3B-FP8';
+
+    /** DeepSeek-V4-Flash MoE, 304B total / 13B active, text only, 512k context. */
+    public const DEEPSEEK_V4_FLASH = 'DeepSeek-V4-Flash-0731';
+
+    /** GLM-5.2 MoE (NVFP4), 744B total / 40B active, text only, 512k context. */
+    public const GLM_5_2_NVFP4 = 'GLM-5.2-NVFP4';
+
+    /** Kimi K2.7 Code MoE, 1T total / 32B active, text + vision, 262k context. */
+    public const KIMI_K2_7_CODE = 'Kimi-K2.7-Code';
 
     // ── Application defaults ────────────────────────────────────────────────
 
@@ -29,7 +39,22 @@ class HetznerModels {
     // ── Per-model output token ceilings ─────────────────────────────────────
 
     private const MAX_TOKENS_CEILING = [
-        self::QWEN3_6_35B => 32768,
+        self::QWEN3_6_35B       => 32768,
+        self::DEEPSEEK_V4_FLASH => 65536,
+        self::GLM_5_2_NVFP4     => 65536,
+        self::KIMI_K2_7_CODE    => 32768,
+    ];
+
+    /**
+     * Models known to be text-only. Everything else is treated as vision
+     * capable, so a model added to the service after this release is not
+     * crippled by a registry that has not caught up with it.
+     *
+     * @var list<string>
+     */
+    private const TEXT_ONLY = [
+        self::DEEPSEEK_V4_FLASH,
+        self::GLM_5_2_NVFP4,
     ];
 
     /**
@@ -41,6 +66,16 @@ class HetznerModels {
     }
 
     /**
+     * Whether a model accepts image input. Unknown IDs default to true: the
+     * line-up changes faster than this registry, and refusing images for a
+     * model we simply have not heard of would be the worse failure — the API
+     * rejects an unsupported modality on its own.
+     */
+    public static function supportsVision(string $model): bool {
+        return !in_array($model, self::TEXT_ONLY, true);
+    }
+
+    /**
      * Ordered fallback model list for the settings UI, used only when the live
      * /models call fails. The field also accepts a free-typed model id.
      *
@@ -49,6 +84,9 @@ class HetznerModels {
     public static function getAllModels(): array {
         return [
             self::QWEN3_6_35B,
+            self::KIMI_K2_7_CODE,
+            self::DEEPSEEK_V4_FLASH,
+            self::GLM_5_2_NVFP4,
         ];
     }
 }

--- a/nextcloud-app/lib/Service/Provider/HetznerProvider.php
+++ b/nextcloud-app/lib/Service/Provider/HetznerProvider.php
@@ -16,9 +16,11 @@ use OCA\AIquila\Service\HetznerModels;
  *   - Bearer token from https://experiments.hetzner.com/inference (required).
  *   - The model line-up changes; the live /models listing is authoritative and
  *     HetznerModels is only the fallback.
- *   - The current model is multimodal, so image input is enabled.
- *   - Per-key token quotas (3M in / 60k out per minute, 500M / 5M per day)
- *     surface as HTTP 429.
+ *   - Some of the served models are multimodal and some are text-only, so image
+ *     input is decided per model via HetznerModels::supportsVision().
+ *   - Per-key quotas surface as HTTP 429: 4M in / 100k out tokens per 60s,
+ *     500M / 5M per day, and — the one that bites the settings pages — a limit
+ *     of 10 requests per 60s.
  *
  * The base URL is overridable through the app config key `hetzner_base_url`
  * because the service is experimental and may move. It is admin-scope only and
@@ -104,9 +106,9 @@ class HetznerProvider extends AbstractOpenAiCompatibleProvider {
         ]);
     }
 
-    /** The served models are multimodal (image + text input). */
+    /** Image input depends on the selected model; unknown ids are assumed capable. */
     protected function supportsVisionInput(?string $userId = null): bool {
-        return true;
+        return HetznerModels::supportsVision($this->getModel($userId));
     }
 
     // ── Errors ──────────────────────────────────────────────────────────────

--- a/nextcloud-app/lib/Service/Provider/ProviderSettingsService.php
+++ b/nextcloud-app/lib/Service/Provider/ProviderSettingsService.php
@@ -40,6 +40,28 @@ class ProviderSettingsService {
      */
     private const MODEL_CACHE_TTL = 3600;
 
+    /**
+     * How long a failed live listing is remembered. Without this every page load
+     * retries an endpoint that just refused us, which against Hetzner's 10
+     * requests / 60s budget keeps the key pinned at its ceiling and turns one
+     * transient 429 into a permanent fallback. Short enough that a fixed key or
+     * a recovered endpoint is picked up on its own; the Refresh models button
+     * bypasses it outright.
+     */
+    private const MODEL_FAILURE_TTL = 60;
+
+    /**
+     * How long a provider status probe is reused. status() is deliberately
+     * live-per-call (see its docblock), but the light is fetched once per card,
+     * so an admin page holding five providers costs five /models calls on top of
+     * the model lists. A throttle this short keeps a reload loop from exhausting
+     * the request budget without letting a revoked key show green for long.
+     */
+    private const STATUS_THROTTLE_TTL = 30;
+
+    /** Marker stored in place of a model list when the live call failed. */
+    private const FAILURE_MARKER = ['__aiquila_failed' => true];
+
     public function __construct(
         private readonly IConfig $config,
         private readonly CredentialService $credentials,
@@ -47,6 +69,7 @@ class ProviderSettingsService {
         private readonly IUserManager $userManager,
         private readonly IGroupManager $groupManager,
         private readonly ICacheFactory $cacheFactory,
+        private readonly LLMProviderFactory $providerFactory,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -205,11 +228,14 @@ class ProviderSettingsService {
      * @return list<string>
      */
     public function listModels(LLMProviderInterface $provider, ?string $userId, bool $refresh = false): array {
-        $cache = $this->cacheFactory->createDistributed('aiquila-models');
-        $cacheKey = $provider->getId();
+        $cache = $this->modelCache($provider->getId());
+        $cacheKey = $this->credentialScope($provider->getId(), $userId);
 
         if (!$refresh) {
             $cached = $cache->get($cacheKey);
+            if ($cached === self::FAILURE_MARKER) {
+                return $this->staticModels($provider);
+            }
             if (is_array($cached)) {
                 return array_values($cached);
             }
@@ -220,8 +246,10 @@ class ProviderSettingsService {
             $this->logger->warning('AIquila: no live model list from ' . $provider->getId() . ', using the static registry', [
                 'provider' => $provider->getId(),
             ]);
-            // Do not cache the fallback: it is static anyway, and caching it
-            // would keep a transient outage pinned for an hour.
+            // The fallback itself is never cached — it is static anyway — but
+            // the *failure* is, briefly, so a dead or rate-limiting endpoint is
+            // not re-asked on every page load.
+            $cache->set($cacheKey, self::FAILURE_MARKER, self::MODEL_FAILURE_TTL);
             return $this->staticModels($provider);
         }
 
@@ -230,12 +258,41 @@ class ProviderSettingsService {
     }
 
     /**
+     * Which credential a model list was fetched with, and therefore who may be
+     * served it from cache.
+     *
+     * A user with a personal key talks to the provider as themselves and can see
+     * a different line-up (or a working endpoint where the instance key is
+     * revoked), so their list must not be handed to anyone else. Everyone
+     * falling back to the instance key shares one entry.
+     */
+    private function credentialScope(string $providerId, ?string $userId): string {
+        if ($userId !== null && $this->credentials->hasApiKey($userId, $providerId)) {
+            return 'user-' . $userId;
+        }
+        return 'instance';
+    }
+
+    /**
+     * One cache namespace per provider, so forgetModels() can drop every scope
+     * of a single provider with clear() — ISimpleCache cannot enumerate or glob
+     * keys, and an admin changing a key must not leave other users' entries
+     * pointing at the old endpoint.
+     */
+    private function modelCache(string $providerId): \OCP\ICache {
+        return $this->cacheFactory->createDistributed('aiquila-models-' . $providerId);
+    }
+
+    /**
      * Live health of one provider, for the status light on its settings card.
      *
-     * Deliberately uncached: the light is fetched lazily per card, and a stale
+     * Near enough to uncached: the light is fetched lazily per card, and a stale
      * green after a key was revoked would be worse than no light at all. The
-     * probe is a single /models call, which is the cheapest thing a provider
-     * answers.
+     * probe is a single /models call, the cheapest thing a provider answers, but
+     * one per card still adds up — Hetzner allows only 10 requests per 60s — so
+     * the result is held for STATUS_THROTTLE_TTL. That is short enough that a
+     * revoked key goes red almost immediately, while a reload loop can no longer
+     * spend the whole request budget on status lights.
      *
      * @param bool $admin true to probe the instance configuration, false to
      *                    probe what this user actually gets (personal key or
@@ -244,7 +301,17 @@ class ProviderSettingsService {
      */
     public function status(LLMProviderInterface $provider, ?string $userId, bool $admin): array {
         $id = $provider->getId();
+
+        $cache = $this->modelCache($id);
+        $throttleKey = 'status-' . ($admin ? 'admin' : $this->credentialScope($id, $userId));
+        $throttled = $cache->get($throttleKey);
+        if (is_array($throttled) && isset($throttled['state'])) {
+            /** @var array{state: string, reason: string, message: string, model: string} $throttled */
+            return ['providerId' => $id] + $throttled;
+        }
+
         $result = $provider->probe($admin ? null : $userId);
+        $cache->set($throttleKey, $result, self::STATUS_THROTTLE_TTL);
 
         $context = [
             'provider' => $id,
@@ -266,12 +333,24 @@ class ProviderSettingsService {
 
     /** Drop the cached model list for a provider (or all of them). */
     public function forgetModels(?string $providerId = null): void {
-        $cache = $this->cacheFactory->createDistributed('aiquila-models');
-        if ($providerId === null) {
-            $cache->clear();
+        if ($providerId !== null) {
+            $this->modelCache($providerId)->clear();
             return;
         }
-        $cache->remove($providerId);
+        foreach ($this->knownProviderIds() as $id) {
+            $this->modelCache($id)->clear();
+        }
+    }
+
+    /**
+     * Provider ids whose caches forgetModels(null) has to sweep. Each provider
+     * owns a cache namespace, so the sweep needs the registry rather than being
+     * able to clear one shared bucket.
+     *
+     * @return list<string>
+     */
+    private function knownProviderIds(): array {
+        return $this->providerFactory->getProviderIds();
     }
 
     // ── Internals ───────────────────────────────────────────────────────────

--- a/nextcloud-app/tests/Unit/HetznerProviderTest.php
+++ b/nextcloud-app/tests/Unit/HetznerProviderTest.php
@@ -265,6 +265,57 @@ class HetznerProviderTest extends TestCase {
         $this->assertContains('zai-org/GLM-5.2', $models);
     }
 
+    public function testStaticRegistryCoversTheFullLineUp(): void {
+        // The fallback is what the settings UI shows when the live listing
+        // fails, so a registry that has gone stale silently narrows the picker.
+        $this->assertSame([
+            HetznerModels::QWEN3_6_35B,
+            HetznerModels::KIMI_K2_7_CODE,
+            HetznerModels::DEEPSEEK_V4_FLASH,
+            HetznerModels::GLM_5_2_NVFP4,
+        ], HetznerModels::getAllModels());
+    }
+
+    public function testEveryKnownModelHasItsOwnCeiling(): void {
+        foreach (HetznerModels::getAllModels() as $model) {
+            $this->assertGreaterThan(
+                HetznerModels::DEFAULT_MAX_TOKENS,
+                HetznerModels::getMaxTokenCeiling($model),
+                $model . ' is clamped to the generic default'
+            );
+        }
+        // An id the registry has not caught up with still gets a safe value.
+        $this->assertSame(HetznerModels::DEFAULT_MAX_TOKENS, HetznerModels::getMaxTokenCeiling('brand/new'));
+    }
+
+    public function testMaxTokensUsesTheSelectedModelsCeiling(): void {
+        $provider = $this->provider([
+            'model_hetzner' => HetznerModels::DEEPSEEK_V4_FLASH,
+            'max_tokens_hetzner' => '999999',
+        ]);
+        $this->assertSame(
+            HetznerModels::getMaxTokenCeiling(HetznerModels::DEEPSEEK_V4_FLASH),
+            $provider->getMaxTokens()
+        );
+    }
+
+    public function testVisionSupportFollowsTheSelectedModel(): void {
+        $this->assertTrue(HetznerModels::supportsVision(HetznerModels::QWEN3_6_35B));
+        $this->assertTrue(HetznerModels::supportsVision(HetznerModels::KIMI_K2_7_CODE));
+        $this->assertFalse(HetznerModels::supportsVision(HetznerModels::DEEPSEEK_V4_FLASH));
+        $this->assertFalse(HetznerModels::supportsVision(HetznerModels::GLM_5_2_NVFP4));
+        // Unknown ids are assumed capable rather than crippled by a stale list.
+        $this->assertTrue(HetznerModels::supportsVision('brand/new'));
+    }
+
+    public function testTextOnlyModelRefusesImageInput(): void {
+        $provider = $this->provider(['model_hetzner' => HetznerModels::GLM_5_2_NVFP4]);
+
+        $result = $provider->askWithImage('what is this', base64_encode('x'), 'image/png', 'u');
+
+        $this->assertStringContainsString('vision', strtolower($result['error']));
+    }
+
     public function testRateLimitErrorIsMapped(): void {
         $this->client->method('post')->willThrowException(new \RuntimeException('HTTP 429 Too Many Requests'));
 

--- a/nextcloud-app/tests/Unit/ProviderSettingsServiceTest.php
+++ b/nextcloud-app/tests/Unit/ProviderSettingsServiceTest.php
@@ -3,6 +3,7 @@
 namespace OCA\AIquila\Tests\Unit;
 
 use OCA\AIquila\Service\CredentialService;
+use OCA\AIquila\Service\Provider\LLMProviderFactory;
 use OCA\AIquila\Service\Provider\LLMProviderInterface;
 use OCA\AIquila\Service\Provider\ProviderAccessService;
 use OCA\AIquila\Service\Provider\ProviderProbe;
@@ -24,6 +25,7 @@ class ProviderSettingsServiceTest extends TestCase {
     private $access;
     private $userManager;
     private $groupManager;
+    private $providerFactory;
     private ProviderSettingsService $service;
 
     protected function setUp(): void {
@@ -42,6 +44,8 @@ class ProviderSettingsServiceTest extends TestCase {
         ]);
         $this->userManager = $this->createMock(IUserManager::class);
         $this->groupManager = $this->createMock(IGroupManager::class);
+        $this->providerFactory = $this->createMock(LLMProviderFactory::class);
+        $this->providerFactory->method('getProviderIds')->willReturn(['testprovider']);
 
         $this->service = new ProviderSettingsService(
             $this->config,
@@ -50,6 +54,7 @@ class ProviderSettingsServiceTest extends TestCase {
             $this->userManager,
             $this->groupManager,
             $this->cacheFactory,
+            $this->providerFactory,
             $this->createMock(LoggerInterface::class),
         );
     }
@@ -262,20 +267,87 @@ class ProviderSettingsServiceTest extends TestCase {
         $provider = $this->provider([]);
         $provider->expects($this->once())->method('listModels')->willReturn(['live-a']);
         $this->cache->expects($this->never())->method('get');
-        $this->cache->expects($this->once())->method('set')->with('testprovider', ['live-a'], 3600);
+        $this->cache->expects($this->once())->method('set')->with('instance', ['live-a'], 3600);
 
         $this->assertSame(['live-a'], $this->service->listModels($provider, 'alice', refresh: true));
     }
 
-    public function testUnreachableProviderFallsBackWithoutCaching(): void {
+    public function testUnreachableProviderFallsBackAndRemembersTheFailure(): void {
         $provider = $this->provider([]);
         $provider->method('listModels')->willReturn(null);
         $provider->method('getModel')->willReturn('configured-tag');
         $this->cache->method('get')->willReturn(null);
 
-        // Caching the fallback would pin a transient outage for the full TTL.
-        $this->cache->expects($this->never())->method('set');
+        // The fallback itself is never cached — it is static anyway — but the
+        // failure is, briefly, so a dead endpoint is not re-asked per page load.
+        $this->cache->expects($this->once())->method('set')
+            ->with('instance', ['__aiquila_failed' => true], 60);
 
         $this->assertSame(['configured-tag'], $this->service->listModels($provider, 'alice'));
+    }
+
+    public function testCachedFailureServesTheFallbackWithoutCallingTheProvider(): void {
+        $provider = $this->provider([]);
+        $provider->expects($this->never())->method('listModels');
+        $provider->method('getModel')->willReturn('configured-tag');
+        $this->cache->method('get')->willReturn(['__aiquila_failed' => true]);
+
+        $this->assertSame(['configured-tag'], $this->service->listModels($provider, 'alice'));
+    }
+
+    public function testRefreshBypassesACachedFailure(): void {
+        $provider = $this->provider([]);
+        $provider->expects($this->once())->method('listModels')->willReturn(['live-a']);
+        $this->cache->expects($this->never())->method('get');
+
+        $this->assertSame(['live-a'], $this->service->listModels($provider, 'alice', refresh: true));
+    }
+
+    /**
+     * A personal key talks to the provider as that user and can see a different
+     * line-up, so it must not share the instance entry.
+     */
+    public function testPersonalKeyGetsItsOwnCacheEntry(): void {
+        $provider = $this->provider([]);
+        $provider->method('listModels')->willReturn(['live-a']);
+        $this->credentials->method('hasApiKey')
+            ->willReturnCallback(static fn (?string $uid): bool => $uid === 'alice');
+        $this->cache->method('get')->willReturn(null);
+
+        $keys = [];
+        $this->cache->method('set')->willReturnCallback(
+            function (string $key) use (&$keys): bool {
+                $keys[] = $key;
+                return true;
+            }
+        );
+
+        $this->service->listModels($provider, 'alice');
+        $this->service->listModels($provider, 'bob');
+        $this->service->listModels($provider, null);
+
+        $this->assertSame(['user-alice', 'instance', 'instance'], $keys);
+    }
+
+    public function testForgetModelsClearsEveryScopeOfTheProvider(): void {
+        // remove() cannot drop the per-user entries, so each provider owns a
+        // cache namespace and the sweep clears the whole thing.
+        $this->cache->expects($this->once())->method('clear');
+        $this->cache->expects($this->never())->method('remove');
+
+        $this->service->forgetModels('testprovider');
+    }
+
+    public function testStatusIsReusedWithinTheThrottleWindow(): void {
+        $provider = $this->provider([]);
+        $provider->method('getId')->willReturn('testprovider');
+        $provider->expects($this->once())->method('probe')->willReturn(
+            ProviderProbe::unconfigured('no key', 'some-model')
+        );
+        $this->cache->method('get')->willReturn(null);
+        $this->cache->expects($this->once())->method('set')
+            ->with('status-admin', $this->anything(), 30);
+
+        $this->service->status($provider, 'alice', admin: true);
     }
 }

--- a/nextcloud-app/tests/Unit/SettingsControllerTest.php
+++ b/nextcloud-app/tests/Unit/SettingsControllerTest.php
@@ -7,6 +7,7 @@ use OCA\AIquila\Service\ClaudeModels;
 use OCA\AIquila\Service\CredentialService;
 use OCA\AIquila\Service\Provider\LLMProviderFactory;
 use OCA\AIquila\Service\Provider\LLMProviderInterface;
+use OCA\AIquila\Service\Provider\ProviderSettingsService;
 use OCP\IConfig;
 use OCP\IRequest;
 use PHPUnit\Framework\TestCase;
@@ -18,6 +19,7 @@ class SettingsControllerTest extends TestCase {
     private $provider;
     private $credentials;
     private $nativeMcp;
+    private $providerSettings;
     private SettingsController $ctrl;
 
     protected function setUp(): void {
@@ -29,6 +31,18 @@ class SettingsControllerTest extends TestCase {
         $this->nativeMcp   = $this->createMock(\OCA\AIquila\Service\NativeMcpService::class);
         $this->nativeMcp->method('isEnabledForUser')->willReturn(false);
         $this->nativeMcp->method('probeAll')->willReturn([]);
+
+        // The controller no longer calls the provider directly; it goes through
+        // the caching service. Stand in for it with the same live-or-fallback
+        // rule the real one applies, so the provider stubs below still drive
+        // what these tests assert on.
+        $this->providerSettings = $this->createMock(ProviderSettingsService::class);
+        $this->providerSettings->method('listModels')->willReturnCallback(
+            static function (LLMProviderInterface $provider): array {
+                $live = $provider->listModels(null);
+                return $live !== null && $live !== [] ? $live : ClaudeModels::getAllModels();
+            }
+        );
 
         // Single-provider (anthropic) world for these tests.
         $this->provider->method('getId')->willReturn('anthropic');
@@ -49,7 +63,8 @@ class SettingsControllerTest extends TestCase {
             'testuser',
             $this->factory,
             $this->credentials,
-            $this->nativeMcp
+            $this->nativeMcp,
+            $this->providerSettings
         );
     }
 


### PR DESCRIPTION
## Problem

The Hetzner provider card offered a single model (`Qwen/Qwen3.6-35B-A3B-FP8`) while the Inference API serves four. One model means the card was rendering the **static fallback** — the live `GET /models` call had failed.

Confirmed on the dev stack:

```
AIquila Hetzner Inference (EU): Could not list models
error: `GET https://inference.hetzner.com/api/v1/models` resulted in `401 Unauthorized`
```

Three defects combine to produce it.

### 1. Stale static registry

`HetznerModels` knew one id and one max-tokens ceiling, so every other model clamped to the 8192 default. `supportsVisionInput()` also returned an unconditional `true`, though `DeepSeek-V4-Flash-0731` and `GLM-5.2-NVFP4` are text-only.

### 2. Cache bypassed and over-called

`SettingsController::get()` called `$provider->listModels()` directly — one live HTTP call per provider per page load, never touching `aiquila-models`. The per-card status light (#466) added a second call per provider. Against Hetzner's **10 requests / 60s** limit a couple of page loads trip 429, which `listModels()` swallows into the fallback. Failures were never cached, so every reload retried and kept the key at its ceiling.

### 3. Cache key not scoped

The key was `$provider->getId()` alone, so a list fetched with one user's personal key was served to every other user, and to the admin scope, for an hour.

## Changes

- **`HetznerModels`** — all four ids, per-model ceilings, and a `supportsVision()` set. Unknown ids default to vision-capable so a newly added model is not crippled by a stale registry.
- **`HetznerProvider`** — model-aware `supportsVisionInput()`; corrected quota docblock (4M/100k per 60s, plus the 10 req/60s limit).
- **`SettingsController`** — routed through `ProviderSettingsService::listModels()`; the now-dead local `staticModels()` helper is gone, leaving one fallback mapping in the codebase.
- **`ProviderSettingsService`** — cache keyed by credential scope (`user-<uid>` vs `instance`); 60s negative cache for failed listings; 30s status-probe throttle. Each provider owns a cache namespace (`aiquila-models-<id>`) so `forgetModels()` can clear every scope — `ISimpleCache` cannot glob keys.

## Verification

Deployed to `docker/installation`. The instance token there is invalid (401), which is exactly the fallback path:

```
"availableModels": ["Qwen/Qwen3.6-35B-A3B-FP8", "Kimi-K2.7-Code",
                    "DeepSeek-V4-Flash-0731", "GLM-5.2-NVFP4"]
```

- 5 consecutive settings loads → **0** outbound `/models` calls (was 5 per load).
- `?refresh=1` → 3 real calls, so the Refresh models button still bypasses.
- Status light still reports the correct `unauthorized` reason under the throttle.
- 519 unit tests pass; Psalm clean; `openapi.json` unchanged.

Docs updated: `docs/dev/hetzner-provider.md` (model table, corrected limits, per-model ceilings, new Troubleshooting section for "only one model in the dropdown") and `docs/dev/provider-settings.md` (caching rationale and TTL table).

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)