### PR TITLE
feat(nextcloud): full auth support for the local model provider

### DIFF
--- a/docs/dev/local-provider.md
+++ b/docs/dev/local-provider.md
@@ -46,7 +46,16 @@ none of it is user-settable (see [Security](#security)).
 | Field | App config key | Default | Notes |
 |---|---|---|---|
 | Endpoint base URL | `local_base_url` | *(empty)* | `/v1` appended automatically; must be `http(s)`. Empty means the provider is unconfigured. |
-| Bearer token | credential manager, provider `local` | *(empty)* | Optional. Empty ⇒ **no** `Authorization` header at all. |
+| API key | credential manager, provider `local` | *(empty)* | Optional, and used by whichever auth mode is selected — the bearer token, the Basic *password*, or the custom header's value. Empty ⇒ **no** credential header at all. |
+| Authentication | `local_auth_mode` | `bearer` | `none` \| `bearer` \| `basic` \| `header` — see [Authentication](#authentication). |
+| Basic auth username | `local_auth_user` | *(empty)* | Only used in `basic` mode. |
+| Header name | `local_auth_header` | *(empty)* | Only used in `header` mode, e.g. `X-API-Key`. |
+| Additional request headers | credential manager, secret `local_extra_headers` | *(empty)* | `Name: value` per line — see [Additional headers](#additional-headers). |
+| Verify TLS certificate | `local_tls_verify` | `yes` | Unchecking accepts any certificate for this endpoint. |
+| CA bundle path | `local_ca_bundle` | *(empty)* | Absolute path to a PEM bundle for a private CA. |
+| Client certificate path | `local_client_cert` | *(empty)* | mTLS; absolute path. |
+| Client key path | `local_client_key` | *(empty)* | mTLS; absolute path. |
+| Client key passphrase | credential manager, secret `local_client_key_password` | *(empty)* | Only for an encrypted private key. |
 | Model | `model_local` | `llama3.2` | Free text; autocompletes from the endpoint's `/v1/models`. Users may override with `user_model_local`. |
 | Max response tokens | `max_tokens_local` | `4096` | No per-model ceiling table — local model ids are arbitrary tags. |
 | Request timeout | `local_timeout` | `300` | Applies to streaming and non-streaming. The shared `api_timeout` (30 s) is far too low for CPU inference. |
@@ -63,9 +72,87 @@ Configuration goes through the schema-driven endpoints
 write whatever `LocalProvider::getSettingsSchema()` declares; the token is stored
 encrypted in Nextcloud's credential manager like every other provider key.
 
-The base URL and the local-address allowance are declared `SCOPE_ADMIN`, so
-`ProviderSettingsService::writeUser()` refuses them even if the personal page
-were to submit them — see the Security section below.
+Every field above is declared `SCOPE_ADMIN`, so
+`ProviderSettingsService::writeUser()` refuses it even if the personal page were
+to submit it — see the Security section below. The only user-scope setting this
+provider has is `user_model_local`.
+
+## Authentication
+
+A bare Ollama or LM Studio takes a bearer token or nothing at all, but a
+self-hosted endpoint published beyond localhost is usually behind a reverse
+proxy that wants something else. `local_auth_mode` picks the scheme; the stored
+API key is the secret in every case, so switching modes does not mean
+re-entering it.
+
+| Mode | Sent | For |
+|---|---|---|
+| `none` | nothing | A backend with no auth, where a stored key should stay unused |
+| `bearer` | `Authorization: Bearer <key>` | LM Studio, `llama-server --api-key`. The default, and what every install had before this existed |
+| `basic` | `Authorization: Basic base64(<local_auth_user>:<key>)` | nginx `auth_basic`, Caddy `basic_auth` |
+| `header` | `<local_auth_header>: <key>` | LiteLLM, vLLM behind a gateway, anything wanting `X-API-Key` |
+
+An empty key means no credential header at all, whatever the mode — that is the
+keyless-Ollama case. In `header` mode with no header name configured, nothing is
+sent either: an obvious 401 beats the key landing in a header nobody named.
+
+The **Test connection** button distinguishes the failures rather than reporting a
+flat "unreachable": a rejected credential names the configured scheme, a TLS
+failure points at the CA settings, an unresolvable host points at
+`host.docker.internal`, and a refused connection points at the port.
+
+## Additional headers
+
+`local_extra_headers` holds static headers for setups that need more than a
+credential — Cloudflare Access sends a `CF-Access-Client-Id` /
+`CF-Access-Client-Secret` pair, gateways want a tenant or routing header. One
+`Name: value` per line; blank lines and `#` comments are ignored.
+
+```
+# Cloudflare Access
+CF-Access-Client-Id: 1234….access
+CF-Access-Client-Secret: abcd…
+X-Tenant: research
+```
+
+It goes through the credential manager rather than `appconfig`, because those
+values are secrets. `HeaderSpec` validates the block both when it is saved (so a
+mistake is a readable error, not a cURL failure hours later) and when it is read
+back, and refuses:
+
+- CR/LF anywhere — header injection, against an endpoint whose SSRF guard is off.
+- Hop-by-hop headers and `Content-Length` — they describe the connection, not the
+  message.
+- `Content-Type` and `Authorization` — owned by the provider; letting an extra
+  header silently beat the configured auth scheme would make the mode a lie.
+
+`Host` **is** allowed: the URL already decides which address is contacted, so
+overriding it only selects a vhost there.
+
+## TLS and mTLS
+
+An internal endpoint is often published with a certificate no public bundle
+trusts, or behind a proxy demanding a client certificate. These map straight onto
+the HTTP client's options, since Nextcloud's `Client` merges caller options over
+its own defaults (`array_merge($defaults, $options)`) — so `verify` set here
+really does replace the instance CA bundle, and leaving it unset keeps that
+bundle applying.
+
+- `local_ca_bundle` → `verify`. The instance-wide alternative is
+  `occ security:certificates:import`, which affects every outbound request rather
+  than just this provider's.
+- `local_client_cert` / `local_client_key` → `cert` / `ssl_key`, paired with
+  `local_client_key_password` when the key is encrypted.
+- `local_tls_verify` off → `verify: false`. Accepts any certificate for this
+  endpoint, including one presented by an attacker on the path. It exists because
+  an admin who knows their own network may knowingly want it; prefer the CA
+  bundle.
+
+Certificate material is given as **paths on the server**, not uploaded: private
+keys stay out of app storage. The path must be absolute and readable by the
+web-server user — in Docker it has to be mounted into the container. It is
+checked when saved and again on every request, so a rotated-away mount reports
+the file and the setting instead of an opaque cURL error.
 
 ## Security
 
@@ -79,10 +166,16 @@ would block every realistic local-model deployment. `LocalProvider` sets
 this provider's requests only — nothing else in the app gains it. Turn it off if
 your endpoint has a public hostname.
 
-**The base URL is admin-only, deliberately.** Nextcloud makes outbound
-server-side requests to whatever is stored there, so a user-settable URL combined
-with the allowance above would be a straightforward SSRF primitive. There is a
-`user_model_local` override for the *model*, but no user override for the URL.
+**Every setting here is admin-only, deliberately.** Nextcloud makes outbound
+server-side requests to whatever is stored in the base URL, so a user-settable
+URL combined with the allowance above would be a straightforward SSRF primitive
+— and user-settable headers on top of it would be a way to post an instance
+credential wherever the user likes. There is a `user_model_local` override for
+the *model*, and nothing else.
+
+**Secrets never touch `appconfig`.** The API key, the extra headers and the
+client-key passphrase all live in the credential manager, encrypted at rest, and
+the settings API returns only whether each one is set.
 
 **Don't expose the backend itself.** The recommended topology is to keep the
 runtime bound to `127.0.0.1` and reach it over the Docker network, a reverse

--- a/docs/dev/provider-settings.md
+++ b/docs/dev/provider-settings.md
@@ -35,13 +35,45 @@ The descriptor carries its own config keys, so key naming stays with the
 provider that owns it — `ProviderSettingsService` reads and writes purely from
 the descriptor and never names a provider.
 
-Types: `text`, `number`, `password`, `select`, `checkbox`, `url`, `multiselect`.
+Types: `text`, `number`, `password`, `textarea`, `select`, `checkbox`, `url`,
+`multiselect`.
 Groups: `basic` renders inline on the card, `advanced` behind a disclosure.
 A select whose `options` is the sentinel `@models` is expanded to the provider's
 live model list (cached per credential, with the static registry as fallback —
 see [Model list caching](#model-list-caching)); a `multiselect`
 whose `options` is `@principals` is a user/group picker that queries
 `/api/admin/principals` as the admin types.
+
+A `format` adds a validation rule on top of the type, applied by
+`ProviderSettingsService::encode()` so the rule lives in one place rather than in
+each provider: `header_name` (a single HTTP header name), `headers` (a
+`Name: value` block, parsed by `HeaderSpec`), `file_path` (an absolute path that
+must exist and be readable by the web-server user). A failure raises
+`InvalidArgumentException`, which the controller turns into a 400 carrying the
+message.
+
+A `visible_if` — `['field' => 'local_auth_mode', 'in' => ['basic']]` — hides a
+field until a sibling holds one of the listed values. Presentation only: scope is
+what decides who may *write* a field, and a hidden field's stored value stays
+put, so flipping between auth modes does not discard what was typed for the other
+one.
+
+## Secrets
+
+`sensitive => true` keeps a value out of every response — `describe()` reports
+only `hasValue`, and the client submits an empty string to mean "leave it alone".
+Where it is stored depends on one more key:
+
+- No `secret` key: the field is *the* provider API key, held in
+  `CredentialService` under the provider id. Writable in user scope, which is how
+  a personal key overrides the instance one.
+- `secret => '<name>'`: a named instance-scope slot
+  (`aiquila/secret/<name>`), for the second credential a provider needs — the
+  local provider's extra request headers and client-key passphrase. Namespaced
+  away from the API keys so a secret name cannot collide with a provider id, and
+  `SCOPE_ADMIN` by construction. Submitting an empty value clears it.
+
+Either way the value never reaches `IConfig`.
 
 ## Fields no provider declares
 

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Nextcloud MCP server — files, calendar, contacts, mail, maps, notes, tasks & 120+ more tools",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,7 +18,7 @@
       ]
     }
   ],
-  "version": "0.4.2",
+  "version": "0.4.3",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "remotes": [
     {
@@ -36,7 +36,7 @@
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -64,7 +64,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.4.2",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.4.3",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.4.2</version>
+    <version>0.4.3</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/lib/Service/CredentialService.php
+++ b/nextcloud-app/lib/Service/CredentialService.php
@@ -14,6 +14,8 @@ class CredentialService {
     private const APP_NAME = 'aiquila';
     private const CREDENTIAL_KEY = 'aiquila/api_key';
     private const NATIVE_MCP_EXTRA_TOKEN_KEY = 'aiquila/native_mcp_extra_token';
+    /** Namespace for the generic named secrets; see secretKey(). */
+    private const SECRET_KEY_PREFIX = 'aiquila/secret/';
 
     /** Default provider whose key lives under the legacy CREDENTIAL_KEY. */
     private const DEFAULT_PROVIDER = 'anthropic';
@@ -170,6 +172,44 @@ class CredentialService {
 
     public function hasNativeMcpExtraToken(): bool {
         return $this->getNativeMcpExtraToken() !== '';
+    }
+
+    // ── Named app-scope secrets ─────────────────────────────────────────────
+
+    /**
+     * Generic instance-scope secret slot, addressed by name rather than by
+     * provider.
+     *
+     * The per-provider API key covers "the one credential a provider needs";
+     * some providers need a second one — the local provider's extra request
+     * headers (a Cloudflare Access client secret lives in there) and its client
+     * key passphrase. Those go here rather than into IConfig so they stay
+     * encrypted at rest, and rather than into credentialKey() so they cannot
+     * collide with a provider id.
+     *
+     * Instance scope only: every field backed by one of these is SCOPE_ADMIN.
+     */
+    private function secretKey(string $name): string {
+        return self::SECRET_KEY_PREFIX . $name;
+    }
+
+    public function getSecret(string $name): string {
+        $value = $this->credentialsManager->retrieve('', $this->secretKey($name));
+        return is_string($value) ? $value : '';
+    }
+
+    public function setSecret(string $name, #[\SensitiveParameter] string $value): void {
+        $this->credentialsManager->store('', $this->secretKey($name), $value);
+        $this->logger->info('AIquila: secret stored', ['secret' => $name]);
+    }
+
+    public function deleteSecret(string $name): void {
+        $this->credentialsManager->delete('', $this->secretKey($name));
+        $this->logger->info('AIquila: secret cleared', ['secret' => $name]);
+    }
+
+    public function hasSecret(string $name): bool {
+        return $this->getSecret($name) !== '';
     }
 
     /**

--- a/nextcloud-app/lib/Service/Provider/HeaderSpec.php
+++ b/nextcloud-app/lib/Service/Provider/HeaderSpec.php
@@ -1,0 +1,134 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Service\Provider;
+
+/**
+ * Parser and validator for admin-supplied static request headers.
+ *
+ * Self-hosted model endpoints are commonly fronted by a proxy that wants extra
+ * headers — Cloudflare Access sends a `CF-Access-Client-Id` /
+ * `CF-Access-Client-Secret` pair, API gateways want a tenant or routing header.
+ * Admins write them as one `Name: value` per line.
+ *
+ * The same code runs on both sides of storage: once when the value is saved, so
+ * a mistake is a readable 400 rather than a cURL error hours later, and again
+ * when it is read back, because a stored value is not trusted input — it may
+ * predate a tightening of these rules, or have been written straight into the
+ * credential store by hand.
+ *
+ * ## What is refused, and why
+ *
+ * - CR/LF anywhere. A newline in a header value is header injection: it lets
+ *   the rest of the request be rewritten, and this provider talks to an
+ *   endpoint that has the SSRF guard disabled.
+ * - Hop-by-hop headers (RFC 9110 §7.6.1) plus `Content-Length`. These describe
+ *   the single connection, not the message; setting them by hand desynchronises
+ *   the client from what it actually sends.
+ * - `Content-Type` and `Authorization`. Both are owned by the provider — the
+ *   first is always JSON, the second is what `local_auth_mode` exists to
+ *   configure. Silently letting an extra header win over the configured auth
+ *   scheme would make the mode setting a lie.
+ *
+ * `Host` is deliberately allowed: the URL already decides which address is
+ * contacted, so overriding it only selects a vhost at that address and adds no
+ * reach.
+ */
+final class HeaderSpec {
+    /** A field-name token, kept to the conservative subset proxies accept. */
+    private const NAME_PATTERN = '/^[A-Za-z0-9][A-Za-z0-9-]{0,63}$/';
+
+    /** Lower-cased names an admin may not set. See the class docblock. */
+    private const FORBIDDEN = [
+        'content-type',
+        'content-length',
+        'authorization',
+        'connection',
+        'keep-alive',
+        'proxy-authenticate',
+        'proxy-authorization',
+        'te',
+        'trailer',
+        'transfer-encoding',
+        'upgrade',
+    ];
+
+    /** True when $name is a usable header name (no forbidden-list check). */
+    public static function isValidName(string $name): bool {
+        return preg_match(self::NAME_PATTERN, $name) === 1;
+    }
+
+    /**
+     * Validate a single header name an admin may set, e.g. the custom auth
+     * header. Returns the name unchanged.
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function requireName(string $name): string {
+        if (!self::isValidName($name)) {
+            throw new \InvalidArgumentException(
+                '"' . $name . '" is not a valid header name. Use letters, digits and hyphens, for example X-API-Key.'
+            );
+        }
+        if (in_array(strtolower($name), self::FORBIDDEN, true)) {
+            throw new \InvalidArgumentException(
+                'The "' . $name . '" header is set by AIquila itself and cannot be overridden.'
+            );
+        }
+        return $name;
+    }
+
+    /**
+     * Parse a `Name: value` block into a header map. Blank lines and `#`
+     * comments are skipped so an admin can annotate the block.
+     *
+     * @return array<string, string>
+     * @throws \InvalidArgumentException on a malformed or forbidden entry
+     */
+    public static function parse(string $raw): array {
+        $headers = [];
+        foreach (preg_split('/\R/', $raw) ?: [] as $index => $line) {
+            $line = trim($line);
+            if ($line === '' || str_starts_with($line, '#')) {
+                continue;
+            }
+            $at = ' (line ' . ($index + 1) . ')';
+
+            $split = strpos($line, ':');
+            if ($split === false || $split === 0) {
+                throw new \InvalidArgumentException(
+                    'Expected "Name: value"' . $at . ', got "' . $line . '".'
+                );
+            }
+
+            $name = self::requireNameAt(trim(substr($line, 0, $split)), $at);
+            $value = trim(substr($line, $split + 1));
+            if ($value === '') {
+                throw new \InvalidArgumentException('The "' . $name . '" header has no value' . $at . '.');
+            }
+            // Redundant after the line split, but this method is also the guard
+            // for values that reach it any other way.
+            if (preg_match('/[\r\n]/', $value) === 1) {
+                throw new \InvalidArgumentException('The "' . $name . '" header value contains a line break' . $at . '.');
+            }
+            if (isset($headers[$name])) {
+                throw new \InvalidArgumentException('The "' . $name . '" header is set twice' . $at . '.');
+            }
+
+            $headers[$name] = $value;
+        }
+
+        return $headers;
+    }
+
+    /** @throws \InvalidArgumentException */
+    private static function requireNameAt(string $name, string $at): string {
+        try {
+            return self::requireName($name);
+        } catch (\InvalidArgumentException $e) {
+            throw new \InvalidArgumentException(rtrim($e->getMessage(), '.') . $at . '.');
+        }
+    }
+}

--- a/nextcloud-app/lib/Service/Provider/LocalProvider.php
+++ b/nextcloud-app/lib/Service/Provider/LocalProvider.php
@@ -17,9 +17,14 @@ namespace OCA\AIquila\Service\Provider;
  *
  * Differences from the hosted providers:
  *   - The base URL is admin configuration rather than a constant.
- *   - The API key is optional. Ollama has no auth at all; LM Studio and
- *     `llama-server --api-key` use a bearer token. When no key is stored the
- *     Authorization header is omitted entirely rather than sent empty.
+ *   - The API key is optional, and how it is sent is configurable. Ollama has no
+ *     auth at all; LM Studio and `llama-server --api-key` use a bearer token;
+ *     a reverse proxy in front of any of them may want HTTP Basic or a header
+ *     of its own, plus static extras such as Cloudflare Access. When no key is
+ *     stored, no credential header is sent at all rather than an empty one.
+ *   - TLS is configurable too: a private CA bundle, a client certificate for
+ *     mTLS, and an explicit opt-out of verification, since an internal endpoint
+ *     is often published with a certificate no public bundle trusts.
  *   - Requests may target a local/private address (localhost, the Docker
  *     network, a LAN box), which Nextcloud's HTTP client blocks by default.
  *   - Vision is opt-in per deployment: we cannot know whether the loaded model
@@ -27,9 +32,11 @@ namespace OCA\AIquila\Service\Provider;
  *   - `tool_choice` is not sent — Ollama rejects the field.
  *   - Timeouts default much higher; CPU inference is slow.
  *
- * Base URL and the local-address allowance are admin-scope only and never
- * user-settable: the server makes outbound requests to whatever is configured,
- * so letting users set it would be an SSRF vector.
+ * Every field here is admin-scope only and never user-settable: the server makes
+ * outbound requests to whatever is configured, with the SSRF guard disabled, so
+ * a user-settable endpoint would be an SSRF vector — and user-settable headers
+ * on top of it would be a way to post an instance credential wherever the user
+ * likes. Secrets go through CredentialService, never IConfig.
  */
 class LocalProvider extends AbstractOpenAiCompatibleProvider {
     private const PROVIDER_ID = 'local';
@@ -41,6 +48,22 @@ class LocalProvider extends AbstractOpenAiCompatibleProvider {
 
     /** Local inference is slow; well above the 30s shared `api_timeout`. */
     public const DEFAULT_TIMEOUT = 300;
+
+    /** No auth at all — a bare Ollama on the same host. */
+    public const AUTH_NONE = 'none';
+    /** `Authorization: Bearer <key>`; what every install had before #446. */
+    public const AUTH_BEARER = 'bearer';
+    /** `Authorization: Basic base64(user:key)` — nginx auth_basic and friends. */
+    public const AUTH_BASIC = 'basic';
+    /** A custom header carrying the key, e.g. `X-API-Key`. */
+    public const AUTH_HEADER = 'header';
+
+    /** @var list<string> */
+    private const AUTH_MODES = [self::AUTH_NONE, self::AUTH_BEARER, self::AUTH_BASIC, self::AUTH_HEADER];
+
+    /** Credential-store names for the two secrets that are not the API key. */
+    private const SECRET_EXTRA_HEADERS = 'local_extra_headers';
+    private const SECRET_CLIENT_KEY_PASSWORD = 'local_client_key_password';
 
     public function getId(): string {
         return self::PROVIDER_ID;
@@ -166,7 +189,91 @@ class LocalProvider extends AbstractOpenAiCompatibleProvider {
                 'Nextcloud blocks requests to localhost and private ranges by default. Required for virtually every local setup.',
                 default: true,
             ),
+
+            // ── Auth scheme ────────────────────────────────────────────────
+            ProviderSettingsSchema::select(
+                'local_auth_mode',
+                'local_auth_mode',
+                'Authentication',
+                'How the key above is sent. Bearer suits LM Studio and llama-server; pick Basic or a custom header when the endpoint sits behind a reverse proxy.',
+                self::AUTH_MODES,
+                default: self::AUTH_BEARER,
+                group: ProviderSettingsSchema::GROUP_BASIC,
+            ),
+            ProviderSettingsSchema::text(
+                'local_auth_user',
+                'local_auth_user',
+                'Basic auth username',
+                'The key above is used as the password.',
+                group: ProviderSettingsSchema::GROUP_BASIC,
+                placeholder: 'nextcloud',
+                visibleIf: ['field' => 'local_auth_mode', 'in' => [self::AUTH_BASIC]],
+            ),
+            ProviderSettingsSchema::text(
+                'local_auth_header',
+                'local_auth_header',
+                'Header name',
+                'The header the key is sent in, e.g. X-API-Key or Api-Key. No Authorization header is sent in this mode.',
+                group: ProviderSettingsSchema::GROUP_BASIC,
+                placeholder: 'X-API-Key',
+                format: ProviderSettingsSchema::FORMAT_HEADER_NAME,
+                visibleIf: ['field' => 'local_auth_mode', 'in' => [self::AUTH_HEADER]],
+            ),
+            ProviderSettingsSchema::secretTextarea(
+                'local_extra_headers',
+                self::SECRET_EXTRA_HEADERS,
+                'Additional request headers',
+                'One "Name: value" per line, for Cloudflare Access or gateway routing headers. Stored encrypted. Content-Type, Authorization and hop-by-hop headers cannot be set here.',
+                placeholder: "CF-Access-Client-Id: …\nCF-Access-Client-Secret: …",
+                format: ProviderSettingsSchema::FORMAT_HEADERS,
+            ),
+
+            // ── TLS ────────────────────────────────────────────────────────
+            ProviderSettingsSchema::checkbox(
+                'local_tls_verify',
+                'local_tls_verify',
+                'Verify the endpoint\'s TLS certificate',
+                'Leave on. Turning it off accepts any certificate for this endpoint, including one presented by an attacker on the path.',
+                default: true,
+            ),
+            ProviderSettingsSchema::text(
+                'local_ca_bundle',
+                'local_ca_bundle',
+                'CA bundle path',
+                'Absolute path to a PEM bundle for a private CA, readable by the web server. Alternatively import the CA instance-wide with occ security:certificates:import.',
+                placeholder: '/etc/ssl/certs/internal-ca.pem',
+                format: ProviderSettingsSchema::FORMAT_FILE_PATH,
+                visibleIf: ['field' => 'local_tls_verify', 'in' => [true]],
+            ),
+            ProviderSettingsSchema::text(
+                'local_client_cert',
+                'local_client_cert',
+                'Client certificate path',
+                'Absolute path to a PEM client certificate, for an endpoint requiring mTLS.',
+                placeholder: '/etc/ssl/certs/aiquila-client.pem',
+                format: ProviderSettingsSchema::FORMAT_FILE_PATH,
+            ),
+            ProviderSettingsSchema::text(
+                'local_client_key',
+                'local_client_key',
+                'Client key path',
+                'Absolute path to the matching private key. Omit when the key is inside the certificate file.',
+                placeholder: '/etc/ssl/private/aiquila-client.key',
+                format: ProviderSettingsSchema::FORMAT_FILE_PATH,
+            ),
+            ProviderSettingsSchema::secret(
+                'local_client_key_password',
+                self::SECRET_CLIENT_KEY_PASSWORD,
+                'Client key passphrase',
+                'Only needed when the private key is encrypted. Stored encrypted.',
+            ),
         ];
+    }
+
+    /** One of the AUTH_* constants; anything unrecognised falls back to bearer. */
+    private function authMode(): string {
+        $mode = $this->config->getAppValue(self::APP_NAME, 'local_auth_mode', self::AUTH_BEARER);
+        return in_array($mode, self::AUTH_MODES, true) ? $mode : self::AUTH_BEARER;
     }
 
     protected function supportsVisionInput(?string $userId = null): bool {
@@ -203,7 +310,68 @@ class LocalProvider extends AbstractOpenAiCompatibleProvider {
         if ($this->config->getAppValue(self::APP_NAME, 'local_allow_local_address', 'yes') === 'yes') {
             $options['nextcloud'] = ['allow_local_address' => true];
         }
+        return $options + $this->tlsOptions();
+    }
+
+    /**
+     * TLS options for a self-hosted endpoint: a private CA, a client
+     * certificate, or an explicit decision to accept whatever certificate is
+     * presented.
+     *
+     * Nextcloud's HTTP client merges caller options over its own defaults
+     * (`array_merge($defaults, $options)` in OC\Http\Client\Client), so
+     * `verify` set here really does replace the instance CA bundle — and, when
+     * it is not set here, that bundle keeps applying.
+     *
+     * @return array<string, mixed>
+     */
+    private function tlsOptions(): array {
+        $options = [];
+
+        if ($this->config->getAppValue(self::APP_NAME, 'local_tls_verify', 'yes') !== 'yes') {
+            $options['verify'] = false;
+        } else {
+            $ca = $this->readablePath('local_ca_bundle', 'CA bundle');
+            if ($ca !== '') {
+                $options['verify'] = $ca;
+            }
+        }
+
+        $passphrase = $this->credentials->getSecret(self::SECRET_CLIENT_KEY_PASSWORD);
+
+        $cert = $this->readablePath('local_client_cert', 'client certificate');
+        if ($cert !== '') {
+            $options['cert'] = $passphrase !== '' ? [$cert, $passphrase] : $cert;
+        }
+
+        $key = $this->readablePath('local_client_key', 'client key');
+        if ($key !== '') {
+            $options['ssl_key'] = $passphrase !== '' ? [$key, $passphrase] : $key;
+        }
+
         return $options;
+    }
+
+    /**
+     * A configured certificate path, checked again at request time.
+     *
+     * The path was verified when it was saved, but a container rebuild or a
+     * rotated mount can take the file away afterwards. Failing here names the
+     * file and the setting; letting it through would surface as an opaque
+     * "cURL error 58" instead.
+     */
+    private function readablePath(string $configKey, string $label): string {
+        $path = trim($this->config->getAppValue(self::APP_NAME, $configKey, ''));
+        if ($path === '') {
+            return '';
+        }
+        if (!is_file($path) || !is_readable($path)) {
+            throw new \RuntimeException(
+                'The configured ' . $label . ' "' . $path . '" is missing or unreadable. '
+                . 'Check the AIquila admin settings for the local model provider.'
+            );
+        }
+        return $path;
     }
 
     /**
@@ -214,13 +382,75 @@ class LocalProvider extends AbstractOpenAiCompatibleProvider {
         return $this->getApiKey($userId);
     }
 
-    /** @return array<string, string> */
+    /**
+     * The stored API key is the secret for every mode — the bearer token, the
+     * Basic *password*, or the custom header's value — so switching schemes
+     * does not mean re-entering it. An empty key still means "send no auth"
+     * rather than an error: that is the whole point of the keyless Ollama case.
+     *
+     * Extra headers are merged last but cannot override anything above:
+     * HeaderSpec forbids Content-Type and Authorization outright, and the
+     * custom auth header is re-applied afterwards so a stale stored block
+     * cannot quietly replace the configured credential.
+     *
+     * @return array<string, string>
+     */
     protected function headers(string $apiKey): array {
-        $headers = ['Content-Type' => 'application/json'];
-        if ($apiKey !== '') {
-            $headers['Authorization'] = 'Bearer ' . $apiKey;
+        $headers = ['Content-Type' => 'application/json'] + $this->extraHeaders();
+
+        if ($apiKey === '') {
+            return $headers;
         }
-        return $headers;
+
+        return match ($this->authMode()) {
+            self::AUTH_NONE => $headers,
+            self::AUTH_BASIC => ['Authorization' => 'Basic ' . base64_encode(
+                $this->config->getAppValue(self::APP_NAME, 'local_auth_user', '') . ':' . $apiKey
+            )] + $headers,
+            self::AUTH_HEADER => $this->customAuthHeader($apiKey) + $headers,
+            default => ['Authorization' => 'Bearer ' . $apiKey] + $headers,
+        };
+    }
+
+    /**
+     * The custom-header mode with no header name configured sends nothing
+     * rather than guessing: a request that silently arrives unauthenticated is
+     * easier to diagnose as a 401 than as a key leaked into a header the admin
+     * never named.
+     *
+     * @return array<string, string>
+     */
+    private function customAuthHeader(string $apiKey): array {
+        $name = trim($this->config->getAppValue(self::APP_NAME, 'local_auth_header', ''));
+        if ($name === '' || !HeaderSpec::isValidName($name)) {
+            $this->logger->warning('AIquila: local provider is set to custom-header auth but has no valid header name; sending no credential', [
+                'provider' => self::PROVIDER_ID,
+            ]);
+            return [];
+        }
+        return [$name => $apiKey];
+    }
+
+    /**
+     * The admin's static extra headers. Re-validated on read — a stored value
+     * is not trusted input, and a block that no longer parses must not be
+     * spliced into an outbound request.
+     *
+     * @return array<string, string>
+     */
+    private function extraHeaders(): array {
+        $raw = $this->credentials->getSecret(self::SECRET_EXTRA_HEADERS);
+        if ($raw === '') {
+            return [];
+        }
+        try {
+            return HeaderSpec::parse($raw);
+        } catch (\InvalidArgumentException $e) {
+            $this->logger->error('AIquila: stored extra headers for the local provider are invalid and were dropped: ' . $e->getMessage(), [
+                'provider' => self::PROVIDER_ID,
+            ]);
+            return [];
+        }
     }
 
     // ── Errors ──────────────────────────────────────────────────────────────
@@ -229,20 +459,69 @@ class LocalProvider extends AbstractOpenAiCompatibleProvider {
         return 'No local model endpoint configured. Set one in the AIquila admin settings.';
     }
 
+    /**
+     * A local endpoint fails in more ways than a hosted one — it may be behind a
+     * proxy, on a private CA, or simply not running — and "could not reach it"
+     * sends an admin to look at the wrong setting in most of them. Each branch
+     * below names the setting that fixes it.
+     */
     protected function errorMessage(\Throwable $e): string {
         $msg = $e->getMessage();
         if ($e instanceof \OCP\Http\Client\LocalServerException) {
             return 'Nextcloud blocked the request to the local model endpoint. Enable "Allow local addresses" in the AIquila admin settings.';
         }
+        if ($this->mentions($msg, ProviderProbe::TLS_MARKERS)) {
+            return $this->config->getAppValue(self::APP_NAME, 'local_tls_verify', 'yes') === 'yes'
+                ? 'TLS failed against the local model endpoint (' . $msg . '). For a private CA, set a CA bundle path in the AIquila admin settings or import the CA with occ security:certificates:import.'
+                : 'TLS failed against the local model endpoint even with verification disabled (' . $msg . '). Check the client certificate settings.';
+        }
         if (stripos($msg, '401') !== false || stripos($msg, 'unauthorized') !== false) {
-            return 'The local model endpoint rejected the API key. Check the token in the AIquila admin settings.';
+            return $this->unauthorizedMessage();
+        }
+        if (stripos($msg, '403') !== false || stripos($msg, 'forbidden') !== false) {
+            return 'The local model endpoint refused the request (403). If it sits behind a proxy such as Cloudflare Access, check the additional request headers in the AIquila admin settings.';
+        }
+        if (stripos($msg, '407') !== false || stripos($msg, 'proxy authentication') !== false) {
+            return 'An HTTP proxy demanded authentication (407). This is Nextcloud\'s own `proxy` / `proxyuserpwd` system configuration, not an AIquila setting.';
         }
         if (stripos($msg, '404') !== false) {
             return 'The local model endpoint returned 404. Check the base URL and that the model is loaded.';
+        }
+        if ($this->mentions($msg, ['could not resolve host', 'name or service not known', 'curl error 6'])) {
+            return 'The host in the local model endpoint (' . $this->apiBase() . ') could not be resolved. From a container, "localhost" is the container itself — use host.docker.internal or the service name.';
+        }
+        if ($this->mentions($msg, ['connection refused', 'curl error 7'])) {
+            return 'Nothing is listening at the local model endpoint (' . $this->apiBase() . '). Is the backend running, and is the port right?';
         }
         if (stripos($msg, 'connection') !== false || stripos($msg, 'timed out') !== false || stripos($msg, 'timeout') !== false) {
             return 'Could not reach the local model endpoint (' . $this->apiBase() . '). Is the server running and reachable from Nextcloud?';
         }
         return 'Local model error: ' . $msg;
+    }
+
+    /**
+     * The 401 wording follows the configured scheme: "check the API key" is
+     * simply wrong advice when the endpoint wants a username and password, or a
+     * header the admin has not named yet.
+     */
+    private function unauthorizedMessage(): string {
+        return match ($this->authMode()) {
+            self::AUTH_NONE => 'The local model endpoint requires authentication, but Authentication is set to "none" in the AIquila admin settings.',
+            self::AUTH_BASIC => 'The local model endpoint rejected the Basic credentials. Check the username and the key in the AIquila admin settings.',
+            self::AUTH_HEADER => 'The local model endpoint rejected the credential sent in "'
+                . ($this->config->getAppValue(self::APP_NAME, 'local_auth_header', '') ?: 'the configured header')
+                . '". Check the header name and the key in the AIquila admin settings.',
+            default => 'The local model endpoint rejected the API key. Check the token in the AIquila admin settings.',
+        };
+    }
+
+    /** @param list<string> $needles */
+    private function mentions(string $haystack, array $needles): bool {
+        foreach ($needles as $needle) {
+            if (stripos($haystack, $needle) !== false) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/nextcloud-app/lib/Service/Provider/ProviderProbe.php
+++ b/nextcloud-app/lib/Service/Provider/ProviderProbe.php
@@ -30,6 +30,7 @@ final class ProviderProbe {
     public const REASON_UNAUTHORIZED = 'unauthorized';
     public const REASON_RATE_LIMITED = 'rate_limited';
     public const REASON_UNREACHABLE = 'unreachable';
+    public const REASON_TLS = 'tls';
     public const REASON_MODEL_MISSING = 'model_missing';
     public const REASON_OK = 'ok';
 
@@ -100,8 +101,37 @@ final class ProviderProbe {
         if (self::mentions($raw, ['429', 'rate limit', 'too many requests', 'quota'])) {
             return self::result(self::STATE_DEGRADED, self::REASON_RATE_LIMITED, $message, $model);
         }
+        // Before the unreachable fallback: a certificate the client refuses is
+        // a reachable endpoint with a fixable configuration, and telling an
+        // admin "unreachable" sends them to look at the wrong thing.
+        if (self::mentions($raw, self::TLS_MARKERS)) {
+            return self::result(self::STATE_ERROR, self::REASON_TLS, $message, $model);
+        }
         return self::result(self::STATE_ERROR, self::REASON_UNREACHABLE, $message, $model);
     }
+
+    /**
+     * Substrings that identify a TLS failure across cURL, OpenSSL and Guzzle
+     * wordings. Shared with the providers' errorMessage() so one failure is
+     * classified the same way wherever it is rendered.
+     *
+     * @var list<string>
+     */
+    public const TLS_MARKERS = [
+        'curl error 35',
+        'curl error 58',
+        'curl error 60',
+        'curl error 77',
+        'certificate verify failed',
+        'ssl certificate problem',
+        'unable to get local issuer',
+        'self signed certificate',
+        'self-signed certificate',
+        'ssl connect error',
+        'sslv3',
+        'tlsv1',
+        'handshake failure',
+    ];
 
     /** @param list<string> $needles */
     private static function mentions(string $haystack, array $needles): bool {

--- a/nextcloud-app/lib/Service/Provider/ProviderSettingsSchema.php
+++ b/nextcloud-app/lib/Service/Provider/ProviderSettingsSchema.php
@@ -46,6 +46,8 @@ final class ProviderSettingsSchema {
     public const TYPE_CHECKBOX = 'checkbox';
     public const TYPE_URL = 'url';
     public const TYPE_NUMBER = 'number';
+    /** Multi-line free text (currently the local provider's extra headers). */
+    public const TYPE_TEXTAREA = 'textarea';
     /** Multiple values from an async lookup; the value is a list of ids. */
     public const TYPE_MULTISELECT = 'multiselect';
 
@@ -76,6 +78,18 @@ final class ProviderSettingsSchema {
      * `aiquila_provider_access` and written through ProviderAccessService.
      */
     public const STORAGE_ACCESS = 'access';
+
+    /**
+     * `format` values. A format is an extra validation rule applied by
+     * ProviderSettingsService::encode() on top of the type check, so the rules
+     * live in one place instead of in each provider.
+     */
+    /** A single HTTP header name, e.g. `X-API-Key`. */
+    public const FORMAT_HEADER_NAME = 'header_name';
+    /** A `Name: value` block, one header per line. */
+    public const FORMAT_HEADERS = 'headers';
+    /** An absolute path to a file readable by the web server. */
+    public const FORMAT_FILE_PATH = 'file_path';
 
     /** Booleans stored as the literal strings 'yes'/'no' (local provider legacy). */
     public const STORAGE_YESNO = 'yesno';
@@ -223,8 +237,10 @@ final class ProviderSettingsSchema {
         string $scope = self::SCOPE_ADMIN,
         string $group = self::GROUP_ADVANCED,
         string $placeholder = '',
+        ?string $format = null,
+        ?array $visibleIf = null,
     ): array {
-        return [
+        return self::visibility([
             'id' => $id,
             'title' => $title,
             'description' => $description,
@@ -234,7 +250,75 @@ final class ProviderSettingsSchema {
             'default' => $default,
             'placeholder' => $placeholder,
             'group' => $group,
-        ];
+        ] + ($format !== null ? ['format' => $format] : []), $visibleIf);
+    }
+
+    /**
+     * Multi-line secret held in CredentialService under its own name rather
+     * than in the per-provider API-key slot, for the second credential a
+     * provider needs (the local provider's extra request headers). Like every
+     * `sensitive` field the value is never returned to the client — only
+     * whether one is stored.
+     */
+    public static function secretTextarea(
+        string $id,
+        string $secret,
+        string $title,
+        string $description,
+        string $placeholder = '',
+        ?string $format = null,
+        ?array $visibleIf = null,
+    ): array {
+        return self::visibility([
+            'id' => $id,
+            'title' => $title,
+            'description' => $description,
+            'type' => self::TYPE_TEXTAREA,
+            'scope' => self::SCOPE_ADMIN,
+            'sensitive' => true,
+            'secret' => $secret,
+            'optional' => true,
+            'placeholder' => $placeholder,
+            'group' => self::GROUP_ADVANCED,
+        ] + ($format !== null ? ['format' => $format] : []), $visibleIf);
+    }
+
+    /** Single-line named secret; see secretTextarea() for the storage rules. */
+    public static function secret(
+        string $id,
+        string $secret,
+        string $title,
+        string $description,
+        ?array $visibleIf = null,
+    ): array {
+        return self::visibility([
+            'id' => $id,
+            'title' => $title,
+            'description' => $description,
+            'type' => self::TYPE_PASSWORD,
+            'scope' => self::SCOPE_ADMIN,
+            'sensitive' => true,
+            'secret' => $secret,
+            'optional' => true,
+            'group' => self::GROUP_ADVANCED,
+        ], $visibleIf);
+    }
+
+    /**
+     * Attach a display condition: the field is only rendered when the named
+     * sibling field currently holds one of `in`.
+     *
+     * Presentation only — the settings page has no business showing a Basic
+     * username while the mode is `bearer`. It is deliberately *not* a write
+     * guard: scope is what decides who may write a field, and a hidden field
+     * whose stored value stays put is the right behaviour when an admin
+     * switches modes back and forth.
+     */
+    private static function visibility(array $field, ?array $visibleIf): array {
+        if ($visibleIf !== null) {
+            $field['visible_if'] = $visibleIf;
+        }
+        return $field;
     }
 
     /**

--- a/nextcloud-app/lib/Service/Provider/ProviderSettingsService.php
+++ b/nextcloud-app/lib/Service/Provider/ProviderSettingsService.php
@@ -129,6 +129,8 @@ class ProviderSettingsService {
             }
 
             if (!empty($field['sensitive'])) {
+                // Named secrets are instance-scope by construction, so they can
+                // never be user-writable and never reach this branch.
                 $plan[] = ['key' => null, 'value' => (string)$value];
                 continue;
             }
@@ -183,6 +185,14 @@ class ProviderSettingsService {
             }
 
             if (!empty($field['sensitive'])) {
+                $secret = $field['secret'] ?? null;
+                if ($secret !== null) {
+                    // Validated before anything is written, like every other
+                    // field — an unparsable header block must not be stored.
+                    $this->validateFormat($field, (string)$value);
+                    $plan[] = ['key' => null, 'secret' => (string)$secret, 'value' => (string)$value];
+                    continue;
+                }
                 $plan[] = ['key' => null, 'value' => (string)$value];
                 continue;
             }
@@ -203,6 +213,10 @@ class ProviderSettingsService {
 
         foreach ($plan as $write) {
             if ($write['key'] === null) {
+                if (isset($write['secret'])) {
+                    $this->writeSecret($write['secret'], $write['value']);
+                    continue;
+                }
                 $this->writeApiKey($provider->getId(), null, $write['value']);
                 continue;
             }
@@ -363,13 +377,13 @@ class ProviderSettingsService {
      * offered a field the scope rules refuse — either a schema bug or an
      * attempt to write an admin-only field from the personal page.
      *
-     * @param list<array{key: ?string, value: string}> $plan
+     * @param list<array{key: ?string, secret?: string, value: string}> $plan
      * @param list<string> $rejected
      */
     private function logWrite(string $providerId, string $scope, array $plan, array $rejected, ?string $userId): void {
         $written = [];
         foreach ($plan as $write) {
-            $written[] = $write['key'] ?? 'api_key';
+            $written[] = $write['key'] ?? ($write['secret'] ?? 'api_key');
         }
 
         $context = ['provider' => $providerId, 'scope' => $scope, 'fields' => $written];
@@ -439,9 +453,12 @@ class ProviderSettingsService {
         }
 
         if (!empty($field['sensitive'])) {
-            $out['hasValue'] = $admin
-                ? $this->credentials->hasApiKey(null, $providerId)
-                : ($userId !== null && $this->credentials->hasApiKey($userId, $providerId));
+            $secret = $field['secret'] ?? null;
+            $out['hasValue'] = $secret !== null
+                ? ($admin && $this->credentials->hasSecret((string)$secret))
+                : ($admin
+                    ? $this->credentials->hasApiKey(null, $providerId)
+                    : ($userId !== null && $this->credentials->hasApiKey($userId, $providerId)));
             unset($out['value']);
             return $out;
         }
@@ -476,6 +493,19 @@ class ProviderSettingsService {
         // '' means "not set — follow the instance default", which the UI renders
         // as an empty picker rather than as a false checkbox.
         return $raw === '' ? '' : $this->decode($field, $raw);
+    }
+
+    /**
+     * A named secret, cleared when submitted empty — the same convention the
+     * API key uses, so "wipe this field and save" removes the credential
+     * instead of storing an empty string.
+     */
+    private function writeSecret(string $name, #[\SensitiveParameter] string $value): void {
+        if ($value === '') {
+            $this->credentials->deleteSecret($name);
+            return;
+        }
+        $this->credentials->setSecret($name, $value);
     }
 
     private function writeApiKey(string $providerId, ?string $userId, #[\SensitiveParameter] string $value): void {
@@ -565,6 +595,8 @@ class ProviderSettingsService {
             }
         }
 
+        $this->validateFormat($field, $string);
+
         // A select may only receive one of the values it offered. `options` is
         // '@models' at this point for model fields, whose valid set is whatever
         // the provider currently serves — those are checked by the provider on
@@ -578,6 +610,51 @@ class ProviderSettingsService {
         }
 
         return $string;
+    }
+
+    /**
+     * Apply the descriptor's `format` rule, if any. Empty always passes: an
+     * empty value means the field is unset, and the caller decides whether that
+     * is allowed.
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function validateFormat(array $field, string $value): void {
+        $format = $field['format'] ?? null;
+        if ($format === null || $value === '') {
+            return;
+        }
+        $label = (string)($field['title'] ?? $field['id']);
+
+        try {
+            match ($format) {
+                ProviderSettingsSchema::FORMAT_HEADER_NAME => HeaderSpec::requireName($value),
+                ProviderSettingsSchema::FORMAT_HEADERS => HeaderSpec::parse($value),
+                ProviderSettingsSchema::FORMAT_FILE_PATH => $this->requireReadableFile($value),
+                default => null,
+            };
+        } catch (\InvalidArgumentException $e) {
+            throw new \InvalidArgumentException($label . ': ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Certificate material is given as a path on the server rather than
+     * uploaded, so a typo would otherwise surface as an opaque TLS failure at
+     * request time. Checked here as the web-server user, which is exactly who
+     * has to read it later.
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function requireReadableFile(string $path): void {
+        if (!str_starts_with($path, '/')) {
+            throw new \InvalidArgumentException('enter an absolute path, for example /etc/ssl/certs/internal-ca.pem.');
+        }
+        if (!is_file($path) || !is_readable($path)) {
+            throw new \InvalidArgumentException(
+                '"' . $path . '" does not exist or is not readable by the web server. In Docker it must be mounted into the container.'
+            );
+        }
     }
 
     /** Turn a stored string back into the type the UI expects. */

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",

--- a/nextcloud-app/src/components/settings/ProviderCard.vue
+++ b/nextcloud-app/src/components/settings/ProviderCard.vue
@@ -162,10 +162,10 @@ export default {
 			return this.provider.fields || []
 		},
 		basicFields() {
-			return this.fields.filter(f => (f.group || 'basic') === 'basic')
+			return this.fields.filter(f => (f.group || 'basic') === 'basic' && this.isVisible(f))
 		},
 		advancedFields() {
-			return this.fields.filter(f => f.group === 'advanced')
+			return this.fields.filter(f => f.group === 'advanced' && this.isVisible(f))
 		},
 		capabilityChips() {
 			const caps = this.provider.capabilities || {}
@@ -219,6 +219,22 @@ export default {
 		this.refreshHealth()
 	},
 	methods: {
+		/**
+		 * Honour a field's `visible_if`: show it only while the named sibling
+		 * holds one of the listed values, read from the live draft so switching
+		 * the auth mode reveals its fields immediately.
+		 *
+		 * Display only — the value of a hidden field is still submitted, which
+		 * is deliberate: an admin flipping between auth modes should not lose
+		 * the username they typed for the other one.
+		 */
+		isVisible(field) {
+			const condition = field.visible_if
+			if (!condition) {
+				return true
+			}
+			return (condition.in || []).includes(this.draft[condition.field])
+		},
 		t,
 		/** One probe per card, fired lazily so the page never waits on providers. */
 		async refreshHealth() {

--- a/nextcloud-app/src/components/settings/SchemaField.vue
+++ b/nextcloud-app/src/components/settings/SchemaField.vue
@@ -48,6 +48,21 @@
 				:placeholder="passwordPlaceholder"
 				@update:model-value="emit" />
 
+			<!--
+				Multi-line secret (the local provider's extra request headers).
+				Like the password field it never receives a value from the
+				server, so the placeholder is what tells the admin whether one
+				is already stored.
+			-->
+			<NcTextArea v-else-if="field.type === 'textarea'"
+				:id="inputId"
+				:model-value="stringValue"
+				:label="field.title"
+				:label-visible="false"
+				:rows="4"
+				:placeholder="textareaPlaceholder"
+				@update:model-value="emit" />
+
 			<NcTextField v-else
 				:id="inputId"
 				:model-value="stringValue"
@@ -70,6 +85,7 @@ import { searchPrincipals } from '../../settings-api.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcPasswordField from '@nextcloud/vue/components/NcPasswordField'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
+import NcTextArea from '@nextcloud/vue/components/NcTextArea'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
 
 export default {
@@ -78,6 +94,7 @@ export default {
 		NcCheckboxRadioSwitch,
 		NcPasswordField,
 		NcSelect,
+		NcTextArea,
 		NcTextField,
 	},
 	props: {
@@ -143,6 +160,14 @@ export default {
 		},
 		textPlaceholder() {
 			return this.userScope ? this.inheritedHint : (this.field.placeholder || '')
+		},
+		textareaPlaceholder() {
+			if (this.field.sensitive) {
+				return this.field.hasValue
+					? t('aiquila', 'Configured — enter new lines to replace them')
+					: (this.field.placeholder || '')
+			}
+			return this.field.placeholder || ''
 		},
 		passwordPlaceholder() {
 			if (this.field.hasValue) {

--- a/nextcloud-app/tests/Unit/CredentialServiceTest.php
+++ b/nextcloud-app/tests/Unit/CredentialServiceTest.php
@@ -215,4 +215,45 @@ class CredentialServiceTest extends TestCase {
         $result = $this->service->decryptToken('plaintext-value');
         $this->assertEquals('plaintext-value', $result);
     }
+
+    // ── Named secrets ───────────────────────────────────────────────────
+
+    public function testSetSecretStoresUnderItsOwnNamespace(): void {
+        // Namespaced away from the per-provider API keys so a secret name can
+        // never collide with a provider id.
+        $this->credManager->expects($this->once())
+            ->method('store')
+            ->with('', 'aiquila/secret/local_extra_headers', 'X-Tenant: acme');
+
+        $this->service->setSecret('local_extra_headers', 'X-Tenant: acme');
+    }
+
+    public function testGetSecretReturnsTheStoredValue(): void {
+        $this->credManager->method('retrieve')->willReturnCallback(
+            fn(string $user, string $key) => $key === 'aiquila/secret/local_extra_headers' ? 'X-Tenant: acme' : null
+        );
+
+        $this->assertSame('X-Tenant: acme', $this->service->getSecret('local_extra_headers'));
+    }
+
+    public function testGetSecretReturnsEmptyStringWhenAbsent(): void {
+        $this->credManager->method('retrieve')->willReturn(null);
+
+        $this->assertSame('', $this->service->getSecret('local_extra_headers'));
+        $this->assertFalse($this->service->hasSecret('local_extra_headers'));
+    }
+
+    public function testHasSecretTrue(): void {
+        $this->credManager->method('retrieve')->willReturn('anything');
+
+        $this->assertTrue($this->service->hasSecret('local_extra_headers'));
+    }
+
+    public function testDeleteSecret(): void {
+        $this->credManager->expects($this->once())
+            ->method('delete')
+            ->with('', 'aiquila/secret/local_extra_headers');
+
+        $this->service->deleteSecret('local_extra_headers');
+    }
 }

--- a/nextcloud-app/tests/Unit/HeaderSpecTest.php
+++ b/nextcloud-app/tests/Unit/HeaderSpecTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace OCA\AIquila\Tests\Unit;
+
+use OCA\AIquila\Service\Provider\HeaderSpec;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class HeaderSpecTest extends TestCase {
+    public function testParsesNameValuePairs(): void {
+        $headers = HeaderSpec::parse("CF-Access-Client-Id: abc\nCF-Access-Client-Secret: def");
+
+        $this->assertSame([
+            'CF-Access-Client-Id' => 'abc',
+            'CF-Access-Client-Secret' => 'def',
+        ], $headers);
+    }
+
+    public function testSkipsBlankLinesAndComments(): void {
+        $headers = HeaderSpec::parse("# routing\n\n  X-Tenant: acme  \r\n");
+
+        $this->assertSame(['X-Tenant' => 'acme'], $headers);
+    }
+
+    public function testKeepsColonsInsideTheValue(): void {
+        // A URL or a time in a header value must survive the split.
+        $headers = HeaderSpec::parse('X-Origin: https://cloud.example.com:8443');
+
+        $this->assertSame(['X-Origin' => 'https://cloud.example.com:8443'], $headers);
+    }
+
+    public function testAllowsHostOverride(): void {
+        // The URL already decides which address is contacted, so a Host header
+        // only selects a vhost there.
+        $this->assertSame(['Host' => 'models.internal'], HeaderSpec::parse('Host: models.internal'));
+    }
+
+    /** @return list<array{0: string, 1: string}> */
+    public static function rejectedProvider(): array {
+        return [
+            'no colon' => ['X-Tenant acme', 'Expected "Name: value"'],
+            'no name' => [': acme', 'Expected "Name: value"'],
+            'no value' => ['X-Tenant:', 'has no value'],
+            'invalid name' => ['X Tenant: acme', 'not a valid header name'],
+            'content type' => ['Content-Type: text/plain', 'cannot be overridden'],
+            'authorization' => ['Authorization: Bearer x', 'cannot be overridden'],
+            'hop by hop' => ['Transfer-Encoding: chunked', 'cannot be overridden'],
+            'content length' => ['Content-Length: 3', 'cannot be overridden'],
+            'duplicate' => ["X-Tenant: a\nX-Tenant: b", 'is set twice'],
+        ];
+    }
+
+    #[DataProvider('rejectedProvider')]
+    public function testRejects(string $raw, string $expected): void {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($expected);
+
+        HeaderSpec::parse($raw);
+    }
+
+    public function testRejectionNamesTheLine(): void {
+        try {
+            HeaderSpec::parse("X-Tenant: acme\nContent-Type: text/plain");
+            $this->fail('expected a rejection');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertStringContainsString('(line 2)', $e->getMessage());
+        }
+    }
+
+    public function testRequireNameAcceptsAnOrdinaryCustomHeader(): void {
+        $this->assertSame('X-API-Key', HeaderSpec::requireName('X-API-Key'));
+    }
+
+    public function testRequireNameRejectsInjectionAttempt(): void {
+        $this->expectException(\InvalidArgumentException::class);
+
+        HeaderSpec::requireName("X-API-Key\r\nAuthorization");
+    }
+}

--- a/nextcloud-app/tests/Unit/LocalProviderTest.php
+++ b/nextcloud-app/tests/Unit/LocalProviderTest.php
@@ -31,15 +31,32 @@ class LocalProviderTest extends TestCase {
 
     /**
      * @param array<string, string> $appValues
+     * @param array<string, string> $secrets named CredentialService secrets
      */
-    private function provider(array $appValues = [], string $apiKey = ''): LocalProvider {
+    private function provider(array $appValues = [], string $apiKey = '', array $secrets = []): LocalProvider {
         $appValues += ['local_base_url' => 'http://localhost:11434'];
         $this->config->method('getAppValue')->willReturnCallback(
             fn($app, $key, $default = '') => $appValues[$key] ?? $default
         );
         $this->credentials->method('getApiKey')->willReturn($apiKey);
+        $this->credentials->method('getSecret')->willReturnCallback(
+            fn(string $name) => $secrets[$name] ?? ''
+        );
 
         return new LocalProvider($this->clientService, $this->config, $this->credentials, $this->logger);
+    }
+
+    /** The IClientService options a plain chat() call ends up sending. */
+    private function postOptions(LocalProvider $provider): array {
+        $captured = null;
+        $this->client->method('post')->willReturnCallback(function (string $url, array $opts) use (&$captured) {
+            $captured = $opts;
+            return $this->jsonResponse(['choices' => [['message' => ['content' => 'ok']]]]);
+        });
+
+        $provider->chat([['role' => 'user', 'content' => 'hi']]);
+
+        return $captured;
     }
 
     private function jsonResponse(array $payload): IResponse {
@@ -292,5 +309,178 @@ class LocalProviderTest extends TestCase {
         $this->assertSame('error', $events[0]['type']);
 
         $this->assertArrayHasKey('error', $provider->chatWithNativeMcpCollect([['role' => 'user', 'content' => 'hi']], []));
+    }
+
+    // ── Auth modes (#446) ───────────────────────────────────────────────
+
+    public function testBearerRemainsTheDefaultMode(): void {
+        // Installs predating the auth-mode setting must keep behaving exactly
+        // as they did.
+        $options = $this->postOptions($this->provider([], 'token'));
+
+        $this->assertSame('Bearer token', $options['headers']['Authorization']);
+    }
+
+    public function testAuthModeNoneSendsNoCredential(): void {
+        $options = $this->postOptions($this->provider(['local_auth_mode' => 'none'], 'token'));
+
+        $this->assertArrayNotHasKey('Authorization', $options['headers']);
+    }
+
+    public function testAuthModeBasicSendsTheKeyAsThePassword(): void {
+        $options = $this->postOptions($this->provider([
+            'local_auth_mode' => 'basic',
+            'local_auth_user' => 'nextcloud',
+        ], 's3cret'));
+
+        $this->assertSame('Basic ' . base64_encode('nextcloud:s3cret'), $options['headers']['Authorization']);
+    }
+
+    public function testAuthModeHeaderSendsTheNamedHeaderAndNoAuthorization(): void {
+        $options = $this->postOptions($this->provider([
+            'local_auth_mode' => 'header',
+            'local_auth_header' => 'X-API-Key',
+        ], 'gateway-key'));
+
+        $this->assertSame('gateway-key', $options['headers']['X-API-Key']);
+        $this->assertArrayNotHasKey('Authorization', $options['headers']);
+    }
+
+    public function testAuthModeHeaderWithoutAHeaderNameSendsNothing(): void {
+        // Better an obvious 401 than the key landing in a header nobody named.
+        $options = $this->postOptions($this->provider(['local_auth_mode' => 'header'], 'gateway-key'));
+
+        $this->assertArrayNotHasKey('Authorization', $options['headers']);
+        $this->assertSame(['Content-Type' => 'application/json'], $options['headers']);
+    }
+
+    public function testUnknownAuthModeFallsBackToBearer(): void {
+        $options = $this->postOptions($this->provider(['local_auth_mode' => 'kerberos'], 'token'));
+
+        $this->assertSame('Bearer token', $options['headers']['Authorization']);
+    }
+
+    public function testEmptyKeySendsNoCredentialInAnyMode(): void {
+        $options = $this->postOptions($this->provider([
+            'local_auth_mode' => 'basic',
+            'local_auth_user' => 'nextcloud',
+        ], ''));
+
+        $this->assertArrayNotHasKey('Authorization', $options['headers']);
+    }
+
+    // ── Extra headers ───────────────────────────────────────────────────
+
+    public function testExtraHeadersAreMerged(): void {
+        $options = $this->postOptions($this->provider([], 'token', [
+            'local_extra_headers' => "# Cloudflare Access\nCF-Access-Client-Id: abc\nCF-Access-Client-Secret: def\n",
+        ]));
+
+        $this->assertSame('abc', $options['headers']['CF-Access-Client-Id']);
+        $this->assertSame('def', $options['headers']['CF-Access-Client-Secret']);
+        $this->assertSame('Bearer token', $options['headers']['Authorization']);
+    }
+
+    public function testExtraHeadersCannotOverrideTheProvidersOwn(): void {
+        // HeaderSpec refuses these at save time; a value that got stored anyway
+        // must still not win over the configured auth scheme.
+        $options = $this->postOptions($this->provider([], 'token', [
+            'local_extra_headers' => "Authorization: Bearer stolen\nContent-Type: text/plain",
+        ]));
+
+        $this->assertSame('Bearer token', $options['headers']['Authorization']);
+        $this->assertSame('application/json', $options['headers']['Content-Type']);
+    }
+
+    public function testUnparsableStoredExtraHeadersAreDroppedNotSpliced(): void {
+        $options = $this->postOptions($this->provider([], 'token', [
+            'local_extra_headers' => 'this is not a header',
+        ]));
+
+        $this->assertSame(
+            ['Authorization' => 'Bearer token', 'Content-Type' => 'application/json'],
+            $options['headers'],
+        );
+    }
+
+    // ── TLS ─────────────────────────────────────────────────────────────
+
+    public function testNoTlsOptionsByDefault(): void {
+        $options = $this->postOptions($this->provider());
+
+        $this->assertArrayNotHasKey('verify', $options);
+        $this->assertArrayNotHasKey('cert', $options);
+        $this->assertArrayNotHasKey('ssl_key', $options);
+    }
+
+    public function testVerificationCanBeTurnedOff(): void {
+        $options = $this->postOptions($this->provider(['local_tls_verify' => 'no']));
+
+        $this->assertFalse($options['verify']);
+    }
+
+    public function testCaBundleAndClientCertificateArePassedThrough(): void {
+        $ca = $this->tempFile('ca');
+        $cert = $this->tempFile('cert');
+        $key = $this->tempFile('key');
+
+        $options = $this->postOptions($this->provider([
+            'local_ca_bundle' => $ca,
+            'local_client_cert' => $cert,
+            'local_client_key' => $key,
+        ]));
+
+        $this->assertSame($ca, $options['verify']);
+        $this->assertSame($cert, $options['cert']);
+        $this->assertSame($key, $options['ssl_key']);
+    }
+
+    public function testClientKeyPassphraseIsPairedWithThePaths(): void {
+        $cert = $this->tempFile('cert');
+        $key = $this->tempFile('key');
+
+        $options = $this->postOptions($this->provider([
+            'local_client_cert' => $cert,
+            'local_client_key' => $key,
+        ], '', ['local_client_key_password' => 'pw']));
+
+        $this->assertSame([$cert, 'pw'], $options['cert']);
+        $this->assertSame([$key, 'pw'], $options['ssl_key']);
+    }
+
+    public function testCaBundleIsIgnoredWhenVerificationIsOff(): void {
+        $options = $this->postOptions($this->provider([
+            'local_tls_verify' => 'no',
+            'local_ca_bundle' => $this->tempFile('ca'),
+        ]));
+
+        $this->assertFalse($options['verify']);
+    }
+
+    public function testAMissingCertificateFileFailsWithAReadableMessage(): void {
+        // chat() renders every failure through errorMessage(), so the check is
+        // that the admin is told which file and which setting — not a cURL 58.
+        $provider = $this->provider(['local_client_cert' => '/nope/missing.pem']);
+
+        $result = $provider->chat([['role' => 'user', 'content' => 'hi']]);
+
+        $this->assertStringContainsString('/nope/missing.pem', $result['error']);
+        $this->assertStringContainsString('client certificate', $result['error']);
+    }
+
+    /** @var list<string> */
+    private array $tempFiles = [];
+
+    private function tempFile(string $prefix): string {
+        $path = tempnam(sys_get_temp_dir(), 'aiquila-' . $prefix);
+        $this->tempFiles[] = $path;
+        return $path;
+    }
+
+    protected function tearDown(): void {
+        foreach ($this->tempFiles as $path) {
+            @unlink($path);
+        }
+        $this->tempFiles = [];
     }
 }

--- a/nextcloud-app/tests/Unit/ProviderSettingsServiceTest.php
+++ b/nextcloud-app/tests/Unit/ProviderSettingsServiceTest.php
@@ -350,4 +350,136 @@ class ProviderSettingsServiceTest extends TestCase {
 
         $this->service->status($provider, 'alice', admin: true);
     }
+
+    // ── Named secrets and formats (#446) ────────────────────────────────
+
+    /** @return list<array<string, mixed>> */
+    private function secretSchema(): array {
+        return [
+            ProviderSettingsSchema::secretTextarea(
+                'extra_headers',
+                'test_extra_headers',
+                'Additional request headers',
+                '',
+                format: ProviderSettingsSchema::FORMAT_HEADERS,
+            ),
+            ProviderSettingsSchema::text(
+                'auth_header',
+                'auth_header',
+                'Header name',
+                '',
+                format: ProviderSettingsSchema::FORMAT_HEADER_NAME,
+            ),
+            ProviderSettingsSchema::text(
+                'ca_bundle',
+                'ca_bundle',
+                'CA bundle path',
+                '',
+                format: ProviderSettingsSchema::FORMAT_FILE_PATH,
+            ),
+        ];
+    }
+
+    public function testNamedSecretGoesToTheCredentialStoreNotConfig(): void {
+        $provider = $this->provider($this->secretSchema());
+
+        $this->config->expects($this->never())->method('setAppValue');
+        $this->credentials->expects($this->once())
+            ->method('setSecret')
+            ->with('test_extra_headers', 'X-Tenant: acme');
+
+        $this->service->writeAdmin($provider, ['extra_headers' => 'X-Tenant: acme']);
+    }
+
+    public function testEmptyNamedSecretClearsIt(): void {
+        $provider = $this->provider($this->secretSchema());
+
+        $this->credentials->expects($this->once())->method('deleteSecret')->with('test_extra_headers');
+        $this->credentials->expects($this->never())->method('setSecret');
+
+        $this->service->writeAdmin($provider, ['extra_headers' => '']);
+    }
+
+    public function testNamedSecretIsNeverReturnedToTheClient(): void {
+        $provider = $this->provider($this->secretSchema());
+        $this->credentials->method('hasSecret')->willReturnCallback(
+            fn(string $name) => $name === 'test_extra_headers'
+        );
+
+        $described = $this->service->describe($provider, null, true);
+        $field = $this->fieldById($described, 'extra_headers');
+
+        $this->assertTrue($field['hasValue']);
+        $this->assertArrayNotHasKey('value', $field);
+    }
+
+    public function testNamedSecretIsNotOfferedOnThePersonalPage(): void {
+        // It is SCOPE_ADMIN, and the local provider's headers are exactly the
+        // thing a user must not be able to point at their own endpoint.
+        $provider = $this->provider($this->secretSchema());
+
+        $described = $this->service->describe($provider, 'alice', false);
+        $ids = array_column($described['fields'], 'id');
+
+        $this->assertNotContains('extra_headers', $ids);
+    }
+
+    public function testMalformedHeaderBlockIsRejectedBeforeStorage(): void {
+        $provider = $this->provider($this->secretSchema());
+
+        $this->credentials->expects($this->never())->method('setSecret');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('cannot be overridden');
+        $this->service->writeAdmin($provider, ['extra_headers' => 'Authorization: Bearer x']);
+    }
+
+    public function testInvalidHeaderNameIsRejected(): void {
+        $provider = $this->provider($this->secretSchema());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('not a valid header name');
+        $this->service->writeAdmin($provider, ['auth_header' => 'X API Key']);
+    }
+
+    public function testRelativeCertificatePathIsRejected(): void {
+        $provider = $this->provider($this->secretSchema());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('absolute path');
+        $this->service->writeAdmin($provider, ['ca_bundle' => 'certs/ca.pem']);
+    }
+
+    public function testUnreadableCertificatePathIsRejected(): void {
+        $provider = $this->provider($this->secretSchema());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('not readable by the web server');
+        $this->service->writeAdmin($provider, ['ca_bundle' => '/nope/ca.pem']);
+    }
+
+    public function testReadableCertificatePathIsAccepted(): void {
+        $provider = $this->provider($this->secretSchema());
+        $path = tempnam(sys_get_temp_dir(), 'aiquila-ca');
+
+        $this->config->expects($this->once())
+            ->method('setAppValue')
+            ->with('aiquila', 'ca_bundle', $path);
+
+        try {
+            $this->assertSame([], $this->service->writeAdmin($provider, ['ca_bundle' => $path]));
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    /** @param array<string, mixed> $described */
+    private function fieldById(array $described, string $id): array {
+        foreach ($described['fields'] as $field) {
+            if ($field['id'] === $id) {
+                return $field;
+            }
+        }
+        $this->fail('no such field: ' . $id);
+    }
 }


### PR DESCRIPTION
The local provider spoke exactly one auth scheme: an optional
`Authorization: Bearer`. That covers a bare Ollama or LM Studio, but a
self-hosted model published beyond localhost is normally behind a reverse proxy
wanting HTTP Basic, an `X-API-Key`-style header, Cloudflare Access header pairs,
a client certificate, or a private CA — none of which were configurable, so
those endpoints were simply unreachable from AIquila.

## Authentication

`local_auth_mode` picks the scheme; the stored API key is the secret in every
case, so switching modes does not mean re-entering it.

| Mode | Sent | For |
|---|---|---|
| `none` | nothing | A backend with no auth, where a stored key should stay unused |
| `bearer` | `Authorization: Bearer <key>` | LM Studio, `llama-server --api-key`. **Default**, so existing installs are untouched |
| `basic` | `Authorization: Basic base64(<user>:<key>)` | nginx `auth_basic`, Caddy `basic_auth` |
| `header` | `<local_auth_header>: <key>` | LiteLLM, vLLM behind a gateway |

An empty key still means no credential header at all, whatever the mode — the
keyless-Ollama case. In `header` mode with no header name configured nothing is
sent either: an obvious 401 beats the key landing in a header nobody named.

## TLS and mTLS

CA bundle, client cert/key, key passphrase, and an explicit verification opt-out,
passed through as Guzzle `verify` / `cert` / `ssl_key`. No new plumbing was
needed — Nextcloud's `Client` does `array_merge($defaults, $options)`, so caller
options really do override the instance CA bundle.

Certificate material is given as **server file paths**, not uploaded, so private
keys stay out of app storage. Checked when saved and again on every request, so a
rotated-away mount names the file and the setting instead of an opaque cURL error.

## Generic pieces, not one-off toggles

Everything lands behind `LocalProvider::headers()` and `requestOptions()` — the
two methods `AbstractOpenAiCompatibleProvider` already funnels chat, streaming,
model listing and the status probe through — so **no other provider changes**.

- **`HeaderSpec`** parses and validates the `Name: value` block, on save *and* on
  read (a stored value is not trusted input). It refuses CR/LF, hop-by-hop
  headers, `Content-Length`, and `Content-Type`/`Authorization` — letting an
  extra header beat the configured auth scheme would make the mode setting a lie.
  `Host` is allowed: the URL already decides which address is contacted.
- **`CredentialService`** gains named instance-scope secret slots, so the extra
  headers and the client-key passphrase stay encrypted at rest instead of landing
  in `appconfig`. Namespaced away from the API keys so a secret name cannot
  collide with a provider id.
- **The settings schema** gains a `textarea` type, a `format` rule
  (`header_name`, `headers`, `file_path`) applied in one place by `encode()`, and
  a presentation-only `visible_if` so the card does not show eight fields at once.

## Security

Every new field is `SCOPE_ADMIN`. This provider runs with
`local_allow_local_address`, which disables Nextcloud's SSRF guard, so
user-settable headers on a user-settable URL would be a way to post an instance
credential wherever the user likes. Secrets go through `CredentialService`, never
`IConfig`; the settings API returns only whether each one is set.

## Better failure reporting

Test connection now names the failure instead of a flat "unreachable": the 401
wording follows the configured scheme, and TLS, DNS, refused connections and
proxy 407s each point at the setting that fixes them. `ProviderProbe` gains a
`tls` reason, sniffed before the unreachable fallback.

## Verification

565 tests pass (29 new), psalm clean, OpenAPI spec unchanged, frontend builds.

Exercised end-to-end against the dev stack with a header-echoing endpoint:

| | Result |
|---|---|
| All four auth modes | Exactly the expected header and nothing else (`Basic bmM6dG9rMTIz` = `nc:tok123`) |
| Extra headers | `CF-Access-Client-Id` and `X-Tenant` arrive alongside the bearer token |
| Forbidden header / CRLF injection / bad cert path | 400 with a readable message |
| Self-signed endpoint | `reason: tls` with actionable text → green via CA bundle, and via verify-off |
| mTLS | Handshake fails without a client cert, succeeds with cert + key |
| Removed certificate file | Names the file and the setting, not a cURL error |
| DNS / connection refused | Each classified separately, pointing at `host.docker.internal` and at the port |
| Personal endpoint | Rejects `local_auth_header`, `local_extra_headers`, `local_base_url` |

## Notes

- The issue mentions `SettingsController::localStatus`; there is no such
  endpoint. Health goes through `ProviderSettingsController::adminStatus`/`test`
  → `ProviderSettingsService::status()` → `LocalProvider::probe()`, which already
  runs through `requestOptions()`. So this was classification work, not plumbing.
- The status light keeps its 30 s throttle, so a config change can take that long
  to re-probe; the Test button bypasses it.
- Version bumped to 0.4.3.

Closes #446
Follow-up to #444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)