### PR TITLE
feat(nextcloud): send hashed metadata.user_id on Anthropic requests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,7 @@ Complete documentation for the AIquila Nextcloud app and MCP server.
 - **[Provider settings schema](dev/provider-settings.md)** — how providers describe their own configuration, and how to add one
 - **[Local model provider](dev/local-provider.md)** — self-hosted inference via Ollama, LM Studio or llama.cpp
 - **[Hetzner Inference provider](dev/hetzner-provider.md)** — EU-hosted open-weight models via Hetzner's experimental API
+- **[Request metadata](dev/request-metadata.md)** — the hashed `metadata.user_id` sent to Anthropic, and how to resolve it
 - **[OpenAPI](dev/openapi.md)** — OpenAPI documentation
 - **MCP Development** — [Architecture](mcp/development/architecture.md) | [Adding Tools](mcp/development/adding-tools.md) | [Adding Apps](mcp/development/adding-apps.md)
 

--- a/docs/dev/provider-settings.md
+++ b/docs/dev/provider-settings.md
@@ -88,6 +88,20 @@ their value from `ProviderAccessService::getLists()` and `writeAdmin()` routes
 them to `setLists()` rather than `IConfig`. Being `SCOPE_ADMIN`, they are
 filtered off the personal page by the ordinary scope rules.
 
+## Buttons instead of values
+
+`ProviderSettingsSchema::action()` declares a field that runs something rather
+than storing something — the Anthropic card's *Reveal* / *Rotate* metadata-salt
+buttons are the only ones today. An action descriptor carries no `key`, so
+`writeAdmin()` rejects it like any other unwritable field; the client instead
+POSTs the field id to
+`/api/admin/providers/{providerId}/action/{actionId}`, which dispatches to
+`ProviderActionsInterface::runAction()` on the provider. The endpoint is
+admin-only, because an action's answer can be a secret. Providers that declare
+no actions need not implement the interface.
+
+See [Request metadata](request-metadata.md).
+
 ## Scope is a security boundary
 
 `scope` decides which endpoint may write a field:
@@ -188,3 +202,4 @@ either can change what the provider serves.
 - [Local model provider](local-provider.md)
 - [Hetzner Inference provider](hetzner-provider.md)
 - [Mistral provider](mistral-provider.md)
+- [Request metadata](request-metadata.md)

--- a/docs/dev/request-metadata.md
+++ b/docs/dev/request-metadata.md
@@ -1,0 +1,112 @@
+# Request metadata (`metadata.user_id`)
+
+The Anthropic Messages API accepts a `metadata` object whose `user_id` is an
+opaque per-user identifier. Anthropic uses it for abuse detection: when a key
+is flagged, the report names the `user_id` rather than the whole instance, so
+an admin can tell *which* account caused it instead of losing API access for
+everyone.
+
+AIquila can attach that field, but **never sends the Nextcloud login name** —
+a UID is personal data. It sends a keyed hash instead.
+
+This applies to the **Anthropic provider only** (`ClaudeSDKService`). No other
+provider's API has an equivalent field.
+
+## What is sent
+
+```
+metadata.user_id = hash_hmac('sha256', <nextcloud uid>, <instance salt>)
+```
+
+A 64-character lowercase hex string. The salt is 32 random bytes, generated
+once per instance and stored encrypted in Nextcloud's credential manager under
+`aiquila/secret/metadata_salt`.
+
+Two properties follow from that:
+
+- **Not reversible by Anthropic.** The salt is secret, so the hash cannot be
+  brute-forced back to a login name from the outside — unlike a plain
+  `sha256(uid)`, which a wordlist of common usernames would crack instantly.
+- **Not correlatable across deployments.** Two AIquila instances produce
+  different hashes for the same login name, so the field cannot be used to
+  link one person's activity across servers.
+
+The field is **omitted entirely** — not sent empty — when sending is off, and
+whenever there is no user attached to the request. Background TaskProcessing
+jobs, the `occ` commands and the setup checks all fall into that second case.
+
+## Turning it on
+
+Off by default. Admin settings → **AIquila** → the Claude (Anthropic) provider
+card → *Advanced* → **Send a pseudonymous user id with each request**.
+
+Stored as the app config value `send_user_metadata`:
+
+```bash
+occ config:app:set aiquila send_user_metadata --value=true
+```
+
+## Coverage
+
+Every Anthropic request path carries the field once enabled. They all build
+their parameters through `ClaudeSDKService::buildRequestParams()`:
+
+| Path | Dispatcher | SDK type |
+|------|-----------|----------|
+| Non-streaming | `callCreate()` | `Anthropic\Messages\Metadata` |
+| Streaming | `callCreateStream()` | `Anthropic\Messages\Metadata` |
+| Message batches | `toBatchParams()` → `callBatchCreate()` | `Anthropic\Messages\Metadata` |
+| Native MCP connector (beta) | `callBetaCreateStreamWithMcp()` | `Anthropic\Beta\Messages\BetaMetadata` |
+
+## Reading and rotating the salt
+
+From the provider card: **Reveal** prints the current salt, **Rotate** issues a
+new one (with a confirmation prompt). Both are admin-only — they go through
+`POST /api/admin/providers/anthropic/action/{actionId}`.
+
+From the command line:
+
+```bash
+occ aiquila:metadata-salt              # sending on/off + the current salt
+occ aiquila:metadata-salt --rotate     # issue a new salt
+occ aiquila:metadata-salt --hash alice # the hash AIquila would send for 'alice'
+```
+
+Rotating **permanently** breaks the mapping for hashes already sent: an abuse
+report that predates the rotation can no longer be resolved. Rotate when the
+salt has leaked, or deliberately to sever the link to past traffic — not as
+routine hygiene.
+
+## Resolving a hash back to an account
+
+Given a `user_id` from an Anthropic abuse report, compare it against every
+account. `--hash` does the computation for one uid:
+
+```bash
+for uid in $(occ user:list --output=json | jq -r 'keys[]'); do
+  echo "$uid $(occ aiquila:metadata-salt --hash "$uid")"
+done | grep "<user_id from the report>"
+```
+
+Or compute it yourself from the salt — the scheme is plain HMAC-SHA256 with no
+encoding tricks:
+
+```bash
+printf '%s' 'alice' | openssl dgst -sha256 -hmac "$(occ aiquila:metadata-salt | awk '/Salt:/ {print $2}')"
+```
+
+`--hash` works regardless of whether sending is currently enabled, so an admin
+who turned the feature off can still answer a report about traffic sent while
+it was on.
+
+## Implementation
+
+- `nextcloud-app/lib/Service/RequestMetadataService.php` — the switch, the salt,
+  and the hash.
+- `nextcloud-app/lib/Service/ClaudeSDKService.php` — `buildRequestParams()`
+  attaches it; `metadataParam()` / `betaMetadataParam()` convert it for the SDK.
+- `nextcloud-app/lib/Command/MetadataSaltCommand.php` — the `occ` command.
+- The card's two buttons are schema-declared
+  (`ProviderSettingsSchema::action()`) and run through
+  `ProviderActionsInterface::runAction()`; see
+  [Provider settings schema](provider-settings.md).

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -73,6 +73,7 @@ Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](htt
         <command>OCA\AIquila\Command\TestSDKCommand</command>
         <command>OCA\AIquila\Command\McpAddCommand</command>
         <command>OCA\AIquila\Command\DoctorCommand</command>
+        <command>OCA\AIquila\Command\MetadataSaltCommand</command>
     </commands>
     <openmetrics>
         <exporter>OCA\AIquila\OpenMetrics\TokensUsedExporter</exporter>

--- a/nextcloud-app/appinfo/routes.php
+++ b/nextcloud-app/appinfo/routes.php
@@ -41,6 +41,8 @@ return [
         ['name' => 'provider_settings#adminIndex',  'url' => '/api/admin/providers',                  'verb' => 'GET'],
         ['name' => 'provider_settings#adminUpdate', 'url' => '/api/admin/providers/{providerId}',     'verb' => 'POST'],
         ['name' => 'provider_settings#test',        'url' => '/api/admin/providers/{providerId}/test', 'verb' => 'POST'],
+        // Schema-declared buttons (ProviderSettingsSchema::action()) — no stored value.
+        ['name' => 'provider_settings#adminAction', 'url' => '/api/admin/providers/{providerId}/action/{actionId}', 'verb' => 'POST'],
         // Live health behind the status light on a provider card. The user-scope
         // route probes what that user actually gets, so the personal page shows
         // the same four states the admin page does.

--- a/nextcloud-app/lib/Command/MetadataSaltCommand.php
+++ b/nextcloud-app/lib/Command/MetadataSaltCommand.php
@@ -1,0 +1,74 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Command;
+
+use OC\Core\Command\Base;
+use OCA\AIquila\Service\RequestMetadataService;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+/**
+ * Show or rotate the salt behind the hashed `metadata.user_id` sent to
+ * Anthropic. See docs/dev/request-metadata.md.
+ */
+class MetadataSaltCommand extends Base {
+
+    public function __construct(
+        private RequestMetadataService $requestMetadata,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void {
+        $this
+            ->setName('aiquila:metadata-salt')
+            ->setDescription('Show or rotate the salt used to hash user ids sent to Anthropic')
+            ->addOption('rotate', null, InputOption::VALUE_NONE, 'Generate a new salt, making previously sent hashes unresolvable')
+            ->addOption('hash', null, InputOption::VALUE_REQUIRED, 'Print the hash for this Nextcloud user id instead of the salt');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int {
+        if ($input->getOption('rotate')) {
+            if (!$this->confirmRotate($input, $output)) {
+                $output->writeln('<comment>Aborted — the salt is unchanged.</comment>');
+                return 1;
+            }
+            $output->writeln('<info>New salt:</info> ' . $this->requestMetadata->rotateSalt());
+            $output->writeln('<comment>Hashes sent before now can no longer be resolved back to a user.</comment>');
+            return 0;
+        }
+
+        $uid = $input->getOption('hash');
+        if (is_string($uid) && $uid !== '') {
+            // Deliberately independent of the opt-in switch: an admin answering
+            // an abuse report needs the mapping even after turning sending off.
+            $output->writeln(hash_hmac('sha256', $uid, $this->requestMetadata->getSalt()));
+            return 0;
+        }
+
+        $output->writeln('<info>Sending enabled:</info> ' . ($this->requestMetadata->isEnabled() ? 'yes' : 'no'));
+        $output->writeln('<info>Salt:</info> ' . $this->requestMetadata->getSalt());
+        return 0;
+    }
+
+    private function confirmRotate(InputInterface $input, OutputInterface $output): bool {
+        if (!$input->isInteractive()) {
+            return true;
+        }
+        $helper = $this->getHelper('question');
+        if (!$helper instanceof QuestionHelper) {
+            return true;
+        }
+        return (bool)$helper->ask(
+            $input,
+            $output,
+            new ConfirmationQuestion('Rotate the metadata salt? Previously sent hashes become unresolvable. [y/N] ', false),
+        );
+    }
+}

--- a/nextcloud-app/lib/Controller/ProviderSettingsController.php
+++ b/nextcloud-app/lib/Controller/ProviderSettingsController.php
@@ -9,6 +9,7 @@ use OCA\AIquila\Service\CredentialService;
 use OCA\AIquila\Service\Provider\LLMProviderFactory;
 use OCA\AIquila\Service\Provider\LocalProvider;
 use OCA\AIquila\Service\Provider\NoPermittedProviderException;
+use OCA\AIquila\Service\Provider\ProviderActionsInterface;
 use OCA\AIquila\Service\Provider\ProviderSettingsService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -277,6 +278,69 @@ class ProviderSettingsController extends Controller {
             null,
             admin: true,
         ));
+    }
+
+    /**
+     * Run an action declared by a provider's settings schema
+     *
+     * Actions are buttons rather than stored values (ProviderSettingsSchema::action()).
+     * `value` carries whatever the action produced — for the Anthropic metadata
+     * salt that is the salt itself, which is why this endpoint is admin-only.
+     *
+     * @param string $providerId Provider owning the action
+     * @param string $actionId Id of the TYPE_ACTION field to run
+     *
+     * 200: The action ran
+     * 400: Unknown provider, or the provider has no such action
+     *
+     * @return JSONResponse<Http::STATUS_OK, array{success: bool, message: string, value: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{success: bool, message: string}, array{}>|JSONResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{success: bool, message: string}, array{}>
+     */
+    #[OpenAPI(scope: OpenAPI::SCOPE_ADMINISTRATION)]
+    public function adminAction(string $providerId, string $actionId): JSONResponse {
+        if (!$this->providerFactory->isKnownProviderId($providerId)) {
+            return new JSONResponse(
+                ['success' => false, 'message' => 'Unknown provider: ' . $providerId],
+                Http::STATUS_BAD_REQUEST,
+            );
+        }
+
+        $service = $this->providerFactory->getProviderById($providerId);
+        if (!($service instanceof ProviderActionsInterface)) {
+            return new JSONResponse(
+                ['success' => false, 'message' => 'Provider has no actions: ' . $providerId],
+                Http::STATUS_BAD_REQUEST,
+            );
+        }
+
+        try {
+            $result = $service->runAction($actionId);
+        } catch (\InvalidArgumentException $e) {
+            return new JSONResponse(
+                ['success' => false, 'message' => $e->getMessage()],
+                Http::STATUS_BAD_REQUEST,
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error('AIquila: provider action failed', [
+                'provider' => $providerId,
+                'action' => $actionId,
+                'exception' => $e,
+            ]);
+            return new JSONResponse(
+                ['success' => false, 'message' => 'Action failed'],
+                Http::STATUS_INTERNAL_SERVER_ERROR,
+            );
+        }
+
+        $this->logger->info('AIquila: ran provider action', [
+            'provider' => $providerId,
+            'action' => $actionId,
+        ]);
+
+        return new JSONResponse([
+            'success' => true,
+            'message' => (string)($result['message'] ?? ''),
+            'value' => (string)($result['value'] ?? ''),
+        ]);
     }
 
     /**

--- a/nextcloud-app/lib/Service/ClaudeSDKService.php
+++ b/nextcloud-app/lib/Service/ClaudeSDKService.php
@@ -5,6 +5,7 @@ namespace OCA\AIquila\Service;
 
 use Anthropic\Beta\AnthropicBeta;
 use Anthropic\Beta\Files\FileMetadata;
+use Anthropic\Beta\Messages\BetaMetadata;
 use Anthropic\Client;
 use Anthropic\Core\Contracts\BaseStream;
 use Anthropic\Core\Exceptions\APIConnectionException;
@@ -22,9 +23,11 @@ use Anthropic\Messages\Batches\MessageBatchExpiredResult;
 use Anthropic\Messages\Batches\MessageBatchIndividualResponse;
 use Anthropic\Messages\Batches\MessageBatchSucceededResult;
 use Anthropic\Messages\Message;
+use Anthropic\Messages\Metadata;
 use Anthropic\Messages\Usage;
 use Anthropic\Models\ModelInfo;
 use OCA\AIquila\Service\Provider\LLMProviderInterface;
+use OCA\AIquila\Service\Provider\ProviderActionsInterface;
 use OCA\AIquila\Service\Provider\ProviderProbe;
 use OCA\AIquila\Service\Provider\ProviderSettingsSchema;
 use OCP\ICache;
@@ -38,11 +41,12 @@ use Psr\Log\LoggerInterface;
  * This is the new implementation using the official SDK.
  * Provides better error handling, type safety, and streaming support.
  */
-class ClaudeSDKService implements LLMProviderInterface {
+class ClaudeSDKService implements LLMProviderInterface, ProviderActionsInterface {
     private IConfig $config;
     private LoggerInterface $logger;
     private CredentialService $credentials;
     private ICache $cache;
+    private RequestMetadataService $requestMetadata;
     private string $appName = 'aiquila';
 
     private const CAPABILITY_CACHE_TTL = 3600; // 1 hour
@@ -54,11 +58,16 @@ class ClaudeSDKService implements LLMProviderInterface {
      */
     private const STREAMING_THRESHOLD = 16384;
 
-    public function __construct(IConfig $config, LoggerInterface $logger, CredentialService $credentials, ICacheFactory $cacheFactory) {
+    /** Ids of the settings-card actions handled by runAction(). */
+    private const ACTION_REVEAL_SALT = 'reveal_metadata_salt';
+    private const ACTION_ROTATE_SALT = 'rotate_metadata_salt';
+
+    public function __construct(IConfig $config, LoggerInterface $logger, CredentialService $credentials, ICacheFactory $cacheFactory, RequestMetadataService $requestMetadata) {
         $this->config = $config;
         $this->logger = $logger;
         $this->credentials = $credentials;
         $this->cache = $cacheFactory->createDistributed('aiquila_model_caps');
+        $this->requestMetadata = $requestMetadata;
     }
 
     public function getId(): string {
@@ -210,6 +219,13 @@ class ClaudeSDKService implements LLMProviderInterface {
             'messages'   => $messages,
         ];
 
+        // Pseudonymous attribution for Anthropic's abuse detection. Never the
+        // raw UID — see RequestMetadataService.
+        $userHash = $this->requestMetadata->hashUserId($userId);
+        if ($userHash !== null) {
+            $params['metadata'] = ['user_id' => $userHash];
+        }
+
         // Adaptive thinking is opt-in (conversation override or admin default).
         // "Off" means omitting the param entirely — an explicit
         // {type: 'disabled'} is rejected with a 400 on Fable 5.
@@ -355,6 +371,21 @@ class ClaudeSDKService implements LLMProviderInterface {
     /**
      * Dispatch a non-streaming create call. Overridable for testing.
      */
+    /**
+     * Metadata param for a create call, or null when nothing is attached.
+     * The SDK property is `userID`; it serializes as `user_id`.
+     */
+    private function metadataParam(array $params): ?Metadata {
+        $userId = $params['metadata']['user_id'] ?? null;
+        return is_string($userId) ? Metadata::with(userID: $userId) : null;
+    }
+
+    /** Beta-endpoint twin of metadataParam(). */
+    private function betaMetadataParam(array $params): ?BetaMetadata {
+        $userId = $params['metadata']['user_id'] ?? null;
+        return is_string($userId) ? BetaMetadata::with(userID: $userId) : null;
+    }
+
     protected function callCreate(Client $client, array $params): Message {
         return $client->messages->create(
             maxTokens: $params['max_tokens'],
@@ -368,6 +399,7 @@ class ClaudeSDKService implements LLMProviderInterface {
             topK: $params['top_k'] ?? null,
             stopSequences: $params['stop_sequences'] ?? null,
             tools: $params['tools'] ?? null,
+            metadata: $this->metadataParam($params),
             requestOptions: $this->requestOptionsForMessages($params),
         );
     }
@@ -506,6 +538,7 @@ class ClaudeSDKService implements LLMProviderInterface {
             topK: $params['top_k'] ?? null,
             stopSequences: $params['stop_sequences'] ?? null,
             tools: $params['tools'] ?? null,
+            metadata: $this->metadataParam($params),
             requestOptions: $this->requestOptionsForMessages($params),
         );
     }
@@ -1087,6 +1120,11 @@ class ClaudeSDKService implements LLMProviderInterface {
         if (isset($params['stop_sequences'])) {
             $out['stopSequences'] = $params['stop_sequences'];
         }
+        // The SDK model wants a Metadata object here, not our snake_case array.
+        $metadata = $this->metadataParam($params);
+        if ($metadata !== null) {
+            $out['metadata'] = $metadata;
+        }
         return $out;
     }
 
@@ -1367,7 +1405,41 @@ class ClaudeSDKService implements LLMProviderInterface {
             ),
             ProviderSettingsSchema::maxTokens('max_tokens', ClaudeModels::DEFAULT_MAX_TOKENS),
             ProviderSettingsSchema::timeout('api_timeout', 30, 'Shared across all hosted providers.'),
+            ProviderSettingsSchema::checkbox(
+                RequestMetadataService::ENABLED_KEY,
+                RequestMetadataService::ENABLED_KEY,
+                'Send a pseudonymous user id with each request',
+                'Attaches metadata.user_id — an HMAC-SHA256 of the Nextcloud user id, salted with a secret unique to this instance. The login name itself is never sent, and the hash cannot be correlated with any other AIquila deployment. Anthropic uses it to attribute abuse; only an admin holding the salt can resolve it back to an account.',
+                storage: ProviderSettingsSchema::STORAGE_BOOL,
+            ),
+            ProviderSettingsSchema::action(
+                self::ACTION_REVEAL_SALT,
+                'Metadata salt',
+                'Reveal',
+                'Needed to resolve a hashed user id back to an account, e.g. when answering an abuse report. Also available as `occ aiquila:metadata-salt`.',
+            ),
+            ProviderSettingsSchema::action(
+                self::ACTION_ROTATE_SALT,
+                'Rotate the metadata salt',
+                'Rotate',
+                'Issues a fresh salt. All hashes sent before this point become permanently unresolvable.',
+                confirm: true,
+            ),
         ];
+    }
+
+    public function runAction(string $actionId): array {
+        switch ($actionId) {
+            case self::ACTION_REVEAL_SALT:
+                return ['value' => $this->requestMetadata->getSalt()];
+            case self::ACTION_ROTATE_SALT:
+                return [
+                    'value' => $this->requestMetadata->rotateSalt(),
+                    'message' => 'A new metadata salt was generated. Hashes sent earlier can no longer be resolved.',
+                ];
+            default:
+                throw new \InvalidArgumentException('Unknown action: ' . $actionId);
+        }
     }
 
     public function getCapabilities(): array {
@@ -1858,6 +1930,7 @@ class ClaudeSDKService implements LLMProviderInterface {
             tools: $params['tools'] ?? null,
             topK: $params['top_k'] ?? null,
             topP: $params['top_p'] ?? null,
+            metadata: $this->betaMetadataParam($params),
             betas: [AnthropicBeta::MCP_CLIENT_2025_11_20],
         );
     }

--- a/nextcloud-app/lib/Service/Provider/ProviderActionsInterface.php
+++ b/nextcloud-app/lib/Service/Provider/ProviderActionsInterface.php
@@ -1,0 +1,27 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Service\Provider;
+
+/**
+ * Optional companion to LLMProviderInterface for providers whose settings card
+ * carries a button rather than only stored values (ProviderSettingsSchema::action()).
+ *
+ * Actions are admin-only and run through
+ * ProviderSettingsController::adminAction(); a provider that does not implement
+ * this interface simply has no actions.
+ */
+interface ProviderActionsInterface {
+    /**
+     * Run one action declared by this provider's schema.
+     *
+     * @param string $actionId The `id` of a TYPE_ACTION field.
+     * @return array<string, mixed> Result rendered by the settings card. By
+     *         convention: `message` (string) for a status line and `value`
+     *         (string) for a secret to reveal.
+     * @throws \InvalidArgumentException when the provider has no such action.
+     */
+    public function runAction(string $actionId): array;
+}

--- a/nextcloud-app/lib/Service/Provider/ProviderSettingsSchema.php
+++ b/nextcloud-app/lib/Service/Provider/ProviderSettingsSchema.php
@@ -50,6 +50,12 @@ final class ProviderSettingsSchema {
     public const TYPE_TEXTAREA = 'textarea';
     /** Multiple values from an async lookup; the value is a list of ids. */
     public const TYPE_MULTISELECT = 'multiselect';
+    /**
+     * A button, not a value. Stores nothing: the client POSTs the field id to
+     * the provider-action endpoint and renders whatever comes back. Providers
+     * that declare one must implement ProviderActionsInterface.
+     */
+    public const TYPE_ACTION = 'action';
 
     /**
      * Placeholder for the `options` of a model select. The API expands it to the
@@ -394,6 +400,35 @@ final class ProviderSettingsSchema {
             'options' => self::OPTIONS_PRINCIPALS,
             'default' => [],
             'group' => self::GROUP_ADVANCED,
+        ];
+    }
+
+    /**
+     * A button that runs a provider-side action instead of storing a value.
+     *
+     * Carries no `key`, so ProviderSettingsService rejects it on write; it is
+     * only ever exercised through the action endpoint. Admin scope only.
+     *
+     * @param string $buttonLabel Text on the button itself.
+     * @param bool   $confirm     Ask the admin to confirm before running.
+     */
+    public static function action(
+        string $id,
+        string $title,
+        string $buttonLabel,
+        string $description = '',
+        bool $confirm = false,
+        string $group = self::GROUP_ADVANCED,
+    ): array {
+        return [
+            'id' => $id,
+            'title' => $title,
+            'description' => $description,
+            'type' => self::TYPE_ACTION,
+            'scope' => self::SCOPE_ADMIN,
+            'button_label' => $buttonLabel,
+            'confirm' => $confirm,
+            'group' => $group,
         ];
     }
 

--- a/nextcloud-app/lib/Service/RequestMetadataService.php
+++ b/nextcloud-app/lib/Service/RequestMetadataService.php
@@ -1,0 +1,105 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Service;
+
+use OCP\IConfig;
+use OCP\Security\ISecureRandom;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Pseudonymous per-user request attribution.
+ *
+ * The Anthropic Messages API accepts `metadata.user_id`, an opaque identifier
+ * used for abuse detection. We never send the Nextcloud UID itself — it is a
+ * login name and therefore personal data. Instead we send
+ *
+ *     hash_hmac('sha256', $uid, $salt)
+ *
+ * where `$salt` is a 32-byte random value generated once per instance and held
+ * encrypted in the credential manager. Because the salt is instance-specific
+ * and secret, the same UID produces different hashes on different AIquila
+ * deployments and the mapping cannot be brute-forced from the hash alone —
+ * but an admin holding the salt can reconstruct it, which is what makes an
+ * Anthropic abuse report actionable.
+ *
+ * Sending is opt-in (`send_user_metadata`, default off) and the salt can be
+ * rotated, which permanently breaks correlation with hashes already sent.
+ *
+ * See docs/dev/request-metadata.md.
+ */
+class RequestMetadataService {
+    private const APP_NAME = 'aiquila';
+
+    /** Named slot in CredentialService's generic secret namespace. */
+    public const SALT_SECRET = 'metadata_salt';
+
+    /** App config key for the opt-in switch. */
+    public const ENABLED_KEY = 'send_user_metadata';
+
+    /** Salt length in bytes; rendered as twice as many hex characters. */
+    private const SALT_BYTES = 32;
+
+    public function __construct(
+        private IConfig $config,
+        private CredentialService $credentials,
+        private ISecureRandom $random,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Whether hashed user ids should be attached to outbound requests.
+     *
+     * Checkboxes have persisted as 'true' or '1' over the app's history, so
+     * both are accepted (matching ClaudeSDKService::resolveThinking()).
+     */
+    public function isEnabled(): bool {
+        return in_array(
+            $this->config->getAppValue(self::APP_NAME, self::ENABLED_KEY, 'false'),
+            ['true', '1'],
+            true,
+        );
+    }
+
+    /**
+     * The instance salt, generated on first use.
+     */
+    public function getSalt(): string {
+        $salt = $this->credentials->getSecret(self::SALT_SECRET);
+        if ($salt !== '') {
+            return $salt;
+        }
+        return $this->generate('AIquila: generated request-metadata salt');
+    }
+
+    /**
+     * Replace the salt with a fresh one. Hashes sent before this point can no
+     * longer be resolved back to a user.
+     */
+    public function rotateSalt(): string {
+        return $this->generate('AIquila: rotated request-metadata salt');
+    }
+
+    private function generate(string $logMessage): string {
+        $salt = $this->random->generate(self::SALT_BYTES * 2, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
+        $this->credentials->setSecret(self::SALT_SECRET, $salt);
+        $this->logger->info($logMessage);
+        return $salt;
+    }
+
+    /**
+     * Hashed identifier for a user, or null when nothing should be sent.
+     *
+     * A null/empty $userId is normal: TaskProcessing background jobs, the occ
+     * commands and the setup checks all issue requests with no user attached.
+     */
+    public function hashUserId(?string $userId): ?string {
+        if ($userId === null || $userId === '' || !$this->isEnabled()) {
+            return null;
+        }
+        return hash_hmac('sha256', $userId, $this->getSalt());
+    }
+}

--- a/nextcloud-app/openapi-administration.json
+++ b/nextcloud-app/openapi-administration.json
@@ -718,6 +718,162 @@
                 }
             }
         },
+        "/index.php/apps/aiquila/api/admin/providers/{providerId}/action/{actionId}": {
+            "post": {
+                "operationId": "provider_settings-admin-action",
+                "summary": "Run an action declared by a provider's settings schema",
+                "description": "Actions are buttons rather than stored values (ProviderSettingsSchema::action()). `value` carries whatever the action produced — for the Anthropic metadata salt that is the salt itself, which is why this endpoint is admin-only.\nThis endpoint requires admin access",
+                "tags": [
+                    "provider_settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "providerId",
+                        "in": "path",
+                        "description": "Provider owning the action",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "actionId",
+                        "in": "path",
+                        "description": "Id of the TYPE_ACTION field to run",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The action ran",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "success",
+                                        "message",
+                                        "value"
+                                    ],
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Unknown provider, or the provider has no such action",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "success",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "success",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Logged in account must be an admin",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/index.php/apps/aiquila/api/admin/providers/{providerId}/status": {
             "get": {
                 "operationId": "provider_settings-admin-status",

--- a/nextcloud-app/openapi-full.json
+++ b/nextcloud-app/openapi-full.json
@@ -6920,6 +6920,162 @@
                 }
             }
         },
+        "/index.php/apps/aiquila/api/admin/providers/{providerId}/action/{actionId}": {
+            "post": {
+                "operationId": "provider_settings-admin-action",
+                "summary": "Run an action declared by a provider's settings schema",
+                "description": "Actions are buttons rather than stored values (ProviderSettingsSchema::action()). `value` carries whatever the action produced — for the Anthropic metadata salt that is the salt itself, which is why this endpoint is admin-only.\nThis endpoint requires admin access",
+                "tags": [
+                    "provider_settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "providerId",
+                        "in": "path",
+                        "description": "Provider owning the action",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "actionId",
+                        "in": "path",
+                        "description": "Id of the TYPE_ACTION field to run",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The action ran",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "success",
+                                        "message",
+                                        "value"
+                                    ],
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Unknown provider, or the provider has no such action",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "success",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "success",
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Logged in account must be an admin",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/index.php/apps/aiquila/api/admin/providers/{providerId}/status": {
             "get": {
                 "operationId": "provider_settings-admin-status",

--- a/nextcloud-app/src/components/settings/ProviderCard.vue
+++ b/nextcloud-app/src/components/settings/ProviderCard.vue
@@ -49,7 +49,9 @@
 				:provider-id="provider.id"
 				:user-scope="scope === 'user'"
 				:model-value="draft[field.id]"
-				@update:model-value="v => setValue(field.id, v)" />
+				:action-running="runningAction === field.id"
+				@update:model-value="v => setValue(field.id, v)"
+				@action="runAction" />
 
 			<details v-if="advancedFields.length" class="provider-card__advanced">
 				<summary>{{ t('aiquila', 'Advanced') }}</summary>
@@ -59,7 +61,9 @@
 					:provider-id="provider.id"
 					:user-scope="scope === 'user'"
 					:model-value="draft[field.id]"
-					@update:model-value="v => setValue(field.id, v)" />
+					:action-running="runningAction === field.id"
+					@update:model-value="v => setValue(field.id, v)"
+					@action="runAction" />
 			</details>
 
 			<NcNoteCard v-if="message" :type="messageType">
@@ -88,7 +92,7 @@ import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwit
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 
 import SchemaField from './SchemaField.vue'
-import { getProviderStatus, saveAdminProvider, saveUserProvider, testProvider } from '../../settings-api.js'
+import { getProviderStatus, runProviderAction, saveAdminProvider, saveUserProvider, testProvider } from '../../settings-api.js'
 
 /** Capability flag → chip label. Flags absent from here are not worth a chip. */
 const CAPABILITY_LABELS = {
@@ -145,6 +149,8 @@ export default {
 			open: false,
 			saving: false,
 			testing: false,
+			/** Id of the action field whose request is in flight, '' when idle. */
+			runningAction: '',
 			dirty: false,
 			message: '',
 			messageType: 'success',
@@ -317,6 +323,25 @@ export default {
 		 * read-only, costs no tokens, and — unlike the admin test — never swaps
 		 * the stored key out from under a concurrent request.
 		 */
+		/**
+		 * Schema-declared button. The answer's `value` (e.g. a revealed salt) is
+		 * shown in the card's note area, which is the only place it is exposed.
+		 */
+		async runAction(actionId) {
+			this.runningAction = actionId
+			this.message = ''
+			try {
+				const { data } = await runProviderAction(this.provider.id, actionId)
+				this.messageType = data.success ? 'success' : 'error'
+				this.message = [data.message, data.value].filter(Boolean).join(' ')
+					|| t('aiquila', 'Done.')
+			} catch (err) {
+				this.messageType = 'error'
+				this.message = err.response?.data?.message || err.message
+			} finally {
+				this.runningAction = ''
+			}
+		},
 		async test() {
 			if (this.scope !== 'admin') {
 				this.testing = true

--- a/nextcloud-app/src/components/settings/SchemaField.vue
+++ b/nextcloud-app/src/components/settings/SchemaField.vue
@@ -12,6 +12,18 @@
 			{{ field.title }}
 		</NcCheckboxRadioSwitch>
 
+		<!--
+			A button, not a value: the parent POSTs the field id to the provider
+			action endpoint. Whatever comes back (e.g. a revealed salt) is shown
+			by the parent, not here.
+		-->
+		<template v-else-if="field.type === 'action'">
+			<label class="schema-field__label">{{ field.title }}</label>
+			<NcButton :disabled="actionRunning" @click="runAction">
+				{{ field.button_label || t('aiquila', 'Run') }}
+			</NcButton>
+		</template>
+
 		<template v-else>
 			<label class="schema-field__label" :for="inputId">{{ field.title }}</label>
 
@@ -82,6 +94,7 @@
 <script>
 import { translate as t } from '@nextcloud/l10n'
 import { searchPrincipals } from '../../settings-api.js'
+import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcPasswordField from '@nextcloud/vue/components/NcPasswordField'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
@@ -91,6 +104,7 @@ import NcTextField from '@nextcloud/vue/components/NcTextField'
 export default {
 	name: 'SchemaField',
 	components: {
+		NcButton,
 		NcCheckboxRadioSwitch,
 		NcPasswordField,
 		NcSelect,
@@ -117,8 +131,13 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		/** Action fields only: the parent's request is in flight. */
+		actionRunning: {
+			type: Boolean,
+			default: false,
+		},
 	},
-	emits: ['update:modelValue'],
+	emits: ['update:modelValue', 'action'],
 	data() {
 		return {
 			/** Options for the principal picker, refreshed as the admin types. */
@@ -187,6 +206,13 @@ export default {
 		t,
 		emit(value) {
 			this.$emit('update:modelValue', value)
+		},
+		/** Destructive actions ask first; the schema decides which those are. */
+		runAction() {
+			if (this.field.confirm && !window.confirm(this.field.description || this.field.title)) {
+				return
+			}
+			this.$emit('action', this.field.id)
 		},
 		/** Emit ids, not option objects — that is what the API stores. */
 		emitPrincipals(options) {

--- a/nextcloud-app/src/settings-api.js
+++ b/nextcloud-app/src/settings-api.js
@@ -57,6 +57,17 @@ export function testProvider(providerId, apiKey = '') {
 }
 
 /**
+ * Run a schema-declared provider action (a button rather than a stored value).
+ *
+ * @param {string} providerId - provider owning the action
+ * @param {string} actionId - id of the action field
+ * @return {Promise} resolving to `{success, message, value}`
+ */
+export function runProviderAction(providerId, actionId) {
+	return axios.post(url(`/api/admin/providers/${providerId}/action/${actionId}`), {})
+}
+
+/**
  * Live health of one provider, behind the status light on its card.
  *
  * The user-scope route reports what this user actually gets (their own key, or

--- a/nextcloud-app/tests/Unit/ClaudeSDKServiceAutoStreamTest.php
+++ b/nextcloud-app/tests/Unit/ClaudeSDKServiceAutoStreamTest.php
@@ -8,6 +8,7 @@ use Anthropic\Messages\Message;
 use OCA\AIquila\Service\ClaudeModels;
 use OCA\AIquila\Service\ClaudeSDKService;
 use OCA\AIquila\Service\CredentialService;
+use OCA\AIquila\Service\RequestMetadataService;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -68,6 +69,7 @@ class ClaudeSDKServiceAutoStreamTest extends TestCase {
     private LoggerInterface $logger;
     private CredentialService $credentials;
     private ICacheFactory $cacheFactory;
+    private RequestMetadataService $requestMetadata;
 
     protected function setUp(): void {
         $this->config = $this->createMock(IConfig::class);
@@ -83,6 +85,7 @@ class ClaudeSDKServiceAutoStreamTest extends TestCase {
             'supports_effort' => false,
         ]);
         $this->cacheFactory = $this->createMock(ICacheFactory::class);
+        $this->requestMetadata = $this->createMock(RequestMetadataService::class);
         $this->cacheFactory->method('createDistributed')->willReturn($cache);
 
         $this->config->method('getUserValue')->willReturn('');
@@ -141,7 +144,7 @@ class ClaudeSDKServiceAutoStreamTest extends TestCase {
     }
 
     public function testLargeMaxTokensUsesStreamingTransport(): void {
-        $service = new AutoStreamTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory);
+        $service = new AutoStreamTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
         $service->setStreamEvents($this->makeEvents());
 
         $result = $service->ask('test prompt', '', 'testuser');
@@ -167,7 +170,7 @@ class ClaudeSDKServiceAutoStreamTest extends TestCase {
                 default => $default,
             });
 
-        $service = new AutoStreamTestableService($config, $this->logger, $this->credentials, $this->cacheFactory);
+        $service = new AutoStreamTestableService($config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
 
         $result = $service->ask('test prompt', '', 'testuser');
 

--- a/nextcloud-app/tests/Unit/ClaudeSDKServiceBatchTest.php
+++ b/nextcloud-app/tests/Unit/ClaudeSDKServiceBatchTest.php
@@ -8,9 +8,11 @@ use Anthropic\Messages\Batches\MessageBatchIndividualResponse;
 use Anthropic\Messages\Batches\MessageBatchRequestCounts;
 use Anthropic\Messages\Batches\MessageBatchSucceededResult;
 use Anthropic\Messages\Message;
+use Anthropic\Messages\Metadata;
 use Anthropic\Messages\Usage;
 use OCA\AIquila\Service\ClaudeSDKService;
 use OCA\AIquila\Service\CredentialService;
+use OCA\AIquila\Service\RequestMetadataService;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -112,7 +114,9 @@ class ClaudeSDKServiceBatchTest extends TestCase {
         $cache = $this->createMock(ICache::class);
         $cacheFactory = $this->createMock(ICacheFactory::class);
         $cacheFactory->method('createDistributed')->willReturn($cache);
-        return new BatchTestableService($config, $logger, $credentials, $cacheFactory);
+        $requestMetadata = $this->createMock(RequestMetadataService::class);
+        $requestMetadata->method('hashUserId')->willReturn('deadbeef');
+        return new BatchTestableService($config, $logger, $credentials, $cacheFactory, $requestMetadata);
     }
 
     public function testBatchSummarySucceedsOnFirstPoll(): void {
@@ -158,5 +162,19 @@ class ClaudeSDKServiceBatchTest extends TestCase {
         $this->assertSame('user', $req['params']['messages'][0]['role']);
         $this->assertStringContainsString('Summarize', $req['params']['messages'][0]['content']);
         $this->assertStringContainsString('document body', $req['params']['messages'][0]['content']);
+    }
+
+    /**
+     * toBatchParams() translates a whitelist of keys, so a new one is dropped
+     * unless it is handled — and metadata has to arrive as an SDK model, not
+     * as the snake_case array the Messages API params carry.
+     */
+    public function testBatchParamsCarryHashedUserMetadata(): void {
+        $svc = $this->makeService();
+        $svc->summarizeViaBatch('document body', 'testuser', null);
+
+        $metadata = $svc->lastBatchRequests[0]['params']['metadata'];
+        $this->assertInstanceOf(Metadata::class, $metadata);
+        $this->assertSame('deadbeef', $metadata->userID);
     }
 }

--- a/nextcloud-app/tests/Unit/ClaudeSDKServiceCapabilityTest.php
+++ b/nextcloud-app/tests/Unit/ClaudeSDKServiceCapabilityTest.php
@@ -10,6 +10,7 @@ use Anthropic\Models\ModelInfo;
 use OCA\AIquila\Service\ClaudeModels;
 use OCA\AIquila\Service\ClaudeSDKService;
 use OCA\AIquila\Service\CredentialService;
+use OCA\AIquila\Service\RequestMetadataService;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -70,6 +71,7 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
     private CredentialService $credentials;
     private ICache $cache;
     private ICacheFactory $cacheFactory;
+    private RequestMetadataService $requestMetadata;
 
     protected function setUp(): void {
         $this->config = $this->createMock(IConfig::class);
@@ -79,6 +81,7 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
 
         $this->cache = $this->createMock(ICache::class);
         $this->cacheFactory = $this->createMock(ICacheFactory::class);
+        $this->requestMetadata = $this->createMock(RequestMetadataService::class);
         $this->cacheFactory->method('createDistributed')->willReturn($this->cache);
 
         $this->config->method('getUserValue')->willReturn('');
@@ -120,7 +123,7 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
             128000
         );
 
-        $service = new CapabilityTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory);
+        $service = new CapabilityTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
         $service->setRetrieveModelInfo($info);
 
         // Trigger buildRequestParams via ask()
@@ -166,7 +169,7 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
             128000
         );
 
-        $service = new CapabilityTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory);
+        $service = new CapabilityTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
         $service->setRetrieveModelInfo($info);
         $service->ask('test', '', 'testuser');
 
@@ -184,7 +187,7 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
         // set() should not be called since we have a cache hit
         $this->cache->expects($this->never())->method('set');
 
-        $service = new CapabilityTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory);
+        $service = new CapabilityTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
         $service->throwOnRetrieveModel(new \RuntimeException('should not be called'));
 
         $result = $service->ask('test', '', 'testuser');
@@ -194,7 +197,7 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
     public function testFallbackOnApiFailure(): void {
         $this->cache->method('get')->willReturn(null);
 
-        $service = new CapabilityTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory);
+        $service = new CapabilityTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
         $service->throwOnRetrieveModel(new \RuntimeException('API unreachable'));
 
         // Should fall back to static values without error
@@ -244,7 +247,7 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
             128000
         );
 
-        $service = new CapabilityTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory);
+        $service = new CapabilityTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
         $service->setRetrieveModelInfo($info);
 
         $service->ask('test', '', 'testuser');
@@ -292,7 +295,7 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
             8192
         );
 
-        $service = new CapabilityTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory);
+        $service = new CapabilityTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
         $service->setRetrieveModelInfo($info);
 
         $result = $service->ask('test', '', 'testuser');
@@ -321,7 +324,7 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
             'supports_effort' => true,
         ]);
 
-        return new CapabilityTestableService($config, $this->logger, $this->credentials, $this->cacheFactory);
+        return new CapabilityTestableService($config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
     }
 
     public function testEffortConversationOverrideWins(): void {
@@ -412,9 +415,9 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
                 }
             });
 
-        $service = new class($this->config, $logger, $this->credentials, $this->cacheFactory, $e) extends ClaudeSDKService {
-            public function __construct($cfg, $log, $cred, $cf, private \Throwable $toThrow) {
-                parent::__construct($cfg, $log, $cred, $cf);
+        $service = new class($this->config, $logger, $this->credentials, $this->cacheFactory, $this->requestMetadata, $e) extends ClaudeSDKService {
+            public function __construct($cfg, $log, $cred, $cf, $meta, private \Throwable $toThrow) {
+                parent::__construct($cfg, $log, $cred, $cf, $meta);
             }
             protected function callCreate(Client $client, array $params): \Anthropic\Messages\Message {
                 throw $this->toThrow;
@@ -449,9 +452,9 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
 
         $refusal = RefusalStopDetails::with('cyber', 'I cannot help with that.');
 
-        $service = new class($this->config, $logger, $this->credentials, $this->cacheFactory, $refusal) extends ClaudeSDKService {
-            public function __construct($cfg, $log, $cred, $cf, private RefusalStopDetails $refusal) {
-                parent::__construct($cfg, $log, $cred, $cf);
+        $service = new class($this->config, $logger, $this->credentials, $this->cacheFactory, $this->requestMetadata, $refusal) extends ClaudeSDKService {
+            public function __construct($cfg, $log, $cred, $cf, $meta, private RefusalStopDetails $refusal) {
+                parent::__construct($cfg, $log, $cred, $cf, $meta);
             }
             protected function callCreate(Client $client, array $params): \Anthropic\Messages\Message {
                 $stub = (new \ReflectionClass(\Anthropic\Messages\Message::class))->newInstanceWithoutConstructor();
@@ -496,7 +499,7 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
             'supports_effort' => false,
         ]);
 
-        $service = new class($this->config, $this->logger, $this->credentials, $this->cacheFactory) extends ClaudeSDKService {
+        $service = new class($this->config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata) extends ClaudeSDKService {
             public ?array $lastCreateParams = null;
             protected function callCreate(Client $client, array $params): \Anthropic\Messages\Message {
                 $this->lastCreateParams = $params;

--- a/nextcloud-app/tests/Unit/ClaudeSDKServiceNativeMcpTest.php
+++ b/nextcloud-app/tests/Unit/ClaudeSDKServiceNativeMcpTest.php
@@ -7,6 +7,7 @@ use Anthropic\Core\Contracts\BaseStream;
 use OCA\AIquila\Service\ClaudeModels;
 use OCA\AIquila\Service\ClaudeSDKService;
 use OCA\AIquila\Service\CredentialService;
+use OCA\AIquila\Service\RequestMetadataService;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -60,6 +61,7 @@ class ClaudeSDKServiceNativeMcpTest extends TestCase {
     private CredentialService $credentials;
     private ICache $cache;
     private ICacheFactory $cacheFactory;
+    private RequestMetadataService $requestMetadata;
 
     protected function setUp(): void {
         $this->config = $this->createMock(IConfig::class);
@@ -75,6 +77,7 @@ class ClaudeSDKServiceNativeMcpTest extends TestCase {
             'supports_effort' => false,
         ]);
         $this->cacheFactory = $this->createMock(ICacheFactory::class);
+        $this->requestMetadata = $this->createMock(RequestMetadataService::class);
         $this->cacheFactory->method('createDistributed')->willReturn($this->cache);
 
         $this->config->method('getUserValue')->willReturn('');
@@ -105,8 +108,35 @@ class ClaudeSDKServiceNativeMcpTest extends TestCase {
         return $o;
     }
 
+    /**
+     * The beta endpoint takes its own metadata type, so the native-MCP path
+     * needs its own conversion — a plain array would not reach the wire.
+     */
+    public function testNativeMcpPathCarriesHashedUserMetadata(): void {
+        $hash = str_repeat('ef', 32);
+        $this->requestMetadata->method('hashUserId')->willReturn($hash);
+
+        $service = new NativeMcpTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
+        $service->setStubStream($this->streamFromEvents([]));
+        iterator_to_array($service->chatWithNativeMcp(
+            messages: [['role' => 'user', 'content' => 'hi']],
+            mcpServers: [['type' => 'url', 'url' => 'https://mcp.example/mcp', 'name' => 'x']],
+            userId: 'alice',
+        ), false);
+
+        $this->assertSame(['user_id' => $hash], $service->lastParams['metadata']);
+
+        $ref = new \ReflectionMethod(ClaudeSDKService::class, 'callBetaCreateStreamWithMcp');
+        $source = implode('', array_slice(
+            file($ref->getFileName()),
+            $ref->getStartLine() - 1,
+            $ref->getEndLine() - $ref->getStartLine() + 1,
+        ));
+        $this->assertStringContainsString('metadata:', $source);
+    }
+
     public function testEmptyMcpServersYieldsError(): void {
-        $service = new NativeMcpTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory);
+        $service = new NativeMcpTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
         $events = iterator_to_array($service->chatWithNativeMcp(
             messages: [['role' => 'user', 'content' => 'hi']],
             mcpServers: [],
@@ -119,7 +149,7 @@ class ClaudeSDKServiceNativeMcpTest extends TestCase {
     }
 
     public function testStreamMapsTextAndMcpBlocksToEvents(): void {
-        $service = new NativeMcpTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory);
+        $service = new NativeMcpTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
 
         $stream = [
             $this->obj([
@@ -186,7 +216,7 @@ class ClaudeSDKServiceNativeMcpTest extends TestCase {
     }
 
     public function testOpenFailureYieldsErrorEvent(): void {
-        $service = new NativeMcpTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory);
+        $service = new NativeMcpTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
         $service->shouldThrowOnOpen = true;
 
         $events = iterator_to_array($service->chatWithNativeMcp(
@@ -201,7 +231,7 @@ class ClaudeSDKServiceNativeMcpTest extends TestCase {
     }
 
     public function testCollectFlattensToLegacyShape(): void {
-        $service = new NativeMcpTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory);
+        $service = new NativeMcpTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
         $stream = [
             $this->obj(['type' => 'message_start', 'message' => ['usage' => ['inputTokens' => 5, 'cacheCreationInputTokens' => 0, 'cacheReadInputTokens' => 0]]]),
             $this->obj(['type' => 'content_block_start', 'index' => 0, 'contentBlock' => ['type' => 'text']]),

--- a/nextcloud-app/tests/Unit/ClaudeServiceTest.php
+++ b/nextcloud-app/tests/Unit/ClaudeServiceTest.php
@@ -17,6 +17,7 @@ use Anthropic\Models\ModelInfo;
 use OCA\AIquila\Service\ClaudeModels;
 use OCA\AIquila\Service\ClaudeSDKService;
 use OCA\AIquila\Service\CredentialService;
+use OCA\AIquila\Service\RequestMetadataService;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -164,6 +165,7 @@ class ClaudeServiceTest extends TestCase {
     private $logger;
     private $credentials;
     private $cacheFactory;
+    private $requestMetadata;
     private ClaudeSDKService $service;
     private TestableClaudeSDKService $testable;
 
@@ -176,10 +178,11 @@ class ClaudeServiceTest extends TestCase {
         $cache->method('get')->willReturn(null);
         $cache->method('set')->willReturn(true);
         $this->cacheFactory = $this->createMock(ICacheFactory::class);
+        $this->requestMetadata = $this->createMock(RequestMetadataService::class);
         $this->cacheFactory->method('createDistributed')->willReturn($cache);
 
-        $this->service     = new ClaudeSDKService($this->config, $this->logger, $this->credentials, $this->cacheFactory);
-        $this->testable    = new TestableClaudeSDKService($this->config, $this->logger, $this->credentials, $this->cacheFactory);
+        $this->service     = new ClaudeSDKService($this->config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
+        $this->testable    = new TestableClaudeSDKService($this->config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
     }
 
     // ── PSR-7 helpers for building SDK exceptions ─────────────────────────
@@ -1339,6 +1342,57 @@ class ClaudeServiceTest extends TestCase {
         $this->assertCount(1, $done['citations']);
         $this->assertSame('page_location', $done['citations'][0]['type']);
         $this->assertSame(2, $done['citations'][0]['start_page_number']);
+    }
+
+    // ── metadata.user_id ───────────────────────────────────────────────────
+
+    public function testMetadataCarriesTheHashAndNeverTheRawUid(): void {
+        $this->configWithApiKey();
+        $hash = str_repeat('ab', 32);
+        $this->requestMetadata->method('hashUserId')
+            ->willReturnCallback(fn (?string $uid) => $uid === 'testuser' ? $hash : null);
+
+        $this->testable->ask('Hi', '', 'testuser');
+
+        $this->assertSame(['user_id' => $hash], $this->testable->lastCreateParams['metadata']);
+        $this->assertStringNotContainsString(
+            'testuser',
+            json_encode($this->testable->lastCreateParams['metadata']),
+        );
+    }
+
+    public function testMetadataIsAbsentWhenSendingIsOff(): void {
+        $this->configWithApiKey();
+        // The default mock returns null — the disabled/no-user case.
+        $this->testable->ask('Hi', '', 'testuser');
+
+        $this->assertArrayNotHasKey('metadata', $this->testable->lastCreateParams);
+    }
+
+    public function testMetadataReachesTheStreamingPath(): void {
+        $this->configWithApiKey();
+        $hash = str_repeat('cd', 32);
+        $this->requestMetadata->method('hashUserId')->willReturn($hash);
+
+        iterator_to_array($this->testable->askStream('Hi', '', 'testuser'), false);
+
+        $this->assertSame(['user_id' => $hash], $this->testable->lastStreamParams['metadata']);
+    }
+
+    /**
+     * A param captured in $lastCreateParams is worthless if the dispatcher
+     * never forwards it, so guard the SDK argument itself.
+     */
+    public function testCreateDispatchersForwardMetadataToTheSdk(): void {
+        foreach (['callCreate', 'callCreateStream'] as $method) {
+            $ref = new \ReflectionMethod(ClaudeSDKService::class, $method);
+            $source = implode('', array_slice(
+                file($ref->getFileName()),
+                $ref->getStartLine() - 1,
+                $ref->getEndLine() - $ref->getStartLine() + 1,
+            ));
+            $this->assertStringContainsString('metadata:', $source, $method . ' must forward metadata');
+        }
     }
 
     public function testChatWithToolsStreamYieldsErrorOnStreamFailure(): void {

--- a/nextcloud-app/tests/Unit/ProviderSettingsControllerTest.php
+++ b/nextcloud-app/tests/Unit/ProviderSettingsControllerTest.php
@@ -7,6 +7,7 @@ use OCA\AIquila\Service\CredentialService;
 use OCA\AIquila\Service\Provider\LLMProviderFactory;
 use OCA\AIquila\Service\Provider\LLMProviderInterface;
 use OCA\AIquila\Service\Provider\NoPermittedProviderException;
+use OCA\AIquila\Service\Provider\ProviderActionsInterface;
 use OCA\AIquila\Service\Provider\ProviderSettingsService;
 use OCP\AppFramework\Http;
 use OCP\IConfig;
@@ -126,5 +127,71 @@ class ProviderSettingsControllerTest extends TestCase {
 
         $this->assertSame(Http::STATUS_OK, $response->getStatus());
         $this->assertSame('ok', $response->getData()['status']);
+    }
+
+    // ── provider actions ───────────────────────────────────────────────────
+
+    /**
+     * @param LLMProviderInterface $provider what getProviderById() answers with
+     */
+    private function ctrlWithProvider(LLMProviderInterface $provider): ProviderSettingsController {
+        $factory = $this->createMock(LLMProviderFactory::class);
+        $factory->method('isKnownProviderId')->willReturn(true);
+        $factory->method('getProviderById')->willReturn($provider);
+
+        return new ProviderSettingsController(
+            'aiquila',
+            $this->createMock(IRequest::class),
+            'testuser',
+            $this->config,
+            $factory,
+            $this->settings,
+            $this->createMock(CredentialService::class),
+            $this->createMock(IUserManager::class),
+            $this->createMock(IGroupManager::class),
+            $this->createMock(LoggerInterface::class),
+        );
+    }
+
+    public function testAdminActionRunsTheProviderAction(): void {
+        $provider = $this->createMockForIntersectionOfInterfaces(
+            [LLMProviderInterface::class, ProviderActionsInterface::class],
+        );
+        $provider->method('getId')->willReturn('anthropic');
+        $provider->expects($this->once())
+            ->method('runAction')
+            ->with('rotate_metadata_salt')
+            ->willReturn(['value' => 'new-salt', 'message' => 'rotated']);
+
+        $response = $this->ctrlWithProvider($provider)->adminAction('anthropic', 'rotate_metadata_salt');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame(
+            ['success' => true, 'message' => 'rotated', 'value' => 'new-salt'],
+            $response->getData(),
+        );
+    }
+
+    public function testAdminActionRejectsAProviderWithoutActions(): void {
+        $provider = $this->createMock(LLMProviderInterface::class);
+        $provider->method('getId')->willReturn('mistral');
+
+        $response = $this->ctrlWithProvider($provider)->adminAction('mistral', 'rotate_metadata_salt');
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertFalse($response->getData()['success']);
+    }
+
+    public function testAdminActionRejectsAnUnknownActionId(): void {
+        $provider = $this->createMockForIntersectionOfInterfaces(
+            [LLMProviderInterface::class, ProviderActionsInterface::class],
+        );
+        $provider->method('getId')->willReturn('anthropic');
+        $provider->method('runAction')->willThrowException(new \InvalidArgumentException('Unknown action: nope'));
+
+        $response = $this->ctrlWithProvider($provider)->adminAction('anthropic', 'nope');
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertStringContainsString('Unknown action', $response->getData()['message']);
     }
 }

--- a/nextcloud-app/tests/Unit/RequestMetadataServiceTest.php
+++ b/nextcloud-app/tests/Unit/RequestMetadataServiceTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace OCA\AIquila\Tests\Unit;
+
+use OCA\AIquila\Service\CredentialService;
+use OCA\AIquila\Service\RequestMetadataService;
+use OCP\IConfig;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class RequestMetadataServiceTest extends TestCase {
+    private const SALT = 'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
+
+    private IConfig $config;
+    private CredentialService $credentials;
+    private ISecureRandom $random;
+    private LoggerInterface $logger;
+
+    /** Secret slot contents, so the mocks behave like real storage. */
+    private array $secrets = [];
+
+    protected function setUp(): void {
+        $this->config = $this->createMock(IConfig::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->credentials = $this->createMock(CredentialService::class);
+        $this->credentials->method('getSecret')
+            ->willReturnCallback(fn (string $name) => $this->secrets[$name] ?? '');
+        $this->credentials->method('setSecret')
+            ->willReturnCallback(function (string $name, string $value): void {
+                $this->secrets[$name] = $value;
+            });
+
+        $this->random = $this->createMock(ISecureRandom::class);
+        $this->random->method('generate')->willReturn(self::SALT);
+    }
+
+    private function service(bool $enabled): RequestMetadataService {
+        $this->config->method('getAppValue')
+            ->willReturnCallback(fn ($app, $key, $default) => $key === RequestMetadataService::ENABLED_KEY
+                ? ($enabled ? 'true' : 'false')
+                : $default);
+        return new RequestMetadataService($this->config, $this->credentials, $this->random, $this->logger);
+    }
+
+    public function testDisabledSendsNothing(): void {
+        $this->assertNull($this->service(false)->hashUserId('alice'));
+    }
+
+    public function testNoUserSendsNothing(): void {
+        $service = $this->service(true);
+        $this->assertNull($service->hashUserId(null));
+        $this->assertNull($service->hashUserId(''));
+    }
+
+    public function testHashIsTheHmacAndNeverTheRawUid(): void {
+        $hash = $this->service(true)->hashUserId('alice');
+
+        $this->assertSame(hash_hmac('sha256', 'alice', self::SALT), $hash);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', (string)$hash);
+        $this->assertStringNotContainsString('alice', (string)$hash);
+    }
+
+    public function testHashIsStableAcrossCalls(): void {
+        $service = $this->service(true);
+        $this->assertSame($service->hashUserId('alice'), $service->hashUserId('alice'));
+        $this->assertNotSame($service->hashUserId('alice'), $service->hashUserId('bob'));
+    }
+
+    public function testSaltIsGeneratedOnceAndPersisted(): void {
+        $service = $this->service(true);
+
+        $this->assertSame(self::SALT, $service->getSalt());
+        $this->assertSame(self::SALT, $this->secrets[RequestMetadataService::SALT_SECRET]);
+
+        // A pre-existing salt is reused rather than regenerated.
+        $this->secrets[RequestMetadataService::SALT_SECRET] = 'stored-salt';
+        $this->assertSame('stored-salt', $service->getSalt());
+    }
+
+    public function testRotateReplacesTheSaltAndChangesTheHash(): void {
+        $service = $this->service(true);
+        $this->secrets[RequestMetadataService::SALT_SECRET] = 'old-salt';
+        $before = $service->hashUserId('alice');
+
+        $this->assertSame(self::SALT, $service->rotateSalt());
+        $this->assertNotSame($before, $service->hashUserId('alice'));
+    }
+
+    public function testSaltIsInstanceSpecific(): void {
+        // Two deployments with different salts must not produce the same hash
+        // for the same login name.
+        $this->assertNotSame(
+            hash_hmac('sha256', 'alice', 'salt-one'),
+            hash_hmac('sha256', 'alice', 'salt-two'),
+        );
+    }
+}


### PR DESCRIPTION
Anthropic's abuse reports name a `metadata.user_id`, so without one a flagged key costs the whole instance its API access instead of pointing at the account responsible. AIquila now attaches one — but never the Nextcloud login name, which is personal data.

## What it sends

```
metadata.user_id = hash_hmac('sha256', <nextcloud uid>, <instance salt>)
```

The salt is 32 random bytes generated once per instance and held encrypted in the credential manager. That keeps the hash unguessable from outside (unlike a plain `sha256(uid)`, which a username wordlist would crack instantly) and uncorrelatable across deployments, while an admin holding the salt can still resolve it for a report.

**Off by default.** The field is omitted entirely — not sent empty — when disabled, and whenever no user is attached (TaskProcessing jobs, `occ`, setup checks).

## Coverage

The hash is attached in `buildRequestParams()`, the single funnel every message-producing method already routes through, then forwarded to all four Anthropic paths:

| Path | Dispatcher | SDK type |
|------|-----------|----------|
| Non-streaming | `callCreate()` | `Messages\Metadata` |
| Streaming | `callCreateStream()` | `Messages\Metadata` |
| Message batches | `toBatchParams()` | `Messages\Metadata` |
| Native MCP (beta) | `callBetaCreateStreamWithMcp()` | `Beta\Messages\BetaMetadata` |

Two of these needed explicit handling: `toBatchParams()` translates a whitelist of keys, so a new one is dropped unless added; and the beta endpoint takes a different metadata type than the mainline one.

Anthropic-only — no other provider's API has this field.

## Reveal and rotate

Both as `occ aiquila:metadata-salt [--rotate] [--hash <uid>]` and as buttons on the provider card.

The buttons are a new generic schema field type (`ProviderSettingsSchema::action()`) dispatching through a new optional `ProviderActionsInterface` via `POST /api/admin/providers/{id}/action/{actionId}` — so the declarative settings UI stays declarative instead of growing an Anthropic special case. Action fields carry no config key, so `writeAdmin()` already rejects them as unwritable; the endpoint is admin-only because an action's answer can be a secret.

## Verification

- 580 tests pass (16 new: hashing, all four dispatch paths, the action endpoint, plus reflection guards that the dispatchers actually forward `metadata:` to the SDK)
- Psalm clean, OpenAPI regenerated, frontend builds
- In the dev stack: `--hash testuser` matched an independent HMAC of the revealed salt, `--rotate` changed it, the schema exposes all three fields on the Anthropic card, no new ERROR lines in `nextcloud.log`

**Not verified:** the two buttons were never clicked in a real browser — no Chrome extension in that session, and curl can't reach the endpoint because Nextcloud's CSRF check rejects it exactly as it does the existing `/test` route. The controller logic has unit tests; the click path itself does not.

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)