### PR TITLE
fix(docker): add memory, CPU and pids limits to all compose services

### DIFF
--- a/docker/installation/docker-compose.yml
+++ b/docker/installation/docker-compose.yml
@@ -1,3 +1,7 @@
+# AIquila dev stack (local development).
+# Resource limits below are deliberately looser than the production stacks in
+# hetzner/docker/* — they exist to contain runaway processes, not to model prod
+# sizing (the dev MCP server runs a tsx watcher and Nextcloud rebuilds assets).
 services:
   # PostgreSQL Database
   db:
@@ -19,6 +23,12 @@ services:
       retries: 5
     networks:
       - aiquila-network
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: '1.0'
+          pids: 200
 
   # Redis Cache
   redis:
@@ -35,6 +45,12 @@ services:
       retries: 5
     networks:
       - aiquila-network
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: '0.5'
+          pids: 100
 
   # Nextcloud with AIquila installed from tarball
   nextcloud:
@@ -87,6 +103,12 @@ services:
       - "8080:80"
     networks:
       - aiquila-network
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: '2.0'
+          pids: 400
 
   # MCP Server (Development)
   mcp-server:
@@ -116,6 +138,12 @@ services:
       - "3339:3339"
     networks:
       - aiquila-network
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: '2.0'
+          pids: 300
 
   # Caddy Reverse Proxy (HTTPS)
   caddy:
@@ -134,6 +162,12 @@ services:
       - caddy_config:/config
     networks:
       - aiquila-network
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: '1.0'
+          pids: 100
 
   # MailHog (Email Testing)
   mailhog:
@@ -145,6 +179,12 @@ services:
       - "1025:1025"  # SMTP
     networks:
       - aiquila-network
+    deploy:
+      resources:
+        limits:
+          memory: 128m
+          cpus: '0.5'
+          pids: 50
 
   # Adminer (Database UI)
   adminer:
@@ -160,6 +200,12 @@ services:
       - "8081:8080"
     networks:
       - aiquila-network
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: '0.5'
+          pids: 100
 
 volumes:
   postgres_data:

--- a/docker/standalone/docker-compose.yml
+++ b/docker/standalone/docker-compose.yml
@@ -34,6 +34,12 @@ services:
       - standalone_mcp_state:/app/state
     networks:
       - aiquila-standalone-network
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: '1.0'
+          pids: 100
 
   # Caddy Reverse Proxy (HTTPS)
   caddy:
@@ -54,6 +60,12 @@ services:
       - standalone_caddy_config:/config
     networks:
       - aiquila-standalone-network
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: '1.0'
+          pids: 100
 
 volumes:
   standalone_mcp_state:

--- a/hetzner/docker/full/docker-compose.yml
+++ b/hetzner/docker/full/docker-compose.yml
@@ -56,6 +56,8 @@ services:
       resources:
         limits:
           memory: 1g
+          cpus: '2.0'
+          pids: 400
     logging:
       driver: "json-file"
       options:
@@ -85,6 +87,8 @@ services:
       resources:
         limits:
           memory: 512m
+          cpus: '1.0'
+          pids: 200
         reservations:
           memory: 256m
     logging:
@@ -105,6 +109,8 @@ services:
       resources:
         limits:
           memory: 256m
+          cpus: '0.5'
+          pids: 100
         reservations:
           memory: 128m
     logging:
@@ -154,6 +160,8 @@ services:
       resources:
         limits:
           memory: 512m
+          cpus: '1.0'
+          pids: 100
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:' + (process.env.MCP_PORT||'3339') + '/health', r => process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
       interval: 30s
@@ -182,6 +190,8 @@ services:
       resources:
         limits:
           memory: 64m
+          cpus: '0.5'
+          pids: 50
         reservations:
           memory: 32m
     logging:
@@ -210,6 +220,8 @@ services:
       resources:
         limits:
           memory: 256m
+          cpus: '1.0'
+          pids: 100
         reservations:
           memory: 128m
     logging:
@@ -235,6 +247,8 @@ services:
       resources:
         limits:
           memory: 512m
+          cpus: '1.0'
+          pids: 200
         reservations:
           memory: 256m
     logging:

--- a/hetzner/docker/mcp/docker-compose.yml
+++ b/hetzner/docker/mcp/docker-compose.yml
@@ -54,6 +54,8 @@ services:
       resources:
         limits:
           memory: 512m
+          cpus: '1.0'
+          pids: 100
     logging:
       driver: "json-file"
       options:
@@ -76,6 +78,8 @@ services:
       resources:
         limits:
           memory: 64m
+          cpus: '0.5'
+          pids: 50
         reservations:
           memory: 32m
     logging:
@@ -104,6 +108,8 @@ services:
       resources:
         limits:
           memory: 256m
+          cpus: '1.0'
+          pids: 100
         reservations:
           memory: 128m
     logging:
@@ -129,6 +135,8 @@ services:
       resources:
         limits:
           memory: 512m
+          cpus: '1.0'
+          pids: 200
         reservations:
           memory: 256m
     logging:
@@ -159,6 +167,8 @@ services:
       resources:
         limits:
           memory: 128m
+          cpus: '0.5'
+          pids: 100
         reservations:
           memory: 64m
     logging:
@@ -190,6 +200,8 @@ services:
       resources:
         limits:
           memory: 256m
+          cpus: '0.5'
+          pids: 150
         reservations:
           memory: 128m
     logging:
@@ -212,6 +224,8 @@ services:
       resources:
         limits:
           memory: 512m
+          cpus: '1.0'
+          pids: 150
         reservations:
           memory: 256m
     logging:
@@ -243,6 +257,8 @@ services:
       resources:
         limits:
           memory: 256m
+          cpus: '1.0'
+          pids: 150
         reservations:
           memory: 128m
     logging:

--- a/hetzner/docker/nextcloud/docker-compose.yml
+++ b/hetzner/docker/nextcloud/docker-compose.yml
@@ -55,6 +55,8 @@ services:
       resources:
         limits:
           memory: 1g
+          cpus: '2.0'
+          pids: 400
     logging:
       driver: "json-file"
       options:
@@ -84,6 +86,8 @@ services:
       resources:
         limits:
           memory: 512m
+          cpus: '1.0'
+          pids: 200
         reservations:
           memory: 256m
     logging:
@@ -104,6 +108,8 @@ services:
       resources:
         limits:
           memory: 256m
+          cpus: '0.5'
+          pids: 100
         reservations:
           memory: 128m
     logging:
@@ -127,6 +133,8 @@ services:
       resources:
         limits:
           memory: 64m
+          cpus: '0.5'
+          pids: 50
         reservations:
           memory: 32m
     logging:
@@ -155,6 +163,8 @@ services:
       resources:
         limits:
           memory: 256m
+          cpus: '1.0'
+          pids: 100
         reservations:
           memory: 128m
     logging:
@@ -180,6 +190,8 @@ services:
       resources:
         limits:
           memory: 512m
+          cpus: '1.0'
+          pids: 200
         reservations:
           memory: 256m
     logging:


### PR DESCRIPTION
## Summary

Every service in all five compose files now declares `deploy.resources.limits` with `memory`, `cpus` and `pids`:

- `docker/standalone/` and `docker/installation/` had no limits at all.
- The three `hetzner/docker/*` stacks had memory limits only — CPU and pids added.

pids values are higher than the issue's suggested 100 where the workload warrants it (Nextcloud apache/php-fpm: 400, dev MCP tsx watcher: 300); a cap that trips under normal load would be worse than none. The dev stack carries a header comment noting its limits are intentionally looser than production.

## Verification

- `docker compose config -q` passes for all five files (plus the mcp `monitoring` profile); `pids` and `cpus` survive rendering, so they are honored by Compose v2 in non-swarm mode.
- Dev stack brought up with `make up`: all 7 containers running, 0 restarts, no OOM kills, `docker inspect` confirms `Memory`/`NanoCpus`/`PidsLimit` are applied.
- Exercised under the caps: Nextcloud `status.php` + dashboard widget API (200), `occ status`, MCP `initialize` over HTTP — all fine; no new ERROR/FATAL lines in `nextcloud.log`. Peak usage well below limits (NC 108 MiB/1 GiB, MCP 163 MiB/1 GiB).

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)