### PR TITLE
feat(nextcloud): add Qwen3.8-27B to the Hetzner model registry

### DIFF
--- a/docs/dev/hetzner-provider.md
+++ b/docs/dev/hetzner-provider.md
@@ -30,14 +30,14 @@ model list and the provider status light are both cached — see
 | Model | Type | Context | Modalities |
 |---|---|---|---|
 | `Qwen/Qwen3.6-35B-A3B-FP8` | MoE, 35B total / 3B active | 262k | Text, Image |
+| `Qwen3.8-27B` | Dense, 27B | 262k | Text, Image |
 
 On 2026-08-19 Hetzner withdrew the large models — `Kimi-K2.7-Code`,
 `DeepSeek-V4-Flash-0731` and `GLM-5.2-NVFP4` — from public Experiments while it
-works on capacity; only the small Qwen models remain, and `Qwen3.8-27B` is
-announced but not yet served ([Hetzner
-blog](https://www.hetzner.com/de/blog/inference-experiment/)). It is deliberately
-absent from `HetznerModels` until `GET /models` reports its exact id — an unknown
-id already degrades safely.
+works on capacity ([Hetzner
+blog](https://www.hetzner.com/de/blog/inference-experiment/)); only the two small
+Qwen models above remain. Note that `Qwen3.8-27B` is served without a vendor
+prefix, unlike `Qwen/Qwen3.6-35B-A3B-FP8`.
 
 The line-up changes as the experiment evolves, so the settings UI lists whatever
 `GET /models` currently returns and falls back to `HetznerModels` only when that
@@ -80,6 +80,7 @@ Per-model output ceilings applied by `HetznerModels::getMaxTokenCeiling()`
 | Model | Ceiling |
 |---|---|
 | `Qwen/Qwen3.6-35B-A3B-FP8` | 32768 |
+| `Qwen3.8-27B` | 32768 |
 
 User config: `user_model_hetzner` (per-user model override), `user_provider`
 (per-user provider override).

--- a/nextcloud-app/lib/Service/HetznerModels.php
+++ b/nextcloud-app/lib/Service/HetznerModels.php
@@ -22,6 +22,9 @@ class HetznerModels {
     /** Qwen3.6 MoE, 35B total / 3B active, causal LM + vision, 262k context. */
     public const QWEN3_6_35B = 'Qwen/Qwen3.6-35B-A3B-FP8';
 
+    /** Qwen3.8 dense, 27B, causal LM + vision, 262k context. */
+    public const QWEN3_8_27B = 'Qwen3.8-27B';
+
     // ── Application defaults ────────────────────────────────────────────────
 
     public const DEFAULT_MODEL      = self::QWEN3_6_35B;
@@ -31,6 +34,7 @@ class HetznerModels {
 
     private const MAX_TOKENS_CEILING = [
         self::QWEN3_6_35B => 32768,
+        self::QWEN3_8_27B => 32768,
     ];
 
     /**
@@ -73,6 +77,7 @@ class HetznerModels {
     public static function getAllModels(): array {
         return [
             self::QWEN3_6_35B,
+            self::QWEN3_8_27B,
         ];
     }
 }

--- a/nextcloud-app/tests/Unit/HetznerProviderTest.php
+++ b/nextcloud-app/tests/Unit/HetznerProviderTest.php
@@ -254,7 +254,7 @@ class HetznerProviderTest extends TestCase {
         $this->client->method('get')->willReturnCallback(function (string $url) use (&$capturedUrl) {
             $capturedUrl = $url;
             return $this->jsonResponse([
-                'data' => [['id' => 'Qwen/Qwen3.6-35B-A3B-FP8'], ['id' => 'Qwen/Qwen3.8-27B']],
+                'data' => [['id' => 'Qwen/Qwen3.6-35B-A3B-FP8'], ['id' => 'Qwen3.8-27B']],
             ]);
         });
 
@@ -262,16 +262,18 @@ class HetznerProviderTest extends TestCase {
 
         $this->assertSame('https://inference.hetzner.com/api/v1/models', $capturedUrl);
         $this->assertContains('Qwen/Qwen3.6-35B-A3B-FP8', $models);
-        $this->assertContains('Qwen/Qwen3.8-27B', $models);
+        $this->assertContains('Qwen3.8-27B', $models);
     }
 
     public function testStaticRegistryCoversTheFullLineUp(): void {
         // The fallback is what the settings UI shows when the live listing
         // fails, so a registry that has gone stale silently narrows the picker.
         // Hetzner withdrew the large models (Kimi-K2.7-Code, DeepSeek-V4-Flash,
-        // GLM-5.2) from Experiments on 2026-08-19; Qwen3.6 is all that is left.
+        // GLM-5.2) from Experiments on 2026-08-19; the two small Qwen models
+        // are all that is left.
         $this->assertSame([
             HetznerModels::QWEN3_6_35B,
+            HetznerModels::QWEN3_8_27B,
         ], HetznerModels::getAllModels());
     }
 
@@ -300,6 +302,7 @@ class HetznerProviderTest extends TestCase {
 
     public function testVisionSupportFollowsTheSelectedModel(): void {
         $this->assertTrue(HetznerModels::supportsVision(HetznerModels::QWEN3_6_35B));
+        $this->assertTrue(HetznerModels::supportsVision(HetznerModels::QWEN3_8_27B));
         // No model currently served by Experiments is text-only, and an id the
         // registry has not caught up with is assumed capable rather than
         // crippled by a stale list.


### PR DESCRIPTION
Follow-up to #472 / #473. Hetzner's Inference API documentation now lists `Qwen3.8-27B` as served alongside Qwen3.6 (dense, 27B, 262k context, Text + Image, Apache 2.0). #473 deliberately left it out because the exact served id was unpublished — it turns out to carry **no vendor prefix**: plain `Qwen3.8-27B`, unlike `Qwen/Qwen3.6-35B-A3B-FP8`.

- `HetznerModels` — new `QWEN3_8_27B` constant, added to `getAllModels()` (the fallback picker) and given the same 32768 output ceiling as the other 262k-context model. Left out of `TEXT_ONLY` since it accepts image input.
- `HetznerProviderTest` — registry and vision assertions extended; the live-listing fixture now uses the real unprefixed id.
- `docs/dev/hetzner-provider.md` — model and ceiling tables, plus a note about the missing vendor prefix.

`DEFAULT_MODEL` stays Qwen3.6 — it was the most-used model in the experiment and there is no reason to switch the default here.

Verified: `composer psalm` clean, full unit suite green (564 tests).