### PR TITLE
fix(hetzner): restrict SSH to the caller's public IP by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,3 +65,25 @@ jobs:
             echo "::error::OpenAPI spec is out of date. Run 'make openapi' and commit the result."
             exit 1
           }
+
+  hetzner-cli:
+    name: Hetzner CLI Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: hetzner
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: hetzner/go.mod
+          cache-dependency-path: hetzner/go.sum
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Run tests
+        run: go test ./...

--- a/docs/hetzner/advanced.md
+++ b/docs/hetzner/advanced.md
@@ -83,7 +83,17 @@ aiquila-hetzner network attach --server myserver --network mynet
 
 ## SSH CIDR restriction
 
-Restrict SSH access to a known IP range:
+SSH (port 22) is never opened to the internet by default. When you do not pass
+`--ssh-allow-cidr`, `create` detects the public IP of the machine you run it
+from and restricts port 22 to that single address:
+
+```
+No --ssh-allow-cidr specified, restricting SSH to your current IP: 203.0.113.7/32
+```
+
+**Always set `--ssh-allow-cidr` explicitly** for anything long-lived — a
+detected address is whatever your ISP or VPN handed you today, and it will
+change. Pass the range you actually administer the server from:
 
 ```bash
 aiquila-hetzner create --mcp-domain mcp.example.com \
@@ -91,8 +101,33 @@ aiquila-hetzner create --mcp-domain mcp.example.com \
   --ssh-allow-cidr 203.0.113.0/24
 ```
 
-The firewall rule for port 22 is updated to allow only the specified CIDR
-instead of the default `0.0.0.0/0`.
+An invalid CIDR is rejected before any Hetzner resource is created. Ports
+80/443 are always open to the world; only port 22 is restricted.
+
+If you genuinely need SSH reachable from anywhere — CI provisioning, a dynamic
+office IP — opt in explicitly:
+
+```bash
+aiquila-hetzner create ... --ssh-allow-any
+```
+
+That prints a warning and falls back to `0.0.0.0/0`. The same fallback applies
+(also with a warning) when public-IP detection fails, so an offline or
+firewalled workstation never blocks a deploy.
+
+### Changing the CIDR later
+
+`create` is idempotent and reuses a firewall that already carries the target
+name. It will **not** rewrite the SSH rule of an existing firewall; if the rule
+does not match what you asked for, you get:
+
+```
+WARNING: existing firewall "myserver-fw" allows SSH from 0.0.0.0/0, not 203.0.113.0/24 — not modified;
+edit it in the Hetzner console or delete it to have it recreated
+```
+
+Adjust the rule in the Hetzner console (or delete the firewall and re-run
+`create`) to change it.
 
 ---
 

--- a/docs/hetzner/commands.md
+++ b/docs/hetzner/commands.md
@@ -76,7 +76,8 @@ Run `aiquila-hetzner options` to list all server types, locations, and images av
 | Flag | Description |
 |------|-------------|
 | `--dns-zone` | Hetzner DNS zone (e.g. `example.com`); creates `<name>.<zone>` A record |
-| `--ssh-allow-cidr` | Restrict SSH to this CIDR (e.g. `203.0.113.0/24`) instead of `0.0.0.0/0` |
+| `--ssh-allow-cidr` | Restrict SSH to this CIDR (e.g. `203.0.113.0/24`); default: your detected public IP as `/32` |
+| `--ssh-allow-any` | Open SSH to `0.0.0.0/0` — disables public-IP detection, prints a warning |
 | `--network` | Attach server to an existing private network |
 
 **Storage:**

--- a/docs/hetzner/configuration.md
+++ b/docs/hetzner/configuration.md
@@ -81,7 +81,8 @@ aiquila-hetzner rebuild --config hetzner/examples/deploy-mcp.yaml
 | `network` | string | `--network` | Attach to an existing private network |
 | `labels` | []string | `--label` | Resource labels `key=value` (repeatable) |
 | `dns_zone` | string | `--dns-zone` | Hetzner DNS zone for auto-record creation |
-| `ssh_allow_cidr` | string | `--ssh-allow-cidr` | Restrict SSH to this CIDR |
+| `ssh_allow_cidr` | string | `--ssh-allow-cidr` | Restrict SSH to this CIDR (default: your detected public IP) |
+| `ssh_allow_any` | bool | `--ssh-allow-any` | Open SSH to `0.0.0.0/0` instead |
 | `packages` | []string | `--package` | Extra OS packages via cloud-init (repeatable) |
 
 ---

--- a/hetzner/cmd/aiquila-hetzner/main.go
+++ b/hetzner/cmd/aiquila-hetzner/main.go
@@ -18,6 +18,7 @@ import (
 	hcloudclient "github.com/elgorro/aiquila/hetzner/internal/hcloud"
 	profilepkg "github.com/elgorro/aiquila/hetzner/internal/profile"
 	"github.com/elgorro/aiquila/hetzner/internal/provision"
+	"github.com/elgorro/aiquila/hetzner/internal/publicip"
 	"github.com/elgorro/aiquila/hetzner/internal/server"
 	"github.com/elgorro/aiquila/hetzner/internal/storagebox"
 	"github.com/elgorro/aiquila/hetzner/internal/volume"
@@ -52,28 +53,29 @@ var (
 	createNCAdminUser     string
 	createNCAdminPassword string
 	// Hetzner Inference (experimental) — preconfigures the AIquila app's LLM provider
-	createInferenceToken string
-	createInferenceModel string
-	createToken      string
-	createAcmeEmail  string
-	createMonitoring bool
-	createVolumeSize int
-	createLUKS       bool
+	createInferenceToken     string
+	createInferenceModel     string
+	createToken              string
+	createAcmeEmail          string
+	createMonitoring         bool
+	createVolumeSize         int
+	createLUKS               bool
 	createStorageBox         int
 	createStorageBoxPassword string
-	createDryRun     bool
-	createNoConfirm  bool
-	createLabels        []string
-	createDNSZone string
-	createSSHAllowCIDR  string
-	createNetworkName   string
-	createSwap          string
-	createConfig        string
-	createPackages      []string
+	createDryRun             bool
+	createNoConfirm          bool
+	createLabels             []string
+	createDNSZone            string
+	createSSHAllowCIDR       string
+	createSSHAllowAny        bool
+	createNetworkName        string
+	createSwap               string
+	createConfig             string
+	createPackages           []string
 
 	// destroy flags
-	destroyName     string
-	destroyToken    string
+	destroyName    string
+	destroyToken   string
 	destroyDNSZone string
 )
 
@@ -168,7 +170,10 @@ func buildCreateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&createDryRun, "dry-run", false, "Print what would be created without making any API calls")
 	cmd.Flags().StringArrayVar(&createLabels, "label", nil, "Resource label key=value (repeatable, applied to server/firewall/key/volume)")
 	cmd.Flags().StringVar(&createDNSZone, "dns-zone", "", "Hetzner DNS zone (e.g. example.com) — creates <name>.<zone> A record after server IP is known")
-	cmd.Flags().StringVar(&createSSHAllowCIDR, "ssh-allow-cidr", "", "Restrict SSH (port 22) to this CIDR instead of 0.0.0.0/0 (e.g. 203.0.113.0/24)")
+	cmd.Flags().StringVar(&createSSHAllowCIDR, "ssh-allow-cidr", "",
+		"Restrict SSH (port 22) to this CIDR (e.g. 203.0.113.0/24); default: your detected public IP")
+	cmd.Flags().BoolVar(&createSSHAllowAny, "ssh-allow-any", false,
+		"Allow SSH (port 22) from any IP (0.0.0.0/0) — disables public-IP auto-detection")
 	cmd.Flags().StringVar(&createNetworkName, "network", "", "Attach server to this private network (must exist; create with 'network create')")
 	cmd.Flags().StringVar(&createSwap, "swap", "", "Create a swap file of this size (e.g. 1G, 2G) — useful for cpx11/cx22 instances")
 	cmd.Flags().StringVar(&createConfig, "config", "", "Path to YAML or JSON deployment config file")
@@ -287,6 +292,9 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 	if createSSHAllowCIDR == "" && fileCfg.SSHAllowCIDR != "" {
 		createSSHAllowCIDR = fileCfg.SSHAllowCIDR
 	}
+	if !cmd.Flags().Changed("ssh-allow-any") && fileCfg.SSHAllowAny {
+		createSSHAllowAny = true
+	}
 	if createNCDomain == "" && fileCfg.NCDomain != "" {
 		createNCDomain = fileCfg.NCDomain
 	}
@@ -376,6 +384,14 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 		createLUKS = false
 	}
 
+	// Resolve the SSH firewall source before anything is created, so a bad CIDR
+	// fails before a server is billed. Under --dry-run we never reach out to the
+	// network; the plan just states that detection happens at create time.
+	sshSourceDesc, err := resolveSSHAllowCIDR(context.Background(), createDryRun)
+	if err != nil {
+		return err
+	}
+
 	if createName == "" {
 		createName = "aiquila-" + randomSuffix(6)
 	}
@@ -388,7 +404,7 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 
 	// ── 5. Dry-run — print plan and exit ───────────────────────────────────
 	if createDryRun {
-		return printDryRun(createSwap, packages)
+		return printDryRun(createSwap, packages, sshSourceDesc)
 	}
 
 	// ── 5b. Cost confirmation ───────────────────────────────────────────────
@@ -1229,7 +1245,56 @@ func runDestroy(_ *cobra.Command, _ []string) error {
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-func printDryRun(swapSize string, packages []string) error {
+// resolveSSHAllowCIDR settles what the firewall's inbound TCP 22 rule will
+// allow and returns a human-readable description of the source for the plan
+// output. It mutates createSSHAllowCIDR, which is what firewall.Setup consumes.
+//
+// Precedence: an explicit --ssh-allow-cidr, then --ssh-allow-any, then this
+// machine's detected public IP. Detection failures never block a deploy — they
+// fall back to the world-open default with a warning.
+func resolveSSHAllowCIDR(ctx context.Context, dryRun bool) (string, error) {
+	const anyCIDR = "0.0.0.0/0"
+
+	if createSSHAllowCIDR != "" && createSSHAllowAny {
+		return "", fmt.Errorf("--ssh-allow-cidr and --ssh-allow-any are mutually exclusive")
+	}
+
+	if createSSHAllowCIDR != "" {
+		if _, err := firewall.ParseSSHSources(createSSHAllowCIDR); err != nil {
+			return "", err
+		}
+		appLog.Info("firewall", "ssh source from --ssh-allow-cidr", "cidr", createSSHAllowCIDR)
+		return createSSHAllowCIDR, nil
+	}
+
+	if createSSHAllowAny {
+		fmt.Fprintln(os.Stderr, "WARNING: --ssh-allow-any: SSH (port 22) will be reachable from any IP")
+		createSSHAllowCIDR = anyCIDR
+		appLog.Info("firewall", "ssh open to all IPs (--ssh-allow-any)", "cidr", anyCIDR)
+		return anyCIDR + " (any IP)", nil
+	}
+
+	if dryRun {
+		return "your detected public IP (auto-detected at create time)", nil
+	}
+
+	ip, err := publicip.Detect(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"WARNING: could not detect your public IP (%v); SSH (port 22) will be open to %s — "+
+				"pass --ssh-allow-cidr to restrict it\n", err, anyCIDR)
+		createSSHAllowCIDR = anyCIDR
+		appLog.Info("firewall", "public IP detection failed; ssh open to all IPs", "error", err.Error())
+		return anyCIDR + " (any IP)", nil
+	}
+
+	createSSHAllowCIDR = publicip.CIDR(ip)
+	fmt.Printf("No --ssh-allow-cidr specified, restricting SSH to your current IP: %s\n", createSSHAllowCIDR)
+	appLog.Info("firewall", "ssh restricted to detected public IP", "cidr", createSSHAllowCIDR)
+	return createSSHAllowCIDR + " (auto-detected)", nil
+}
+
+func printDryRun(swapSize string, packages []string, sshSourceDesc string) error {
 	home, _ := os.UserHomeDir()
 	keyDesc := "generate Ed25519 → " + home + "/.ssh/aiquila_ed25519"
 	if createSSHKey != "" {
@@ -1263,6 +1328,7 @@ func printDryRun(swapSize string, packages []string) error {
   Stack:     %s
   Server:    %s (%s, %s, %s)
   Firewall:  %s-fw  (TCP 22/80/443, UDP 443)
+  SSH from:  %s
   SSH key:   %s-key  (%s)
   Volume:    %s
   MCP Domain: %s
@@ -1277,6 +1343,7 @@ func printDryRun(swapSize string, packages []string) error {
 		createStack,
 		createName, createType, createImage, createLocation,
 		createName,
+		sshSourceDesc,
 		createName, keyDesc,
 		volumeDesc,
 		createMCPDomain,

--- a/hetzner/cmd/aiquila-hetzner/rebuild.go
+++ b/hetzner/cmd/aiquila-hetzner/rebuild.go
@@ -22,37 +22,38 @@ import (
 // DeployConfig holds the deployment parameters that can be supplied via a
 // YAML or JSON config file (keys match flag names, snake_case).
 type DeployConfig struct {
-	Name       string `yaml:"name"        json:"name"`
-	Domain     string `yaml:"domain"      json:"domain"`
-	NCURL      string `yaml:"nc_url"      json:"nc_url"`
-	NCUser     string `yaml:"nc_user"     json:"nc_user"`
-	NCPassword string `yaml:"nc_password" json:"nc_password"`
+	Name       string   `yaml:"name"        json:"name"`
+	Domain     string   `yaml:"domain"      json:"domain"`
+	NCURL      string   `yaml:"nc_url"      json:"nc_url"`
+	NCUser     string   `yaml:"nc_user"     json:"nc_user"`
+	NCPassword string   `yaml:"nc_password" json:"nc_password"`
 	AcmeEmail  string   `yaml:"acme_email"  json:"acme_email"`
 	Monitoring bool     `yaml:"monitoring"  json:"monitoring"`
 	SSHKey     string   `yaml:"ssh_key"     json:"ssh_key"`
 	Token      string   `yaml:"token"       json:"token"`
 	Packages   []string `yaml:"packages"    json:"packages"`
 	// Infrastructure
-	Stack      string `yaml:"stack"       json:"stack"`
-	Image      string `yaml:"image"       json:"image"`
-	Location   string `yaml:"location"    json:"location"`
-	Type       string `yaml:"type"        json:"type"`
-	Swap       string `yaml:"swap"        json:"swap"`
-	VolumeSize int    `yaml:"volume_size" json:"volume_size"`
-	LUKS       bool   `yaml:"luks"        json:"luks"`
-	StorageBox         int    `yaml:"storage_box"          json:"storage_box"`
-	StorageBoxPassword string `yaml:"storage_box_password" json:"storage_box_password"`
-	Network    string `yaml:"network"     json:"network"`
-	Labels     []string `yaml:"labels"    json:"labels"`
+	Stack              string   `yaml:"stack"       json:"stack"`
+	Image              string   `yaml:"image"       json:"image"`
+	Location           string   `yaml:"location"    json:"location"`
+	Type               string   `yaml:"type"        json:"type"`
+	Swap               string   `yaml:"swap"        json:"swap"`
+	VolumeSize         int      `yaml:"volume_size" json:"volume_size"`
+	LUKS               bool     `yaml:"luks"        json:"luks"`
+	StorageBox         int      `yaml:"storage_box"          json:"storage_box"`
+	StorageBoxPassword string   `yaml:"storage_box_password" json:"storage_box_password"`
+	Network            string   `yaml:"network"     json:"network"`
+	Labels             []string `yaml:"labels"    json:"labels"`
 	// DNS
 	DNSZone  string `yaml:"dns_zone"  json:"dns_zone"`
 	DNSToken string `yaml:"dns_token" json:"dns_token"` // deprecated: DNS uses the Cloud API token
 	// SSH
 	SSHAllowCIDR string `yaml:"ssh_allow_cidr" json:"ssh_allow_cidr"`
+	SSHAllowAny  bool   `yaml:"ssh_allow_any" json:"ssh_allow_any"`
 	// Nextcloud self-hosted (--stack nextcloud/full)
-	NCDomain         string `yaml:"nc_domain"          json:"nc_domain"`
-	NCAdminUser      string `yaml:"nc_admin_user"      json:"nc_admin_user"`
-	NCAdminPassword  string `yaml:"nc_admin_password"  json:"nc_admin_password"`
+	NCDomain        string `yaml:"nc_domain"          json:"nc_domain"`
+	NCAdminUser     string `yaml:"nc_admin_user"      json:"nc_admin_user"`
+	NCAdminPassword string `yaml:"nc_admin_password"  json:"nc_admin_password"`
 	// Hetzner Inference (experimental) — preconfigures the AIquila LLM provider
 	InferenceToken string `yaml:"hetzner_inference_token" json:"hetzner_inference_token"`
 	InferenceModel string `yaml:"hetzner_inference_model" json:"hetzner_inference_model"`

--- a/hetzner/internal/firewall/setup.go
+++ b/hetzner/internal/firewall/setup.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
+	"strings"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
@@ -15,23 +17,25 @@ import (
 // firewall with the same name already exists, it is reused.
 //
 // sshCIDR restricts SSH access to the given CIDR (e.g. "203.0.113.0/24").
-// Pass "" to allow SSH from anywhere (0.0.0.0/0 and ::/0).
+// Pass "" to allow SSH from anywhere (0.0.0.0/0 and ::/0) — callers should
+// resolve a concrete CIDR up front rather than relying on that default.
 func Setup(ctx context.Context, client *hcloud.Client, name string, server *hcloud.Server, labels map[string]string, sshCIDR string) (*hcloud.Firewall, error) {
 	existing, _, err := client.Firewall.GetByName(ctx, name)
 	if err != nil {
 		return nil, fmt.Errorf("look up firewall %q: %w", name, err)
 	}
+	sshSources, err := ParseSSHSources(sshCIDR)
+	if err != nil {
+		return nil, err
+	}
+
 	if existing != nil {
 		fmt.Printf("  Reusing existing firewall %q (id=%d)\n", name, existing.ID)
+		warnSSHRuleMismatch(existing, sshSources)
 		if err := attach(ctx, client, existing, server); err != nil {
 			return nil, err
 		}
 		return existing, nil
-	}
-
-	sshSources, err := parseSSHSources(sshCIDR)
-	if err != nil {
-		return nil, err
 	}
 
 	rules := []hcloud.FirewallRule{
@@ -88,7 +92,61 @@ func tcpRuleWithSources(port int, description string, sources []net.IPNet) hclou
 	}
 }
 
-func parseSSHSources(sshCIDR string) ([]net.IPNet, error) {
+// warnSSHRuleMismatch reports when an existing firewall we are about to reuse
+// permits SSH from somewhere other than what was requested. The firewall may
+// have been tuned by hand, so it is never modified here.
+func warnSSHRuleMismatch(fw *hcloud.Firewall, want []net.IPNet) {
+	for _, rule := range fw.Rules {
+		if rule.Direction != hcloud.FirewallRuleDirectionIn ||
+			rule.Protocol != hcloud.FirewallRuleProtocolTCP ||
+			rule.Port == nil || *rule.Port != "22" {
+			continue
+		}
+		if sameSources(rule.SourceIPs, want) {
+			return
+		}
+		fmt.Fprintf(os.Stderr,
+			"WARNING: existing firewall %q allows SSH from %s, not %s — not modified; "+
+				"edit it in the Hetzner console or delete it to have it recreated\n",
+			fw.Name, joinNets(rule.SourceIPs), joinNets(want))
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"WARNING: existing firewall %q has no inbound TCP 22 rule — SSH may be unreachable\n", fw.Name)
+}
+
+func sameSources(a, b []net.IPNet) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[string]int, len(a))
+	for _, n := range a {
+		seen[n.String()]++
+	}
+	for _, n := range b {
+		key := n.String()
+		if seen[key] == 0 {
+			return false
+		}
+		seen[key]--
+	}
+	return true
+}
+
+func joinNets(nets []net.IPNet) string {
+	parts := make([]string, 0, len(nets))
+	for _, n := range nets {
+		parts = append(parts, n.String())
+	}
+	if len(parts) == 0 {
+		return "(nothing)"
+	}
+	return strings.Join(parts, ", ")
+}
+
+// ParseSSHSources turns a CIDR string into firewall source networks. An empty
+// string yields the world-open default (0.0.0.0/0 and ::/0).
+func ParseSSHSources(sshCIDR string) ([]net.IPNet, error) {
 	if sshCIDR == "" {
 		return []net.IPNet{
 			{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)},

--- a/hetzner/internal/firewall/setup_test.go
+++ b/hetzner/internal/firewall/setup_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+
+package firewall
+
+import (
+	"net"
+	"testing"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+func TestParseSSHSources(t *testing.T) {
+	cases := []struct {
+		name    string
+		cidr    string
+		want    []string
+		wantErr bool
+	}{
+		{name: "empty is world-open", cidr: "", want: []string{"0.0.0.0/0", "::/0"}},
+		{name: "ipv4 network", cidr: "203.0.113.0/24", want: []string{"203.0.113.0/24"}},
+		{name: "ipv4 single host", cidr: "203.0.113.7/32", want: []string{"203.0.113.7/32"}},
+		{name: "ipv6 host", cidr: "2001:db8::1/128", want: []string{"2001:db8::1/128"}},
+		{name: "host bits are masked off", cidr: "203.0.113.7/24", want: []string{"203.0.113.0/24"}},
+		{name: "address without prefix", cidr: "203.0.113.7", wantErr: true},
+		{name: "garbage", cidr: "not-a-cidr", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseSSHSources(tc.cidr)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseSSHSources(%q) = %v, want error", tc.cidr, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseSSHSources(%q): %v", tc.cidr, err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d sources (%v), want %d", len(got), got, len(tc.want))
+			}
+			for i, want := range tc.want {
+				if got[i].String() != want {
+					t.Errorf("source %d = %s, want %s", i, got[i].String(), want)
+				}
+			}
+		})
+	}
+}
+
+func mustCIDR(t *testing.T, s string) net.IPNet {
+	t.Helper()
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return *n
+}
+
+func TestSameSources(t *testing.T) {
+	a := []net.IPNet{mustCIDR(t, "0.0.0.0/0"), mustCIDR(t, "::/0")}
+	reordered := []net.IPNet{mustCIDR(t, "::/0"), mustCIDR(t, "0.0.0.0/0")}
+	other := []net.IPNet{mustCIDR(t, "203.0.113.7/32")}
+
+	if !sameSources(a, reordered) {
+		t.Error("sameSources should ignore ordering")
+	}
+	if sameSources(a, other) {
+		t.Error("different sources reported as equal")
+	}
+	if sameSources(a, other[:0]) {
+		t.Error("different lengths reported as equal")
+	}
+}
+
+func TestWarnSSHRuleMismatchFindsRule(t *testing.T) {
+	port := "22"
+	fw := &hcloud.Firewall{
+		Name: "example-fw",
+		Rules: []hcloud.FirewallRule{{
+			Direction: hcloud.FirewallRuleDirectionIn,
+			Protocol:  hcloud.FirewallRuleProtocolTCP,
+			Port:      &port,
+			SourceIPs: []net.IPNet{mustCIDR(t, "203.0.113.7/32")},
+		}},
+	}
+
+	// Matching sources must not be reported; this only asserts the lookup and
+	// comparison agree — the warning itself goes to stderr.
+	want, err := ParseSSHSources("203.0.113.7/32")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameSources(fw.Rules[0].SourceIPs, want) {
+		t.Error("expected the TCP/22 rule to match the requested source")
+	}
+	warnSSHRuleMismatch(fw, want)
+}
+
+func TestJoinNets(t *testing.T) {
+	if got := joinNets(nil); got != "(nothing)" {
+		t.Errorf("joinNets(nil) = %q", got)
+	}
+	got := joinNets([]net.IPNet{mustCIDR(t, "0.0.0.0/0"), mustCIDR(t, "::/0")})
+	if got != "0.0.0.0/0, ::/0" {
+		t.Errorf("joinNets = %q", got)
+	}
+}

--- a/hetzner/internal/publicip/detect.go
+++ b/hetzner/internal/publicip/detect.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+
+// Package publicip discovers the public IP address of the machine running the
+// CLI, so firewall rules can be scoped to the operator instead of the internet.
+package publicip
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// defaultEndpoints are queried in order; the first usable answer wins. Each one
+// returns the caller's address as a bare string body.
+var defaultEndpoints = []string{
+	"https://api.ipify.org",
+	"https://ifconfig.co/ip",
+}
+
+// timeout bounds the whole detection attempt per endpoint.
+const timeout = 5 * time.Second
+
+// Detect returns the public IP address of this machine.
+func Detect(ctx context.Context) (net.IP, error) {
+	return detect(ctx, defaultEndpoints)
+}
+
+func detect(ctx context.Context, endpoints []string) (net.IP, error) {
+	client := &http.Client{Timeout: timeout}
+
+	var lastErr error
+	for _, endpoint := range endpoints {
+		ip, err := query(ctx, client, endpoint)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return ip, nil
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no endpoints configured")
+	}
+	return nil, fmt.Errorf("detect public IP: %w", lastErr)
+}
+
+func query(ctx context.Context, client *http.Client, endpoint string) (net.IP, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", endpoint, err)
+	}
+	req.Header.Set("User-Agent", "aiquila-hetzner")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", endpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: unexpected status %s", endpoint, resp.Status)
+	}
+
+	// Cap the read — these services answer with a short address, anything
+	// larger is a captive portal or an error page.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 128))
+	if err != nil {
+		return nil, fmt.Errorf("%s: read response: %w", endpoint, err)
+	}
+
+	ip := net.ParseIP(strings.TrimSpace(string(body)))
+	if ip == nil {
+		return nil, fmt.Errorf("%s: response is not an IP address", endpoint)
+	}
+	if !isPublic(ip) {
+		return nil, fmt.Errorf("%s: returned non-public address %s", endpoint, ip)
+	}
+	return ip, nil
+}
+
+func isPublic(ip net.IP) bool {
+	return !ip.IsUnspecified() &&
+		!ip.IsLoopback() &&
+		!ip.IsPrivate() &&
+		!ip.IsLinkLocalUnicast() &&
+		!ip.IsLinkLocalMulticast() &&
+		!ip.IsMulticast()
+}
+
+// CIDR renders ip as a single-host CIDR (/32 for IPv4, /128 for IPv6).
+func CIDR(ip net.IP) string {
+	if v4 := ip.To4(); v4 != nil {
+		return v4.String() + "/32"
+	}
+	return ip.String() + "/128"
+}

--- a/hetzner/internal/publicip/detect_test.go
+++ b/hetzner/internal/publicip/detect_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+
+package publicip
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func serve(t *testing.T, status int, body string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestDetect(t *testing.T) {
+	ok := serve(t, http.StatusOK, "203.0.113.7\n")
+	bad := serve(t, http.StatusOK, "<html>captive portal</html>")
+	private := serve(t, http.StatusOK, "10.0.0.1")
+	boom := serve(t, http.StatusInternalServerError, "nope")
+
+	cases := []struct {
+		name      string
+		endpoints []string
+		want      string
+		wantErr   bool
+	}{
+		{name: "first endpoint answers", endpoints: []string{ok, bad}, want: "203.0.113.7"},
+		{name: "falls through non-IP body", endpoints: []string{bad, ok}, want: "203.0.113.7"},
+		{name: "falls through private address", endpoints: []string{private, ok}, want: "203.0.113.7"},
+		{name: "falls through error status", endpoints: []string{boom, ok}, want: "203.0.113.7"},
+		{name: "all endpoints fail", endpoints: []string{bad, boom}, wantErr: true},
+		{name: "no endpoints", endpoints: nil, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := detect(context.Background(), tc.endpoints)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("detect = %v, want error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("detect: %v", err)
+			}
+			if got.String() != tc.want {
+				t.Errorf("detect = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCIDR(t *testing.T) {
+	if got := CIDR(net.ParseIP("203.0.113.7")); got != "203.0.113.7/32" {
+		t.Errorf("CIDR(v4) = %q", got)
+	}
+	if got := CIDR(net.ParseIP("2001:db8::1")); got != "2001:db8::1/128" {
+		t.Errorf("CIDR(v6) = %q", got)
+	}
+}

--- a/hetzner/scripts/integration-test.ts
+++ b/hetzner/scripts/integration-test.ts
@@ -94,7 +94,8 @@ Your job:
      --nc-admin-password NC_PASS_VALUE \\
      --name "NC_NAME_VALUE" \\
      --type NC_SERVER_TYPE \\
-     --dns-zone DNS_ZONE
+     --dns-zone DNS_ZONE \\
+     --ssh-allow-any
 
 4. While NC is provisioning (or after), provision the MCP server (MCP_SERVER_TYPE, default cpx11):
    /tmp/aiquila-hetzner create \\
@@ -105,7 +106,8 @@ Your job:
      --nc-password NC_PASS_VALUE \\
      --name "MCP_NAME_VALUE" \\
      --type MCP_SERVER_TYPE \\
-     --dns-zone DNS_ZONE
+     --dns-zone DNS_ZONE \\
+     --ssh-allow-any
 
    Note: The NC server creates an app password via OCC; use the Nextcloud admin password
    as the --nc-password if no separate app password was generated.


### PR DESCRIPTION
## Problem

`hetzner/internal/firewall/setup.go` returned `0.0.0.0/0` + `::/0` for the inbound TCP 22 rule whenever `--ssh-allow-cidr` was empty, and printed nothing. Every deploy that omitted the flag — including `hetzner/scripts/integration-test.ts` and all `hetzner/examples/*.yaml` — silently exposed SSH to the internet. CrowdSec mitigates brute force but not network exposure.

## Change

`create` now resolves the SSH firewall source during pre-flight, before any Hetzner API call:

| Case | Result |
|---|---|
| `--ssh-allow-cidr X` | validated up front — an invalid CIDR used to fail only inside `firewall.Setup`, i.e. after the server was created and billed |
| `--ssh-allow-any` (new) | `0.0.0.0/0` + `WARNING: … SSH (port 22) will be reachable from any IP` |
| neither (default) | detect this machine's public IP → `<ip>/32`, printing `No --ssh-allow-cidr specified, restricting SSH to your current IP: …` |
| detection failed | `0.0.0.0/0` + loud warning — an offline or firewalled workstation never blocks a deploy |

Passing both flags is an error. Detection is skipped under `--dry-run`; the plan output gained an `SSH from:` line. Outcomes are recorded through the existing `appLog` audit logger.

Adjacent gaps fixed in the same pass:

- **Late validation** — CIDR parsing moved ahead of server creation (`firewall.parseSSHSources` exported as `ParseSSHSources`).
- **Silent reuse** — `firewall.Setup` reused an existing firewall by name as-is, ignoring the requested CIDR on re-runs. It now warns when the existing TCP/22 rule differs. It deliberately does **not** rewrite the rule, since the firewall may have been tuned by hand; the warning points at the console.

## New package

`hetzner/internal/publicip` — `Detect` queries `api.ipify.org` then `ifconfig.co/ip` with a 5s timeout, caps the response read, and rejects unspecified/loopback/private/link-local answers. `CIDR` renders `/32` or `/128`. No new module dependencies. Note this is the first outbound HTTP call the CLI makes on its own behalf, and it runs on every default `create`.

## Tests & CI

There were **no Go tests anywhere under `hetzner/`** and no Go job in CI. This adds `internal/firewall/setup_test.go` and `internal/publicip/detect_test.go` (httptest-driven, covering fallthrough on bad body / private address / error status / all-endpoints-fail), plus a `hetzner-cli` job in `.github/workflows/test.yml` running `go vet ./...` and `go test ./...` so they actually run.

`hetzner/scripts/integration-test.ts` now passes `--ssh-allow-any` on both `create` invocations, keeping the CI provisioning path explicit rather than relying on runner egress IP.

## Docs

`docs/hetzner/advanced.md` (SSH section rewritten around the new default, incl. how to change the CIDR of an existing firewall), `docs/hetzner/commands.md`, `docs/hetzner/configuration.md` (`ssh_allow_any` config key).

## Verification

`go build`, `go vet`, `go test ./...` pass. Exercised the CLI: invalid CIDR and the flag conflict both exit 1 before any API call; dry-run shows `SSH from: your detected public IP (auto-detected at create time)` and `0.0.0.0/0 (any IP)` under `--ssh-allow-any`. Live detection returned a correct `/32`; forcing a dead proxy exercised the fallback warning.

Not done: a real end-to-end provision against Hetzner (needs a live token and incurs cost).

Note: `gofmt` normalized the `DeployConfig` struct alignment in `rebuild.go`, so that file carries some mechanical churn beyond the one added field.

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)