### PR TITLE
fix(nextcloud): drop the Hetzner models withdrawn from Experiments

### DIFF
--- a/docs/dev/hetzner-provider.md
+++ b/docs/dev/hetzner-provider.md
@@ -30,9 +30,14 @@ model list and the provider status light are both cached — see
 | Model | Type | Context | Modalities |
 |---|---|---|---|
 | `Qwen/Qwen3.6-35B-A3B-FP8` | MoE, 35B total / 3B active | 262k | Text, Image |
-| `Kimi-K2.7-Code` | MoE, 1T total / 32B active | 262k | Text, Image |
-| `DeepSeek-V4-Flash-0731` | MoE, 304B total / 13B active | 512k | Text |
-| `GLM-5.2-NVFP4` | MoE, 744B total / 40B active | 512k | Text |
+
+On 2026-08-19 Hetzner withdrew the large models — `Kimi-K2.7-Code`,
+`DeepSeek-V4-Flash-0731` and `GLM-5.2-NVFP4` — from public Experiments while it
+works on capacity; only the small Qwen models remain, and `Qwen3.8-27B` is
+announced but not yet served ([Hetzner
+blog](https://www.hetzner.com/de/blog/inference-experiment/)). It is deliberately
+absent from `HetznerModels` until `GET /models` reports its exact id — an unknown
+id already degrades safely.
 
 The line-up changes as the experiment evolves, so the settings UI lists whatever
 `GET /models` currently returns and falls back to `HetznerModels` only when that
@@ -49,8 +54,8 @@ and `LocalProvider` use, so all wire-format handling is shared. It only supplies
 
 - identity (`hetzner`, "Hetzner Inference (EU)") and the base URL,
 - `supportsVisionInput()` — decided per model via `HetznerModels::supportsVision()`:
-  true for Qwen3.6 and Kimi-K2.7-Code, false for DeepSeek-V4-Flash and GLM-5.2.
-  An id the registry does not know is assumed vision-capable, so a model added to
+  no model currently served by Experiments is text-only, so the text-only set is
+  empty. An id the registry does not know is assumed vision-capable, so a model added to
   the service after this release is not crippled by a stale list — the API
   rejects an unsupported modality on its own,
 - error mapping for 401 (bad token), 429 (quota) and 502/503 (experiment down),
@@ -75,9 +80,6 @@ Per-model output ceilings applied by `HetznerModels::getMaxTokenCeiling()`
 | Model | Ceiling |
 |---|---|
 | `Qwen/Qwen3.6-35B-A3B-FP8` | 32768 |
-| `Kimi-K2.7-Code` | 32768 |
-| `DeepSeek-V4-Flash-0731` | 65536 |
-| `GLM-5.2-NVFP4` | 65536 |
 
 User config: `user_model_hetzner` (per-user model override), `user_provider`
 (per-user provider override).

--- a/nextcloud-app/lib/Service/HetznerModels.php
+++ b/nextcloud-app/lib/Service/HetznerModels.php
@@ -22,15 +22,6 @@ class HetznerModels {
     /** Qwen3.6 MoE, 35B total / 3B active, causal LM + vision, 262k context. */
     public const QWEN3_6_35B = 'Qwen/Qwen3.6-35B-A3B-FP8';
 
-    /** DeepSeek-V4-Flash MoE, 304B total / 13B active, text only, 512k context. */
-    public const DEEPSEEK_V4_FLASH = 'DeepSeek-V4-Flash-0731';
-
-    /** GLM-5.2 MoE (NVFP4), 744B total / 40B active, text only, 512k context. */
-    public const GLM_5_2_NVFP4 = 'GLM-5.2-NVFP4';
-
-    /** Kimi K2.7 Code MoE, 1T total / 32B active, text + vision, 262k context. */
-    public const KIMI_K2_7_CODE = 'Kimi-K2.7-Code';
-
     // ── Application defaults ────────────────────────────────────────────────
 
     public const DEFAULT_MODEL      = self::QWEN3_6_35B;
@@ -39,10 +30,7 @@ class HetznerModels {
     // ── Per-model output token ceilings ─────────────────────────────────────
 
     private const MAX_TOKENS_CEILING = [
-        self::QWEN3_6_35B       => 32768,
-        self::DEEPSEEK_V4_FLASH => 65536,
-        self::GLM_5_2_NVFP4     => 65536,
-        self::KIMI_K2_7_CODE    => 32768,
+        self::QWEN3_6_35B => 32768,
     ];
 
     /**
@@ -50,12 +38,13 @@ class HetznerModels {
      * capable, so a model added to the service after this release is not
      * crippled by a registry that has not caught up with it.
      *
+     * Currently empty: the text-only members of the line-up (DeepSeek-V4-Flash
+     * and GLM-5.2) were withdrawn from Experiments on 2026-08-19. The mechanism
+     * stays because their replacements may well be text-only again.
+     *
      * @var list<string>
      */
-    private const TEXT_ONLY = [
-        self::DEEPSEEK_V4_FLASH,
-        self::GLM_5_2_NVFP4,
-    ];
+    private const TEXT_ONLY = [];
 
     /**
      * Maximum output token ceiling for a model; used to clamp the configured
@@ -84,9 +73,6 @@ class HetznerModels {
     public static function getAllModels(): array {
         return [
             self::QWEN3_6_35B,
-            self::KIMI_K2_7_CODE,
-            self::DEEPSEEK_V4_FLASH,
-            self::GLM_5_2_NVFP4,
         ];
     }
 }

--- a/nextcloud-app/tests/Unit/HetznerProviderTest.php
+++ b/nextcloud-app/tests/Unit/HetznerProviderTest.php
@@ -254,7 +254,7 @@ class HetznerProviderTest extends TestCase {
         $this->client->method('get')->willReturnCallback(function (string $url) use (&$capturedUrl) {
             $capturedUrl = $url;
             return $this->jsonResponse([
-                'data' => [['id' => 'Qwen/Qwen3.6-35B-A3B-FP8'], ['id' => 'zai-org/GLM-5.2']],
+                'data' => [['id' => 'Qwen/Qwen3.6-35B-A3B-FP8'], ['id' => 'Qwen/Qwen3.8-27B']],
             ]);
         });
 
@@ -262,17 +262,16 @@ class HetznerProviderTest extends TestCase {
 
         $this->assertSame('https://inference.hetzner.com/api/v1/models', $capturedUrl);
         $this->assertContains('Qwen/Qwen3.6-35B-A3B-FP8', $models);
-        $this->assertContains('zai-org/GLM-5.2', $models);
+        $this->assertContains('Qwen/Qwen3.8-27B', $models);
     }
 
     public function testStaticRegistryCoversTheFullLineUp(): void {
         // The fallback is what the settings UI shows when the live listing
         // fails, so a registry that has gone stale silently narrows the picker.
+        // Hetzner withdrew the large models (Kimi-K2.7-Code, DeepSeek-V4-Flash,
+        // GLM-5.2) from Experiments on 2026-08-19; Qwen3.6 is all that is left.
         $this->assertSame([
             HetznerModels::QWEN3_6_35B,
-            HetznerModels::KIMI_K2_7_CODE,
-            HetznerModels::DEEPSEEK_V4_FLASH,
-            HetznerModels::GLM_5_2_NVFP4,
         ], HetznerModels::getAllModels());
     }
 
@@ -290,30 +289,21 @@ class HetznerProviderTest extends TestCase {
 
     public function testMaxTokensUsesTheSelectedModelsCeiling(): void {
         $provider = $this->provider([
-            'model_hetzner' => HetznerModels::DEEPSEEK_V4_FLASH,
+            'model_hetzner' => HetznerModels::QWEN3_6_35B,
             'max_tokens_hetzner' => '999999',
         ]);
         $this->assertSame(
-            HetznerModels::getMaxTokenCeiling(HetznerModels::DEEPSEEK_V4_FLASH),
+            HetznerModels::getMaxTokenCeiling(HetznerModels::QWEN3_6_35B),
             $provider->getMaxTokens()
         );
     }
 
     public function testVisionSupportFollowsTheSelectedModel(): void {
         $this->assertTrue(HetznerModels::supportsVision(HetznerModels::QWEN3_6_35B));
-        $this->assertTrue(HetznerModels::supportsVision(HetznerModels::KIMI_K2_7_CODE));
-        $this->assertFalse(HetznerModels::supportsVision(HetznerModels::DEEPSEEK_V4_FLASH));
-        $this->assertFalse(HetznerModels::supportsVision(HetznerModels::GLM_5_2_NVFP4));
-        // Unknown ids are assumed capable rather than crippled by a stale list.
+        // No model currently served by Experiments is text-only, and an id the
+        // registry has not caught up with is assumed capable rather than
+        // crippled by a stale list.
         $this->assertTrue(HetznerModels::supportsVision('brand/new'));
-    }
-
-    public function testTextOnlyModelRefusesImageInput(): void {
-        $provider = $this->provider(['model_hetzner' => HetznerModels::GLM_5_2_NVFP4]);
-
-        $result = $provider->askWithImage('what is this', base64_encode('x'), 'image/png', 'u');
-
-        $this->assertStringContainsString('vision', strtolower($result['error']));
     }
 
     public function testRateLimitErrorIsMapped(): void {


### PR DESCRIPTION
Hetzner withdrew `GLM-5.2-NVFP4`, `Kimi-K2.7-Code` and `DeepSeek-V4-Flash-0731` from public Experiments on 2026-08-19 while it works on capacity for the large models; only the small Qwen models remain ([blog](https://www.hetzner.com/de/blog/inference-experiment/)).

Chat itself is unaffected — `HetznerProvider` resolves models live via `GET /models`. What went stale is `HetznerModels`: the fallback list shown when that call fails offered three dead models, and the per-model ceilings / text-only set carried entries for them.

- `HetznerModels` — trimmed to `QWEN3_6_35B`; `TEXT_ONLY` kept but empty (no served model is text-only now), `supportsVision()` unchanged so unknown ids stay capable.
- `HetznerProviderTest` — registry/ceiling/vision tests updated; `testTextOnlyModelRefusesImageInput` dropped (no Hetzner model exercises it any more; the path stays covered by the DeepSeek/Local provider tests).
- `docs/dev/hetzner-provider.md` — model table, ceiling table and the `supportsVisionInput()` prose.

`Qwen3.8-27B` is announced but not yet served, so it is deliberately left out until `GET /models` reports its exact id — an unknown id already degrades safely.

Verified: `composer psalm` clean, full unit suite green (564 tests).

Closes #472