### PR TITLE
feat(mcp): close Maps API coverage gaps and add myMapId scoping

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ Complete documentation for the AIquila Nextcloud app and MCP server.
 | Contacts (CardDAV) | 6 | [Contacts](mcp/tools/apps/contacts.md) |
 | Email | 8 | [Mail](mcp/tools/apps/mail.md) |
 | Bookmarks, folders, tags | 13 | [Bookmarks](mcp/tools/apps/bookmarks.md) |
-| Maps, GPS, tracks, photos | 26 | [Maps](mcp/tools/apps/maps.md) |
+| Maps, GPS, tracks, photos, contacts | 40 | [Maps](mcp/tools/apps/maps.md) |
 | Notes | 5 | [Notes](mcp/tools/apps/notes.md) |
 | News (RSS feeds) | 17 | [News](mcp/tools/apps/news.md) |
 | Recipes | 6 | [Cookbook](mcp/tools/apps/cookbook.md) |

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -33,7 +33,7 @@ Nextcloud apps and administration:
 - **Contacts** — Full CRUD for contacts with structured fields (CardDAV)
 - **Mail** — Email accounts, mailboxes, messages, send, and flags
 - **Bookmarks** — Bookmark CRUD, folder hierarchy, and tag management
-- **Maps** — Favorites, GPS devices/tracks, photo geotagging, custom maps, import/export
+- **Maps** — Favorites, category/device sharing, GPS devices/tracks, photo geotagging, contacts, custom maps, import/export
 - **Notes** — Markdown notes with categories and search
 - **News** — RSS/Atom feed subscriptions, folders, and article reading/triage
 - **Polls** — Create text/date polls, vote, comment, and share
@@ -162,13 +162,18 @@ Nextcloud apps and administration:
 | `rename_bookmark_tag` | Rename a tag | [Bookmarks](tools/apps/bookmarks.md#rename_bookmark_tag) |
 | `delete_bookmark_tag` | Delete a tag | [Bookmarks](tools/apps/bookmarks.md#delete_bookmark_tag) |
 
-#### Maps (26 tools)
+#### Maps (40 tools)
 | Tool | Description | Documentation |
 |------|-------------|---------------|
 | `list_map_favorites` | List saved locations | [Maps](tools/apps/maps.md#list_map_favorites) |
 | `create_map_favorite` | Create a favorite | [Maps](tools/apps/maps.md#create_map_favorite) |
 | `update_map_favorite` | Update a favorite | [Maps](tools/apps/maps.md#update_map_favorite) |
 | `delete_map_favorite` | Delete a favorite | [Maps](tools/apps/maps.md#delete_map_favorite) |
+| `rename_map_favorite_category` | Rename favorite categories | [Maps](tools/apps/maps.md#rename_map_favorite_category) |
+| `list_shared_map_categories` | List shared favorite categories | [Maps](tools/apps/maps.md#list_shared_map_categories) |
+| `share_map_category` | Share a category via link | [Maps](tools/apps/maps.md#share_map_category) |
+| `unshare_map_category` | Revoke a category share | [Maps](tools/apps/maps.md#unshare_map_category) |
+| `add_shared_category_to_map` | Add a shared category to a map | [Maps](tools/apps/maps.md#add_shared_category_to_map) |
 | `export_map_favorites` | Export favorites as GPX | [Maps](tools/apps/maps.md#export_map_favorites) |
 | `import_map_favorites` | Import favorites from file | [Maps](tools/apps/maps.md#import_map_favorites) |
 | `list_map_devices` | List GPS devices | [Maps](tools/apps/maps.md#list_map_devices) |
@@ -178,6 +183,10 @@ Nextcloud apps and administration:
 | `delete_map_device` | Delete a device | [Maps](tools/apps/maps.md#delete_map_device) |
 | `export_map_devices` | Export device data as GPX | [Maps](tools/apps/maps.md#export_map_devices) |
 | `import_map_devices` | Import device data | [Maps](tools/apps/maps.md#import_map_devices) |
+| `share_map_device` | Share a device via link | [Maps](tools/apps/maps.md#share_map_device) |
+| `list_shared_map_devices` | List device shares on a map | [Maps](tools/apps/maps.md#list_shared_map_devices) |
+| `remove_map_device_share` | Revoke a device share | [Maps](tools/apps/maps.md#remove_map_device_share) |
+| `add_shared_device_to_map` | Add a shared device to a map | [Maps](tools/apps/maps.md#add_shared_device_to_map) |
 | `list_map_tracks` | List GPS tracks | [Maps](tools/apps/maps.md#list_map_tracks) |
 | `get_map_track` | Get track details/content | [Maps](tools/apps/maps.md#get_map_track) |
 | `update_map_track` | Update track metadata | [Maps](tools/apps/maps.md#update_map_track) |
@@ -186,6 +195,12 @@ Nextcloud apps and administration:
 | `list_map_photos_nonlocalized` | List photos without GPS | [Maps](tools/apps/maps.md#list_map_photos_nonlocalized) |
 | `place_map_photos` | Set GPS coords on photos | [Maps](tools/apps/maps.md#place_map_photos) |
 | `reset_map_photo_coords` | Remove GPS from photos | [Maps](tools/apps/maps.md#reset_map_photo_coords) |
+| `get_map_photo_job_status` | Photo geolocation job status | [Maps](tools/apps/maps.md#get_map_photo_job_status) |
+| `list_map_contacts` | List contacts with addresses | [Maps](tools/apps/maps.md#list_map_contacts) |
+| `search_map_contacts` | Search contacts by name | [Maps](tools/apps/maps.md#search_map_contacts) |
+| `place_map_contact` | Put a contact on the map | [Maps](tools/apps/maps.md#place_map_contact) |
+| `add_contact_to_map` | Copy a contact into a map | [Maps](tools/apps/maps.md#add_contact_to_map) |
+| `delete_map_contact_address` | Remove a contact's address | [Maps](tools/apps/maps.md#delete_map_contact_address) |
 | `list_maps` | List custom maps | [Maps](tools/apps/maps.md#list_maps) |
 | `create_map` | Create a custom map | [Maps](tools/apps/maps.md#create_map) |
 | `update_map` | Update a custom map | [Maps](tools/apps/maps.md#update_map) |

--- a/docs/mcp/tools/apps/maps.md
+++ b/docs/mcp/tools/apps/maps.md
@@ -1,11 +1,22 @@
 # Nextcloud Maps Tools
 
-Integration with Nextcloud Maps app. Manage favorites, GPS devices, tracks, photos, and custom maps through Claude.
+Integration with Nextcloud Maps app. Manage favorites, favorite/device shares, GPS devices,
+tracks, photos, contacts, and custom maps through Claude.
+
+Tested against Nextcloud Maps 1.8.0.
 
 ## Prerequisites
 
 - Nextcloud Maps app must be installed and enabled
 - For photo features, photos must be stored in Nextcloud
+- For contact features, the Contacts app must be installed
+
+## Custom maps and `myMapId`
+
+Maps stores data in two places: the user's default store (the database) and *custom maps*,
+which are folders holding JSON files. Most tools take an optional `myMapId` — the ID of a
+custom map, as returned by `list_maps` — to operate on that map instead of the default
+store. Omit it to work with the default store.
 
 ## Available Tools
 
@@ -16,8 +27,17 @@ Integration with Nextcloud Maps app. Manage favorites, GPS devices, tracks, phot
 | `create_map_favorite` | Create a new favorite |
 | `update_map_favorite` | Update a favorite |
 | `delete_map_favorite` | Delete a favorite |
+| `rename_map_favorite_category` | Rename one or more favorite categories |
 | `export_map_favorites` | Export favorites as GPX |
 | `import_map_favorites` | Import favorites from file |
+
+### Favorite Category Sharing
+| Tool | Description |
+|------|-------------|
+| `list_shared_map_categories` | List categories shared via public link |
+| `share_map_category` | Share a category via public link |
+| `unshare_map_category` | Revoke a category share |
+| `add_shared_category_to_map` | Add a shared category to a custom map |
 
 ### Devices & GPS
 | Tool | Description |
@@ -29,6 +49,14 @@ Integration with Nextcloud Maps app. Manage favorites, GPS devices, tracks, phot
 | `delete_map_device` | Delete a device and its points |
 | `export_map_devices` | Export device data as GPX |
 | `import_map_devices` | Import device data from file |
+
+### Device Sharing
+| Tool | Description |
+|------|-------------|
+| `share_map_device` | Share a device via public link for a time window |
+| `list_shared_map_devices` | List device shares added to a custom map |
+| `remove_map_device_share` | Revoke a device share |
+| `add_shared_device_to_map` | Add a shared device to a custom map |
 
 ### Tracks
 | Tool | Description |
@@ -45,6 +73,16 @@ Integration with Nextcloud Maps app. Manage favorites, GPS devices, tracks, phot
 | `list_map_photos_nonlocalized` | List photos without GPS data |
 | `place_map_photos` | Set GPS coordinates on photos |
 | `reset_map_photo_coords` | Remove GPS coordinates from photos |
+| `get_map_photo_job_status` | Status of the photo geolocation background job |
+
+### Contacts
+| Tool | Description |
+|------|-------------|
+| `list_map_contacts` | List contacts that have a geographic address |
+| `search_map_contacts` | Search contacts by name |
+| `place_map_contact` | Set a contact's address and coordinates |
+| `add_contact_to_map` | Copy a contact into a custom map |
+| `delete_map_contact_address` | Remove a contact's address and coordinates |
 
 ### Custom Maps
 | Tool | Description |
@@ -64,6 +102,7 @@ List map favorites (saved locations/pins) from Nextcloud Maps.
 
 **Parameters:**
 - `pruneBefore` (number, optional): Unix timestamp — only return favorites modified after this time
+- `myMapId` (number, optional): Custom map to scope to
 
 **Returns:**
 List of favorites with coordinates, name, category, and comment.
@@ -87,6 +126,7 @@ Create a new map favorite (saved location/pin) in Nextcloud Maps.
 - `category` (string, optional): Category name
 - `comment` (string, optional): A comment or note
 - `extensions` (string, optional): Extra data as a string
+- `myMapId` (number, optional): Custom map to create the favorite in
 
 **Returns:**
 Created favorite with ID.
@@ -111,9 +151,13 @@ Update an existing map favorite. Only provided fields are changed.
 - `category` (string, optional): New category
 - `comment` (string, optional): New comment
 - `extensions` (string, optional): New extensions data
+- `myMapId` (number, optional): Custom map the favorite lives in
 
 **Returns:**
 Updated favorite details.
+
+Coordinates are always sent to the server, so when `lat` or `lng` is omitted the tool looks
+up the favorite's current coordinates first.
 
 ---
 
@@ -123,6 +167,22 @@ Delete a map favorite by its ID. This action is irreversible.
 
 **Parameters:**
 - `id` (number, required): Favorite ID to delete
+- `myMapId` (number, optional): Custom map the favorite lives in
+
+**Returns:**
+Confirmation message.
+
+---
+
+### rename_map_favorite_category
+
+Rename one or more favorite categories. All favorites in the listed categories are moved to
+the new name; an existing category share follows the rename.
+
+**Parameters:**
+- `categories` (string[], required): Existing category names to rename
+- `newName` (string, required): New category name
+- `myMapId` (number, optional): Custom map to scope to
 
 **Returns:**
 Confirmation message.
@@ -166,6 +226,64 @@ Ask Claude: "Import favorites from /Maps/my-places.gpx"
 
 ---
 
+## Favorite Category Sharing
+
+### list_shared_map_categories
+
+List favorite categories that are shared via a public link.
+
+**Parameters:**
+- `myMapId` (number, optional): Custom map to scope to
+
+**Returns:**
+List of shares with category name and token.
+
+---
+
+### share_map_category
+
+Share a favorite category via a public link. The category must already contain at least one
+favorite, otherwise the server rejects the request.
+
+**Parameters:**
+- `category` (string, required): Category name to share
+
+**Returns:**
+The share, including its token.
+
+**Example Usage:**
+```
+Ask Claude: "Share my 'Hiking' favorites as a public link"
+```
+
+---
+
+### unshare_map_category
+
+Remove the public link share from a favorite category.
+
+**Parameters:**
+- `category` (string, required): Category name to unshare
+
+**Returns:**
+Confirmation message, noting whether a share existed.
+
+---
+
+### add_shared_category_to_map
+
+Add a shared favorite category to a custom map so its favorites show up there.
+
+**Parameters:**
+- `category` (string, required): Shared category name
+- `targetMapId` (number, required): ID of the custom map to add the category to
+- `myMapId` (number, optional): Custom map the share originates from
+
+**Returns:**
+Confirmation message.
+
+---
+
 ## Devices & GPS
 
 ### list_map_devices
@@ -173,7 +291,7 @@ Ask Claude: "Import favorites from /Maps/my-places.gpx"
 List GPS tracking devices registered in Nextcloud Maps.
 
 **Parameters:**
-None
+- `myMapId` (number, optional): Custom map to scope to
 
 **Returns:**
 List of devices with IDs and metadata.
@@ -182,11 +300,13 @@ List of devices with IDs and metadata.
 
 ### get_map_device_points
 
-Get GPS location points for a specific device. Supports time filtering.
+Get GPS location points for a specific device. Supports time filtering and pagination.
 
 **Parameters:**
 - `id` (number, required): Device ID
 - `pruneBefore` (number, optional): Unix timestamp — only return points after this time
+- `limit` (number, optional): Maximum number of points to return (default 10000)
+- `offset` (number, optional): Number of points to skip (default 0)
 
 **Returns:**
 List of location points with timestamps.
@@ -218,11 +338,12 @@ Ask Claude: "Log a GPS point at 59.3293, 18.0686 for device 'my-phone'"
 
 ### update_map_device
 
-Update a device's display color.
+Update a device's display color and/or name. At least one must be provided.
 
 **Parameters:**
 - `id` (number, required): Device ID
-- `color` (string, required): New color (e.g. `#ff0000`)
+- `color` (string, optional): New color (e.g. `#ff0000`)
+- `name` (string, optional): New device name (user agent)
 
 **Returns:**
 Updated device details.
@@ -265,6 +386,61 @@ Import device location data from a file in Nextcloud storage. Supports GPX, KML,
 
 **Returns:**
 Number of imported device points.
+
+---
+
+## Device Sharing
+
+### share_map_device
+
+Share a GPS device via a public link, limited to a time window.
+
+**Parameters:**
+- `id` (number, required): Device ID to share
+- `timestampFrom` (number, required): Unix timestamp — start of the shared window
+- `timestampTo` (number, required): Unix timestamp — end of the shared window
+
+**Returns:**
+The share, including its token.
+
+---
+
+### list_shared_map_devices
+
+List device shares that have been added to a custom map.
+
+**Parameters:**
+- `myMapId` (number, required): Custom map to list device shares from
+
+**Returns:**
+List of shares with tokens and time windows.
+
+> The default store holds no device shares — this tool always needs a custom map ID.
+
+---
+
+### remove_map_device_share
+
+Revoke a device share by its token.
+
+**Parameters:**
+- `token` (string, required): Share token to revoke
+
+**Returns:**
+Confirmation message.
+
+---
+
+### add_shared_device_to_map
+
+Add a shared device (by token) to a custom map so its track shows up there.
+
+**Parameters:**
+- `token` (string, required): Device share token
+- `targetMapId` (number, required): ID of the custom map to add the device to
+
+**Returns:**
+Confirmation message.
 
 ---
 
@@ -387,6 +563,104 @@ Remove GPS coordinates from one or more photos.
 **Parameters:**
 - `paths` (string[], required): File paths in Nextcloud storage
 - `myMapId` (number, optional): Custom map ID to scope to
+
+**Returns:**
+Confirmation message.
+
+---
+
+### get_map_photo_job_status
+
+Get the status of the background job that scans photos for GPS coordinates. Useful after
+uploading photos to see whether geolocation has finished.
+
+**Parameters:**
+None
+
+**Returns:**
+Key-value status reported by the job.
+
+---
+
+## Contacts
+
+### list_map_contacts
+
+List address book contacts that carry a geographic address, as shown on the map.
+
+**Parameters:**
+- `myMapId` (number, optional): Custom map to scope to
+
+**Returns:**
+List of contacts with name, address, coordinates, and the `BOOKID`/`URI` needed by the other
+contact tools.
+
+---
+
+### search_map_contacts
+
+Search address book contacts by name, to find the `bookid`/`uri`/`uid` needed to place a
+contact on the map.
+
+**Parameters:**
+- `query` (string, required): Search term matched against contact display names
+
+**Returns:**
+List of matching contacts with UID, book ID, and URI.
+
+---
+
+### place_map_contact
+
+Set a contact's geographic address and coordinates so it appears on the map.
+
+**Parameters:**
+- `bookid` (string, required): Address book ID
+- `uri` (string, required): Contact URI (e.g. `abc123.vcf`)
+- `uid` (string, required): Contact UID
+- `lat` (number, optional): Latitude
+- `lng` (number, optional): Longitude
+- `address_string` (string, optional): Full address as one string, used instead of the fields below
+- `attraction`, `house_number`, `road`, `postcode`, `city`, `state`, `country` (string, optional): Address parts
+- `type` (string, optional): Address type (e.g. `HOME`, `WORK`)
+- `myMapId` (number, optional): Custom map to scope to
+
+**Returns:**
+Confirmation message. A read-only address book or non-writable contact is returned as an error.
+
+**Example Usage:**
+```
+Ask Claude: "Put Ada Lovelace's home address on the map at 52.52, 13.405"
+```
+
+---
+
+### add_contact_to_map
+
+Copy a contact into a custom map so it shows up as a pin on that map.
+
+**Parameters:**
+- `bookid` (string, required): Address book ID
+- `uri` (string, required): Contact URI
+- `myMapId` (number, required): ID of the custom map to add the contact to
+
+**Returns:**
+Confirmation message.
+
+---
+
+### delete_map_contact_address
+
+Remove an address and its coordinates from a contact, taking it off the map. The contact
+itself is kept.
+
+**Parameters:**
+- `bookid` (string, required): Address book ID
+- `uri` (string, required): Contact URI
+- `uid` (string, required): Contact UID
+- `adr` (string, required): The `ADR` value to remove, exactly as returned by `list_map_contacts`
+- `geo` (string, required): The `GEO` value to remove, exactly as returned by `list_map_contacts`
+- `myMapId` (number, optional): Custom map to scope to
 
 **Returns:**
 Confirmation message.

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Nextcloud MCP server — files, calendar, contacts, mail, maps, notes, tasks & 120+ more tools",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,7 +18,7 @@
       ]
     }
   ],
-  "version": "0.4.4",
+  "version": "0.4.5",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "remotes": [
     {
@@ -36,7 +36,7 @@
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -64,7 +64,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.4.4",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.4.5",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/__tests__/tools-maps.test.ts
+++ b/mcp-server/src/__tests__/tools-maps.test.ts
@@ -3,11 +3,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the Maps API client module
-const mockFetchMapsExternalAPI = vi.fn();
 const mockFetchMapsAPI = vi.fn();
 
 vi.mock('../client/maps.js', () => ({
-  fetchMapsExternalAPI: (...args: unknown[]) => mockFetchMapsExternalAPI(...args),
   fetchMapsAPI: (...args: unknown[]) => mockFetchMapsAPI(...args),
 }));
 
@@ -23,7 +21,7 @@ describe('Maps Tools', () => {
 
   describe('list_map_favorites', () => {
     it('should return formatted favorites list', async () => {
-      mockFetchMapsExternalAPI.mockResolvedValue([
+      mockFetchMapsAPI.mockResolvedValue([
         {
           id: 1,
           name: 'Home',
@@ -58,20 +56,34 @@ describe('Maps Tools', () => {
       expect(result.content[0].text).toContain('2');
     });
 
-    it('should pass pruneBefore param', async () => {
-      mockFetchMapsExternalAPI.mockResolvedValue([]);
+    it('should filter by pruneBefore client-side', async () => {
+      mockFetchMapsAPI.mockResolvedValue([
+        { id: 1, name: 'Old', lat: 1, lng: 2, date_created: 1, date_modified: 1699999999 },
+        { id: 2, name: 'Fresh', lat: 3, lng: 4, date_created: 1, date_modified: 1700000001 },
+      ]);
 
       const { mapsTools } = await import('../tools/apps/maps.js');
       const tool = mapsTools.find((t) => t.name === 'list_map_favorites')!;
-      await tool.handler({ pruneBefore: 1700000000 });
+      const result = await tool.handler({ pruneBefore: 1700000000 });
 
-      expect(mockFetchMapsExternalAPI).toHaveBeenCalledWith('/favorites', {
-        queryParams: { pruneBefore: '1700000000' },
+      expect(result.content[0].text).toContain('Fresh');
+      expect(result.content[0].text).not.toContain('Old');
+    });
+
+    it('should scope to a custom map', async () => {
+      mockFetchMapsAPI.mockResolvedValue([]);
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'list_map_favorites')!;
+      await tool.handler({ myMapId: 77 });
+
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/favorites', {
+        queryParams: { myMapId: '77' },
       });
     });
 
     it('should handle empty results', async () => {
-      mockFetchMapsExternalAPI.mockResolvedValue([]);
+      mockFetchMapsAPI.mockResolvedValue([]);
 
       const { mapsTools } = await import('../tools/apps/maps.js');
       const tool = mapsTools.find((t) => t.name === 'list_map_favorites')!;
@@ -81,7 +93,7 @@ describe('Maps Tools', () => {
     });
 
     it('should handle API errors', async () => {
-      mockFetchMapsExternalAPI.mockRejectedValue(new Error('Maps API 500: Internal Server Error'));
+      mockFetchMapsAPI.mockRejectedValue(new Error('Maps API 500: Internal Server Error'));
 
       const { mapsTools } = await import('../tools/apps/maps.js');
       const tool = mapsTools.find((t) => t.name === 'list_map_favorites')!;
@@ -94,7 +106,7 @@ describe('Maps Tools', () => {
 
   describe('create_map_favorite', () => {
     it('should create a favorite successfully', async () => {
-      mockFetchMapsExternalAPI.mockResolvedValue({
+      mockFetchMapsAPI.mockResolvedValue({
         id: 10,
         name: 'Cafe',
         lat: 52.52,
@@ -118,14 +130,14 @@ describe('Maps Tools', () => {
 
       expect(result.content[0].text).toContain('Favorite created');
       expect(result.content[0].text).toContain('ID: 10');
-      expect(mockFetchMapsExternalAPI).toHaveBeenCalledWith('/favorites', {
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/favorite', {
         method: 'POST',
         body: { name: 'Cafe', lat: 52.52, lng: 13.405, category: 'Food', comment: 'Great coffee' },
       });
     });
 
     it('should handle creation errors', async () => {
-      mockFetchMapsExternalAPI.mockRejectedValue(new Error('Maps API 400: Bad Request'));
+      mockFetchMapsAPI.mockRejectedValue(new Error('Maps API 400: Bad Request'));
 
       const { mapsTools } = await import('../tools/apps/maps.js');
       const tool = mapsTools.find((t) => t.name === 'create_map_favorite')!;
@@ -138,7 +150,7 @@ describe('Maps Tools', () => {
 
   describe('update_map_favorite', () => {
     it('should update a favorite successfully', async () => {
-      mockFetchMapsExternalAPI.mockResolvedValue({
+      mockFetchMapsAPI.mockResolvedValue({
         id: 1,
         name: 'Updated Name',
         lat: 52.52,
@@ -152,30 +164,67 @@ describe('Maps Tools', () => {
 
       const { mapsTools } = await import('../tools/apps/maps.js');
       const tool = mapsTools.find((t) => t.name === 'update_map_favorite')!;
-      const result = await tool.handler({ id: 1, name: 'Updated Name' });
+      const result = await tool.handler({ id: 1, name: 'Updated Name', lat: 52.52, lng: 13.405 });
 
       expect(result.content[0].text).toContain('Favorite 1 updated');
-      expect(mockFetchMapsExternalAPI).toHaveBeenCalledWith('/favorites/1', {
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/favorites/1', {
         method: 'PUT',
-        body: { name: 'Updated Name' },
+        body: { lat: 52.52, lng: 13.405, name: 'Updated Name' },
       });
+    });
+
+    it('should look up current coordinates when lat/lng are omitted', async () => {
+      mockFetchMapsAPI
+        .mockResolvedValueOnce([{ id: 1, name: 'Home', lat: 52.52, lng: 13.405 }])
+        .mockResolvedValueOnce({
+          id: 1,
+          name: 'Updated Name',
+          lat: 52.52,
+          lng: 13.405,
+          date_created: 1700000000,
+        });
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'update_map_favorite')!;
+      const result = await tool.handler({ id: 1, name: 'Updated Name' });
+
+      expect(mockFetchMapsAPI).toHaveBeenNthCalledWith(1, '/favorites', { queryParams: {} });
+      expect(mockFetchMapsAPI).toHaveBeenNthCalledWith(2, '/favorites/1', {
+        method: 'PUT',
+        body: { lat: 52.52, lng: 13.405, name: 'Updated Name' },
+      });
+      expect(result.content[0].text).toContain('Favorite 1 updated');
+    });
+
+    it('should error when the favorite does not exist', async () => {
+      mockFetchMapsAPI.mockResolvedValue([]);
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'update_map_favorite')!;
+      const result = await tool.handler({ id: 9999, name: 'Nope' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('No favorite with ID 9999');
     });
   });
 
   describe('delete_map_favorite', () => {
     it('should delete a favorite successfully', async () => {
-      mockFetchMapsExternalAPI.mockResolvedValue('DELETED');
+      mockFetchMapsAPI.mockResolvedValue('DELETED');
 
       const { mapsTools } = await import('../tools/apps/maps.js');
       const tool = mapsTools.find((t) => t.name === 'delete_map_favorite')!;
       const result = await tool.handler({ id: 1 });
 
       expect(result.content[0].text).toContain('Favorite 1 deleted');
-      expect(mockFetchMapsExternalAPI).toHaveBeenCalledWith('/favorites/1', { method: 'DELETE' });
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/favorites/1', {
+        method: 'DELETE',
+        queryParams: {},
+      });
     });
 
     it('should handle deletion errors', async () => {
-      mockFetchMapsExternalAPI.mockRejectedValue(new Error('Maps API 400: Not found'));
+      mockFetchMapsAPI.mockRejectedValue(new Error('Maps API 400: Not found'));
 
       const { mapsTools } = await import('../tools/apps/maps.js');
       const tool = mapsTools.find((t) => t.name === 'delete_map_favorite')!;
@@ -186,11 +235,289 @@ describe('Maps Tools', () => {
     });
   });
 
+  describe('rename_map_favorite_category', () => {
+    it('should rename categories', async () => {
+      mockFetchMapsAPI.mockResolvedValue('RENAMED');
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'rename_map_favorite_category')!;
+      const result = await tool.handler({ categories: ['Food', 'Eats'], newName: 'Restaurants' });
+
+      expect(result.content[0].text).toContain('Renamed 2 categories');
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/favorites-category', {
+        method: 'PUT',
+        body: { categories: ['Food', 'Eats'], newName: 'Restaurants' },
+      });
+    });
+
+    it('should pass myMapId', async () => {
+      mockFetchMapsAPI.mockResolvedValue('RENAMED');
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'rename_map_favorite_category')!;
+      await tool.handler({ categories: ['Food'], newName: 'Restaurants', myMapId: 42 });
+
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/favorites-category', {
+        method: 'PUT',
+        body: { categories: ['Food'], newName: 'Restaurants', myMapId: 42 },
+      });
+    });
+
+    it('should handle API errors', async () => {
+      mockFetchMapsAPI.mockRejectedValue(new Error('Maps API 500: Internal Server Error'));
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'rename_map_favorite_category')!;
+      const result = await tool.handler({ categories: ['Food'], newName: 'Restaurants' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Error renaming favorite categories');
+    });
+  });
+
+  // ── Favorite category sharing ──────────────────────────────────────────
+
+  describe('list_shared_map_categories', () => {
+    it('should return formatted shares', async () => {
+      mockFetchMapsAPI.mockResolvedValue([
+        { id: 1, category: 'Food', token: 'abc123', owner: 'testuser' },
+      ]);
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'list_shared_map_categories')!;
+      const result = await tool.handler({});
+
+      expect(result.content[0].text).toContain('Food');
+      expect(result.content[0].text).toContain('abc123');
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/favorites-category/shared', {
+        queryParams: {},
+      });
+    });
+
+    it('should scope to a custom map', async () => {
+      mockFetchMapsAPI.mockResolvedValue([]);
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'list_shared_map_categories')!;
+      await tool.handler({ myMapId: 42 });
+
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/favorites-category/shared', {
+        queryParams: { myMapId: '42' },
+      });
+    });
+
+    it('should handle empty results', async () => {
+      mockFetchMapsAPI.mockResolvedValue([]);
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'list_shared_map_categories')!;
+      const result = await tool.handler({});
+
+      expect(result.content[0].text).toContain('No shared favorite categories');
+    });
+  });
+
+  describe('share_map_category', () => {
+    it('should share a category', async () => {
+      mockFetchMapsAPI.mockResolvedValue({ id: 1, category: 'Food', token: 'tok1' });
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'share_map_category')!;
+      const result = await tool.handler({ category: 'Food' });
+
+      expect(result.content[0].text).toContain('shared');
+      expect(result.content[0].text).toContain('tok1');
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/favorites-category/Food/share', {
+        method: 'POST',
+      });
+    });
+
+    it('should url-encode the category name', async () => {
+      mockFetchMapsAPI.mockResolvedValue({ category: 'My Food', token: 'tok1' });
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'share_map_category')!;
+      await tool.handler({ category: 'My Food' });
+
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/favorites-category/My%20Food/share', {
+        method: 'POST',
+      });
+    });
+
+    it('should handle API errors', async () => {
+      mockFetchMapsAPI.mockRejectedValue(new Error('Maps API 400: Unknown category'));
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'share_map_category')!;
+      const result = await tool.handler({ category: 'Nope' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Error sharing category');
+    });
+  });
+
+  describe('unshare_map_category', () => {
+    it('should report a removed share', async () => {
+      mockFetchMapsAPI.mockResolvedValue({ did_exist: true });
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'unshare_map_category')!;
+      const result = await tool.handler({ category: 'Food' });
+
+      expect(result.content[0].text).toContain('unshared');
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/favorites-category/Food/un-share', {
+        method: 'POST',
+      });
+    });
+
+    it('should report when nothing was shared', async () => {
+      mockFetchMapsAPI.mockResolvedValue({ did_exist: false });
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'unshare_map_category')!;
+      const result = await tool.handler({ category: 'Food' });
+
+      expect(result.content[0].text).toContain('was not shared');
+    });
+  });
+
+  describe('add_shared_category_to_map', () => {
+    it('should add a shared category to a map', async () => {
+      mockFetchMapsAPI.mockResolvedValue('Done');
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'add_shared_category_to_map')!;
+      const result = await tool.handler({ category: 'Food', targetMapId: 99 });
+
+      expect(result.content[0].text).toContain('added to map 99');
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/favorites-category/Food/add-to-map/99', {
+        method: 'PUT',
+        queryParams: {},
+      });
+    });
+
+    it('should handle API errors', async () => {
+      mockFetchMapsAPI.mockRejectedValue(new Error('Maps API 404: Map not Found'));
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'add_shared_category_to_map')!;
+      const result = await tool.handler({ category: 'Food', targetMapId: 99 });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('404');
+    });
+  });
+
+  // ── Device sharing ─────────────────────────────────────────────────────
+
+  describe('share_map_device', () => {
+    it('should share a device', async () => {
+      mockFetchMapsAPI.mockResolvedValue({
+        id: 1,
+        token: 'devtok',
+        deviceId: 7,
+        timestampFrom: 1700000000,
+        timestampTo: 1700003600,
+      });
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'share_map_device')!;
+      const result = await tool.handler({
+        id: 7,
+        timestampFrom: 1700000000,
+        timestampTo: 1700003600,
+      });
+
+      expect(result.content[0].text).toContain('Device 7 shared');
+      expect(result.content[0].text).toContain('devtok');
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/devices/7/share', {
+        method: 'POST',
+        body: { timestampFrom: 1700000000, timestampTo: 1700003600 },
+      });
+    });
+
+    it('should handle API errors', async () => {
+      mockFetchMapsAPI.mockRejectedValue(new Error('Maps API 400: No such device'));
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'share_map_device')!;
+      const result = await tool.handler({ id: 9999, timestampFrom: 0, timestampTo: 1 });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Error sharing device 9999');
+    });
+  });
+
+  describe('list_shared_map_devices', () => {
+    it('should list device shares on a map', async () => {
+      mockFetchMapsAPI.mockResolvedValue([{ token: 'devtok', device_id: 7 }]);
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'list_shared_map_devices')!;
+      const result = await tool.handler({ myMapId: 42 });
+
+      expect(result.content[0].text).toContain('devtok');
+      expect(result.content[0].text).toContain('Device ID: 7');
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/devices/s/', {
+        queryParams: { myMapId: '42' },
+      });
+    });
+
+    it('should handle empty results', async () => {
+      mockFetchMapsAPI.mockResolvedValue([]);
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'list_shared_map_devices')!;
+      const result = await tool.handler({ myMapId: 42 });
+
+      expect(result.content[0].text).toContain('No shared devices on map 42');
+    });
+  });
+
+  describe('remove_map_device_share', () => {
+    it('should revoke a share', async () => {
+      mockFetchMapsAPI.mockResolvedValue(true);
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'remove_map_device_share')!;
+      const result = await tool.handler({ token: 'devtok' });
+
+      expect(result.content[0].text).toContain('Device share devtok removed');
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/devices/s/devtok', { method: 'DELETE' });
+    });
+
+    it('should handle API errors', async () => {
+      mockFetchMapsAPI.mockRejectedValue(new Error('Maps API 404: Not Found'));
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'remove_map_device_share')!;
+      const result = await tool.handler({ token: 'nope' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Error removing device share');
+    });
+  });
+
+  describe('add_shared_device_to_map', () => {
+    it('should add a shared device to a map', async () => {
+      mockFetchMapsAPI.mockResolvedValue('Done');
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'add_shared_device_to_map')!;
+      const result = await tool.handler({ token: 'devtok', targetMapId: 99 });
+
+      expect(result.content[0].text).toContain('added to map 99');
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/devices/s/devtok/map-link/99', {
+        method: 'POST',
+      });
+    });
+  });
+
   // ── Devices ────────────────────────────────────────────────────────────
 
   describe('list_map_devices', () => {
     it('should return formatted device list', async () => {
-      mockFetchMapsExternalAPI.mockResolvedValue([
+      mockFetchMapsAPI.mockResolvedValue([
         { id: 1, user_agent: 'PhoneTrack/1.0', color: '#ff0000' },
         { id: 2, user_agent: 'OwnTracks/2.0', color: '#00ff00' },
       ]);
@@ -205,7 +532,7 @@ describe('Maps Tools', () => {
     });
 
     it('should handle empty results', async () => {
-      mockFetchMapsExternalAPI.mockResolvedValue([]);
+      mockFetchMapsAPI.mockResolvedValue([]);
 
       const { mapsTools } = await import('../tools/apps/maps.js');
       const tool = mapsTools.find((t) => t.name === 'list_map_devices')!;
@@ -217,7 +544,7 @@ describe('Maps Tools', () => {
 
   describe('get_map_device_points', () => {
     it('should return device location points', async () => {
-      mockFetchMapsExternalAPI.mockResolvedValue([
+      mockFetchMapsAPI.mockResolvedValue([
         { id: 1, lat: 52.52, lng: 13.405, timestamp: 1700000000, altitude: 35, accuracy: 10 },
         { id: 2, lat: 52.53, lng: 13.41, timestamp: 1700003600 },
       ]);
@@ -232,19 +559,19 @@ describe('Maps Tools', () => {
     });
 
     it('should pass pruneBefore param', async () => {
-      mockFetchMapsExternalAPI.mockResolvedValue([]);
+      mockFetchMapsAPI.mockResolvedValue([]);
 
       const { mapsTools } = await import('../tools/apps/maps.js');
       const tool = mapsTools.find((t) => t.name === 'get_map_device_points')!;
       await tool.handler({ id: 1, pruneBefore: 1700000000 });
 
-      expect(mockFetchMapsExternalAPI).toHaveBeenCalledWith('/devices/1', {
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/devices/1', {
         queryParams: { pruneBefore: '1700000000' },
       });
     });
 
     it('should handle empty results', async () => {
-      mockFetchMapsExternalAPI.mockResolvedValue([]);
+      mockFetchMapsAPI.mockResolvedValue([]);
 
       const { mapsTools } = await import('../tools/apps/maps.js');
       const tool = mapsTools.find((t) => t.name === 'get_map_device_points')!;
@@ -256,7 +583,7 @@ describe('Maps Tools', () => {
 
   describe('add_map_device_point', () => {
     it('should log a GPS point successfully', async () => {
-      mockFetchMapsExternalAPI.mockResolvedValue({ deviceId: 1, pointId: 42 });
+      mockFetchMapsAPI.mockResolvedValue({ deviceId: 1, pointId: 42 });
 
       const { mapsTools } = await import('../tools/apps/maps.js');
       const tool = mapsTools.find((t) => t.name === 'add_map_device_point')!;
@@ -269,7 +596,7 @@ describe('Maps Tools', () => {
 
       expect(result.content[0].text).toContain('device ID: 1');
       expect(result.content[0].text).toContain('point ID: 42');
-      expect(mockFetchMapsExternalAPI).toHaveBeenCalledWith('/devices', {
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/devices', {
         method: 'POST',
         body: { lat: 52.52, lng: 13.405, user_agent: 'TestDevice', altitude: 35 },
       });
@@ -278,7 +605,7 @@ describe('Maps Tools', () => {
 
   describe('update_map_device', () => {
     it('should update device color', async () => {
-      mockFetchMapsExternalAPI.mockResolvedValue({
+      mockFetchMapsAPI.mockResolvedValue({
         id: 1,
         user_agent: 'TestDevice',
         color: '#0000ff',
@@ -289,27 +616,27 @@ describe('Maps Tools', () => {
       const result = await tool.handler({ id: 1, color: '#0000ff' });
 
       expect(result.content[0].text).toContain('Device 1 updated');
-      expect(mockFetchMapsExternalAPI).toHaveBeenCalledWith('/devices/1', {
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/devices/1', {
         method: 'PUT',
-        body: { color: '#0000ff' },
+        body: { color: '#0000ff', name: '' },
       });
     });
   });
 
   describe('delete_map_device', () => {
     it('should delete a device successfully', async () => {
-      mockFetchMapsExternalAPI.mockResolvedValue('DELETED');
+      mockFetchMapsAPI.mockResolvedValue('DELETED');
 
       const { mapsTools } = await import('../tools/apps/maps.js');
       const tool = mapsTools.find((t) => t.name === 'delete_map_device')!;
       const result = await tool.handler({ id: 1 });
 
       expect(result.content[0].text).toContain('Device 1 deleted');
-      expect(mockFetchMapsExternalAPI).toHaveBeenCalledWith('/devices/1', { method: 'DELETE' });
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/devices/1', { method: 'DELETE' });
     });
 
     it('should handle deletion errors', async () => {
-      mockFetchMapsExternalAPI.mockRejectedValue(new Error('Maps API 400: Not found'));
+      mockFetchMapsAPI.mockRejectedValue(new Error('Maps API 400: Not found'));
 
       const { mapsTools } = await import('../tools/apps/maps.js');
       const tool = mapsTools.find((t) => t.name === 'delete_map_device')!;
@@ -486,6 +813,216 @@ describe('Maps Tools', () => {
         method: 'DELETE',
         body: { paths: ['/Photos/a.jpg'] },
       });
+    });
+  });
+
+  describe('get_map_photo_job_status', () => {
+    it('should report the job status', async () => {
+      mockFetchMapsAPI.mockResolvedValue({ running: true, done: 12 });
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'get_map_photo_job_status')!;
+      const result = await tool.handler({});
+
+      expect(result.content[0].text).toContain('running: true');
+      expect(result.content[0].text).toContain('done: 12');
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/photos/backgroundJobStatus');
+    });
+
+    it('should handle an empty status', async () => {
+      mockFetchMapsAPI.mockResolvedValue({});
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'get_map_photo_job_status')!;
+      const result = await tool.handler({});
+
+      expect(result.content[0].text).toContain('No photo background job status');
+    });
+  });
+
+  // ── Contacts ───────────────────────────────────────────────────────────
+
+  describe('list_map_contacts', () => {
+    it('should return formatted contacts', async () => {
+      mockFetchMapsAPI.mockResolvedValue([
+        {
+          FN: 'Ada Lovelace',
+          URI: 'ada.vcf',
+          UID: 'ada',
+          BOOKID: 1,
+          ADR: ';;Main St 1;Berlin;;10115;Germany',
+          ADRTYPE: 'HOME',
+          GEO: '52.52;13.405',
+        },
+      ]);
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'list_map_contacts')!;
+      const result = await tool.handler({});
+
+      expect(result.content[0].text).toContain('Ada Lovelace');
+      expect(result.content[0].text).toContain('52.52;13.405');
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/contacts', { queryParams: {} });
+    });
+
+    it('should scope to a custom map', async () => {
+      mockFetchMapsAPI.mockResolvedValue([]);
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'list_map_contacts')!;
+      await tool.handler({ myMapId: 42 });
+
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/contacts', {
+        queryParams: { myMapId: '42' },
+      });
+    });
+
+    it('should handle empty results', async () => {
+      mockFetchMapsAPI.mockResolvedValue([]);
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'list_map_contacts')!;
+      const result = await tool.handler({});
+
+      expect(result.content[0].text).toContain('No contacts with addresses found');
+    });
+  });
+
+  describe('search_map_contacts', () => {
+    it('should return matching contacts', async () => {
+      mockFetchMapsAPI.mockResolvedValue([
+        { FN: 'Ada Lovelace', URI: 'ada.vcf', UID: 'ada', BOOKID: 1 },
+      ]);
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'search_map_contacts')!;
+      const result = await tool.handler({ query: 'Ada' });
+
+      expect(result.content[0].text).toContain('Ada Lovelace');
+      expect(result.content[0].text).toContain('ada.vcf');
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/contacts-search', {
+        queryParams: { query: 'Ada' },
+      });
+    });
+
+    it('should handle empty results', async () => {
+      mockFetchMapsAPI.mockResolvedValue([]);
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'search_map_contacts')!;
+      const result = await tool.handler({ query: 'Nobody' });
+
+      expect(result.content[0].text).toContain('No contacts matching "Nobody"');
+    });
+  });
+
+  describe('place_map_contact', () => {
+    it('should place a contact', async () => {
+      mockFetchMapsAPI.mockResolvedValue('EDITED');
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'place_map_contact')!;
+      const result = await tool.handler({
+        bookid: '1',
+        uri: 'ada.vcf',
+        uid: 'ada',
+        lat: 52.52,
+        lng: 13.405,
+        city: 'Berlin',
+      });
+
+      expect(result.content[0].text).toContain('Contact ada placed at 52.52, 13.405');
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/contacts/1/ada.vcf', {
+        method: 'PUT',
+        body: { uid: 'ada', lat: 52.52, lng: 13.405, city: 'Berlin' },
+      });
+    });
+
+    it('should surface a non-EDITED status as an error', async () => {
+      mockFetchMapsAPI.mockResolvedValue('CONTACT NOT WRITABLE');
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'place_map_contact')!;
+      const result = await tool.handler({
+        bookid: '1',
+        uri: 'ada.vcf',
+        uid: 'ada',
+        lat: 1,
+        lng: 2,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('CONTACT NOT WRITABLE');
+    });
+  });
+
+  describe('add_contact_to_map', () => {
+    it('should add a contact to a map', async () => {
+      mockFetchMapsAPI.mockResolvedValue('DONE');
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'add_contact_to_map')!;
+      const result = await tool.handler({ bookid: '1', uri: 'ada.vcf', myMapId: 42 });
+
+      expect(result.content[0].text).toContain('added to map 42');
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/contacts/1/ada.vcf/add-to-map/', {
+        method: 'PUT',
+        body: { myMapId: 42 },
+      });
+    });
+
+    it('should surface a non-DONE status as an error', async () => {
+      mockFetchMapsAPI.mockResolvedValue('MAP NOT FOUND');
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'add_contact_to_map')!;
+      const result = await tool.handler({ bookid: '1', uri: 'ada.vcf', myMapId: 9999 });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('MAP NOT FOUND');
+    });
+  });
+
+  describe('delete_map_contact_address', () => {
+    it('should remove an address', async () => {
+      mockFetchMapsAPI.mockResolvedValue('DELETED');
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'delete_map_contact_address')!;
+      const result = await tool.handler({
+        bookid: '1',
+        uri: 'ada.vcf',
+        uid: 'ada',
+        adr: ';;Main St 1;Berlin;;10115;Germany',
+        geo: '52.52;13.405',
+      });
+
+      expect(result.content[0].text).toContain('Address removed from contact ada');
+      expect(mockFetchMapsAPI).toHaveBeenCalledWith('/contacts/1/ada.vcf', {
+        method: 'DELETE',
+        body: {
+          uid: 'ada',
+          adr: ';;Main St 1;Berlin;;10115;Germany',
+          geo: '52.52;13.405',
+        },
+      });
+    });
+
+    it('should surface a READONLY status as an error', async () => {
+      mockFetchMapsAPI.mockResolvedValue('READONLY');
+
+      const { mapsTools } = await import('../tools/apps/maps.js');
+      const tool = mapsTools.find((t) => t.name === 'delete_map_contact_address')!;
+      const result = await tool.handler({
+        bookid: '1',
+        uri: 'ada.vcf',
+        uid: 'ada',
+        adr: 'x',
+        geo: 'y',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('READONLY');
     });
   });
 

--- a/mcp-server/src/client/maps.ts
+++ b/mcp-server/src/client/maps.ts
@@ -6,9 +6,10 @@ import { logger } from '../logger.js';
 /**
  * Nextcloud Maps API client.
  *
- * Two helpers:
- *  - fetchMapsExternalAPI  — CORS-enabled external REST API  (/apps/maps/api/1.0/...)
- *  - fetchMapsAPI          — Internal controller endpoints    (/apps/maps/...)
+ * A single helper, fetchMapsAPI, targeting the internal controller endpoints
+ * (/apps/maps/...). Those are a strict superset of the CORS-enabled external
+ * REST API (/apps/maps/api/1.0/...): they accept the same parameters plus the
+ * optional myMapId used to scope an operation to a custom "My Map".
  */
 
 interface FetchOptions {
@@ -54,42 +55,8 @@ function buildHeaders(auth: string, hasBody: boolean): Record<string, string> {
 }
 
 /**
- * Fetch from the CORS-enabled external Maps API.
- * Base: /apps/maps/api/1.0
- * Used for: favorites, devices
- */
-export async function fetchMapsExternalAPI<T = unknown>(
-  endpoint: string,
-  options: FetchOptions = {}
-): Promise<T> {
-  const config = getNextcloudConfig();
-  const auth = Buffer.from(`${config.user}:${config.password}`).toString('base64');
-  const url = buildUrl(`${config.url}/apps/maps/api/1.0`, endpoint, options.queryParams);
-  const body = options.body ? JSON.stringify(options.body) : undefined;
-
-  const t0 = Date.now();
-  const response = await fetch(url, {
-    method: options.method || 'GET',
-    headers: buildHeaders(auth, !!options.body),
-    body,
-  });
-  logger.trace(
-    { method: options.method || 'GET', url, status: response.status, ms: Date.now() - t0 },
-    '[nc] HTTP'
-  );
-
-  if (!response.ok) {
-    const text = await response.text().catch(() => '');
-    throw new Error(`Maps API ${response.status}: ${text || response.statusText}`);
-  }
-
-  return (await response.json()) as T;
-}
-
-/**
  * Fetch from the internal Maps controller endpoints.
  * Base: /apps/maps
- * Used for: tracks, photos, my maps, routing, import/export
  */
 export async function fetchMapsAPI<T = unknown>(
   endpoint: string,

--- a/mcp-server/src/tools/apps/maps.ts
+++ b/mcp-server/src/tools/apps/maps.ts
@@ -1,12 +1,35 @@
 // SPDX-License-Identifier: MIT
 
 import { z } from 'zod';
-import { fetchMapsExternalAPI, fetchMapsAPI } from '../../client/maps.js';
+import { fetchMapsAPI } from '../../client/maps.js';
+import { handleAppError } from '../error-utils.js';
 
 /**
  * Nextcloud Maps App Tools
- * Manages favorites, devices, tracks, photos, custom maps, routing, and import/export.
+ * Manages favorites, favorite/device sharing, devices, tracks, photos, contacts,
+ * custom maps, routing, and import/export.
+ *
+ * Verified against Nextcloud Maps 1.8.0.
  */
+
+// ── Shared helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Most Maps controller methods accept an optional myMapId to operate on a custom
+ * "My Map" (a folder holding JSON files) instead of the user's default DB store.
+ */
+const MY_MAP_ID_SCHEMA = z
+  .number()
+  .optional()
+  .describe("ID of a custom map to scope the operation to; omit for the user's default map");
+
+function myMapIdQuery(myMapId?: number): Record<string, string> {
+  return myMapId === undefined ? {} : { myMapId: String(myMapId) };
+}
+
+function errorResult(what: string, error: unknown) {
+  return handleAppError(error, `Error ${what}`);
+}
 
 // ── Interfaces ──────────────────────────────────────────────────────────────
 
@@ -19,7 +42,8 @@ interface Favorite {
   lng: number;
   category: string;
   comment: string;
-  extensions: string;
+  // Favorites stored in a custom map come back with extensions as an array.
+  extensions: string | string[] | null;
 }
 
 interface Device {
@@ -77,6 +101,39 @@ interface MyMap {
   [key: string]: unknown;
 }
 
+interface FavoriteShare {
+  id?: number;
+  token: string;
+  category: string;
+  owner?: string;
+  [key: string]: unknown;
+}
+
+interface DeviceShare {
+  id?: number;
+  token: string;
+  deviceId?: number;
+  device_id?: number;
+  timestampFrom?: number;
+  timestampTo?: number;
+  [key: string]: unknown;
+}
+
+interface Contact {
+  FN: string;
+  URI: string;
+  UID: string;
+  BOOKID: number | string;
+  BOOKURI?: string;
+  ADR?: string;
+  // The Contacts app returns ADRTYPE as an array of types.
+  ADRTYPE?: string | string[];
+  GEO?: string;
+  GROUPS?: string;
+  READONLY?: boolean | string;
+  [key: string]: unknown;
+}
+
 // ── Formatters ──────────────────────────────────────────────────────────────
 
 function formatFavorite(f: Favorite): string {
@@ -84,7 +141,8 @@ function formatFavorite(f: Favorite): string {
   lines.push(`  Coords: ${f.lat}, ${f.lng}`);
   if (f.category) lines.push(`  Category: ${f.category}`);
   if (f.comment) lines.push(`  Comment: ${f.comment}`);
-  if (f.extensions) lines.push(`  Extensions: ${f.extensions}`);
+  const extensions = Array.isArray(f.extensions) ? f.extensions.join(', ') : f.extensions;
+  if (extensions) lines.push(`  Extensions: ${extensions}`);
   lines.push(`  Created: ${new Date(f.date_created * 1000).toISOString()}`);
   return lines.join('\n');
 }
@@ -98,9 +156,9 @@ function formatDevice(d: Device): string {
 function formatDevicePoint(p: DevicePoint): string {
   const parts = [`  ${p.lat}, ${p.lng}`];
   parts.push(`@ ${new Date(p.timestamp * 1000).toISOString()}`);
-  if (p.altitude !== undefined) parts.push(`alt: ${p.altitude}m`);
-  if (p.accuracy !== undefined) parts.push(`acc: ${p.accuracy}m`);
-  if (p.battery !== undefined) parts.push(`bat: ${p.battery}%`);
+  if (p.altitude != null) parts.push(`alt: ${p.altitude}m`);
+  if (p.accuracy != null) parts.push(`acc: ${p.accuracy}m`);
+  if (p.battery != null) parts.push(`bat: ${p.battery}%`);
   return `- ${parts.join(' | ')}`;
 }
 
@@ -124,14 +182,44 @@ function formatNonLocalizedPhoto(p: NonLocalizedPhoto): string {
   return lines.join('\n');
 }
 
+function formatFavoriteShare(s: FavoriteShare): string {
+  const lines = [`- **${s.category}**`];
+  lines.push(`  Token: ${s.token}`);
+  if (s.owner) lines.push(`  Owner: ${s.owner}`);
+  return lines.join('\n');
+}
+
+function formatDeviceShare(s: DeviceShare): string {
+  const deviceId = s.deviceId ?? s.device_id;
+  const lines = [`- Share token: ${s.token}`];
+  if (deviceId !== undefined) lines.push(`  Device ID: ${deviceId}`);
+  if (s.timestampFrom !== undefined) {
+    lines.push(`  From: ${new Date(s.timestampFrom * 1000).toISOString()}`);
+  }
+  if (s.timestampTo !== undefined) {
+    lines.push(`  To: ${new Date(s.timestampTo * 1000).toISOString()}`);
+  }
+  return lines.join('\n');
+}
+
+function formatContact(c: Contact): string {
+  const lines = [`- **${c.FN || '(unnamed)'}**`];
+  lines.push(`  Book ID: ${c.BOOKID} | URI: ${c.URI}`);
+  if (c.GEO) lines.push(`  Coords: ${c.GEO}`);
+  const adrType = Array.isArray(c.ADRTYPE) ? c.ADRTYPE.join('/') : c.ADRTYPE;
+  if (c.ADR) lines.push(`  Address: ${c.ADR}${adrType ? ` (${adrType})` : ''}`);
+  if (c.GROUPS) lines.push(`  Groups: ${c.GROUPS}`);
+  return lines.join('\n');
+}
+
 function formatMyMap(m: MyMap): string {
   const entries = Object.entries(m)
     .filter(([k]) => k !== 'id')
-    .map(([k, v]) => `  ${k}: ${v}`);
+    .map(([k, v]) => `  ${k}: ${typeof v === 'object' && v !== null ? JSON.stringify(v) : v}`);
   return [`- Map ID: ${m.id}`, ...entries].join('\n');
 }
 
-// ── Favorites Tools (External API) ──────────────────────────────────────────
+// ── Favorites Tools ─────────────────────────────────────────────────────────
 
 export const listMapFavoritesTool = {
   name: 'list_map_favorites',
@@ -143,19 +231,24 @@ export const listMapFavoritesTool = {
     openWorldHint: false,
   },
   description:
-    'List map favorites (saved locations/pins) from Nextcloud Maps. Optionally filter by modification time.',
+    'List map favorites (saved locations/pins) from Nextcloud Maps. Optionally filter by modification time or scope to a custom map.',
   inputSchema: z.object({
     pruneBefore: z
       .number()
       .optional()
       .describe('Unix timestamp — only return favorites modified after this time'),
+    myMapId: MY_MAP_ID_SCHEMA,
   }),
-  handler: async (args: { pruneBefore?: number }) => {
+  handler: async (args: { pruneBefore?: number; myMapId?: number }) => {
     try {
-      const queryParams: Record<string, string> = {};
-      if (args.pruneBefore !== undefined) queryParams['pruneBefore'] = String(args.pruneBefore);
+      let result = await fetchMapsAPI<Favorite[]>('/favorites', {
+        queryParams: myMapIdQuery(args.myMapId),
+      });
 
-      const result = await fetchMapsExternalAPI<Favorite[]>('/favorites', { queryParams });
+      if (args.pruneBefore !== undefined) {
+        const cutoff = args.pruneBefore;
+        result = result.filter((f) => (f.date_modified ?? 0) > cutoff);
+      }
 
       if (result.length === 0) {
         return { content: [{ type: 'text' as const, text: 'No map favorites found.' }] };
@@ -168,15 +261,7 @@ export const listMapFavoritesTool = {
         ],
       };
     } catch (error) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Error listing map favorites: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
+      return errorResult('listing map favorites', error);
     }
   },
 };
@@ -199,6 +284,7 @@ export const createMapFavoriteTool = {
     category: z.string().optional().describe("Category name (e.g. 'Restaurant', 'Home')"),
     comment: z.string().optional().describe('A comment or note'),
     extensions: z.string().optional().describe('Extra data as a string'),
+    myMapId: MY_MAP_ID_SCHEMA,
   }),
   handler: async (args: {
     name?: string;
@@ -207,6 +293,7 @@ export const createMapFavoriteTool = {
     category?: string;
     comment?: string;
     extensions?: string;
+    myMapId?: number;
   }) => {
     try {
       const body: Record<string, unknown> = { lat: args.lat, lng: args.lng };
@@ -214,8 +301,10 @@ export const createMapFavoriteTool = {
       if (args.category !== undefined) body.category = args.category;
       if (args.comment !== undefined) body.comment = args.comment;
       if (args.extensions !== undefined) body.extensions = args.extensions;
+      if (args.myMapId !== undefined) body.myMapId = args.myMapId;
 
-      const result = await fetchMapsExternalAPI<Favorite>('/favorites', {
+      // Note: the create route is /favorite (singular); /favorites is the batch route.
+      const result = await fetchMapsAPI<Favorite>('/favorite', {
         method: 'POST',
         body,
       });
@@ -229,15 +318,7 @@ export const createMapFavoriteTool = {
         ],
       };
     } catch (error) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Error creating map favorite: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
+      return errorResult('creating map favorite', error);
     }
   },
 };
@@ -260,6 +341,7 @@ export const updateMapFavoriteTool = {
     category: z.string().optional().describe('New category'),
     comment: z.string().optional().describe('New comment'),
     extensions: z.string().optional().describe('New extensions data'),
+    myMapId: MY_MAP_ID_SCHEMA,
   }),
   handler: async (args: {
     id: number;
@@ -269,17 +351,33 @@ export const updateMapFavoriteTool = {
     category?: string;
     comment?: string;
     extensions?: string;
+    myMapId?: number;
   }) => {
     try {
-      const body: Record<string, unknown> = {};
+      // The controller types lat/lng as non-nullable floats, so they must always be
+      // sent — look up the current coordinates when the caller omits either one.
+      let lat = args.lat;
+      let lng = args.lng;
+      if (lat === undefined || lng === undefined) {
+        const existing = await fetchMapsAPI<Favorite[]>('/favorites', {
+          queryParams: myMapIdQuery(args.myMapId),
+        });
+        const current = existing.find((f) => f.id === args.id);
+        if (!current) {
+          throw new Error(`No favorite with ID ${args.id}`);
+        }
+        lat = lat ?? current.lat;
+        lng = lng ?? current.lng;
+      }
+
+      const body: Record<string, unknown> = { lat, lng };
       if (args.name !== undefined) body.name = args.name;
-      if (args.lat !== undefined) body.lat = args.lat;
-      if (args.lng !== undefined) body.lng = args.lng;
       if (args.category !== undefined) body.category = args.category;
       if (args.comment !== undefined) body.comment = args.comment;
       if (args.extensions !== undefined) body.extensions = args.extensions;
+      if (args.myMapId !== undefined) body.myMapId = args.myMapId;
 
-      const result = await fetchMapsExternalAPI<Favorite>(`/favorites/${args.id}`, {
+      const result = await fetchMapsAPI<Favorite>(`/favorites/${args.id}`, {
         method: 'PUT',
         body,
       });
@@ -293,15 +391,7 @@ export const updateMapFavoriteTool = {
         ],
       };
     } catch (error) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Error updating map favorite ${args.id}: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
+      return errorResult(`updating map favorite ${args.id}`, error);
     }
   },
 };
@@ -318,28 +408,211 @@ export const deleteMapFavoriteTool = {
   description: 'Delete a map favorite by its ID. This action is irreversible.',
   inputSchema: z.object({
     id: z.number().describe('Favorite ID to delete'),
+    myMapId: MY_MAP_ID_SCHEMA,
   }),
-  handler: async (args: { id: number }) => {
+  handler: async (args: { id: number; myMapId?: number }) => {
     try {
-      await fetchMapsExternalAPI(`/favorites/${args.id}`, { method: 'DELETE' });
+      await fetchMapsAPI(`/favorites/${args.id}`, {
+        method: 'DELETE',
+        queryParams: myMapIdQuery(args.myMapId),
+      });
       return {
         content: [{ type: 'text' as const, text: `Favorite ${args.id} deleted.` }],
       };
     } catch (error) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Error deleting map favorite ${args.id}: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
+      return errorResult(`deleting map favorite ${args.id}`, error);
     }
   },
 };
 
-// ── Devices Tools (External API) ────────────────────────────────────────────
+export const renameMapFavoriteCategoryTool = {
+  name: 'rename_map_favorite_category',
+  title: 'Rename Map Favorite Category',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  description:
+    'Rename one or more favorite categories. All favorites in the listed categories are moved to the new name.',
+  inputSchema: z.object({
+    categories: z.array(z.string()).min(1).describe('Existing category names to rename'),
+    newName: z.string().describe('New category name'),
+    myMapId: MY_MAP_ID_SCHEMA,
+  }),
+  handler: async (args: { categories: string[]; newName: string; myMapId?: number }) => {
+    try {
+      const body: Record<string, unknown> = {
+        categories: args.categories,
+        newName: args.newName,
+      };
+      if (args.myMapId !== undefined) body.myMapId = args.myMapId;
+
+      await fetchMapsAPI('/favorites-category', { method: 'PUT', body });
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Renamed ${args.categories.length} categor${args.categories.length === 1 ? 'y' : 'ies'} (${args.categories.join(', ')}) to "${args.newName}".`,
+          },
+        ],
+      };
+    } catch (error) {
+      return errorResult('renaming favorite categories', error);
+    }
+  },
+};
+
+// ── Favorite Category Sharing Tools ─────────────────────────────────────────
+
+export const listSharedMapCategoriesTool = {
+  name: 'list_shared_map_categories',
+  title: 'List Shared Map Categories',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  description: 'List favorite categories that are shared via a public link.',
+  inputSchema: z.object({
+    myMapId: MY_MAP_ID_SCHEMA,
+  }),
+  handler: async (args: { myMapId?: number }) => {
+    try {
+      const result = await fetchMapsAPI<FavoriteShare[]>('/favorites-category/shared', {
+        queryParams: myMapIdQuery(args.myMapId),
+      });
+
+      if (result.length === 0) {
+        return { content: [{ type: 'text' as const, text: 'No shared favorite categories.' }] };
+      }
+
+      const formatted = result.map(formatFavoriteShare).join('\n');
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Shared favorite categories (${result.length}):\n\n${formatted}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return errorResult('listing shared favorite categories', error);
+    }
+  },
+};
+
+export const shareMapCategoryTool = {
+  name: 'share_map_category',
+  title: 'Share Map Category',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  description:
+    'Share a favorite category via a public link. The category must already contain at least one favorite.',
+  inputSchema: z.object({
+    category: z.string().describe('Category name to share'),
+  }),
+  handler: async (args: { category: string }) => {
+    try {
+      const result = await fetchMapsAPI<FavoriteShare>(
+        `/favorites-category/${encodeURIComponent(args.category)}/share`,
+        { method: 'POST' }
+      );
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Category "${args.category}" shared.\n\n${formatFavoriteShare(result)}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return errorResult(`sharing category "${args.category}"`, error);
+    }
+  },
+};
+
+export const unshareMapCategoryTool = {
+  name: 'unshare_map_category',
+  title: 'Unshare Map Category',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  description: 'Remove the public link share from a favorite category.',
+  inputSchema: z.object({
+    category: z.string().describe('Category name to unshare'),
+  }),
+  handler: async (args: { category: string }) => {
+    try {
+      const result = await fetchMapsAPI<{ did_exist?: boolean }>(
+        `/favorites-category/${encodeURIComponent(args.category)}/un-share`,
+        { method: 'POST' }
+      );
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: result.did_exist
+              ? `Category "${args.category}" unshared.`
+              : `Category "${args.category}" was not shared.`,
+          },
+        ],
+      };
+    } catch (error) {
+      return errorResult(`unsharing category "${args.category}"`, error);
+    }
+  },
+};
+
+export const addSharedCategoryToMapTool = {
+  name: 'add_shared_category_to_map',
+  title: 'Add Shared Category To Map',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  description: 'Add a shared favorite category to a custom map so its favorites show up there.',
+  inputSchema: z.object({
+    category: z.string().describe('Shared category name'),
+    targetMapId: z.number().describe('ID of the custom map to add the shared category to'),
+    myMapId: MY_MAP_ID_SCHEMA,
+  }),
+  handler: async (args: { category: string; targetMapId: number; myMapId?: number }) => {
+    try {
+      const result = await fetchMapsAPI<string>(
+        `/favorites-category/${encodeURIComponent(args.category)}/add-to-map/${args.targetMapId}`,
+        { method: 'PUT', queryParams: myMapIdQuery(args.myMapId) }
+      );
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Category "${args.category}" added to map ${args.targetMapId} (${result}).`,
+          },
+        ],
+      };
+    } catch (error) {
+      return errorResult(`adding category "${args.category}" to map ${args.targetMapId}`, error);
+    }
+  },
+};
+
+// ── Devices Tools ───────────────────────────────────────────────────────────
 
 export const listMapDevicesTool = {
   name: 'list_map_devices',
@@ -351,10 +624,14 @@ export const listMapDevicesTool = {
     openWorldHint: false,
   },
   description: 'List GPS tracking devices registered in Nextcloud Maps.',
-  inputSchema: z.object({}),
-  handler: async () => {
+  inputSchema: z.object({
+    myMapId: MY_MAP_ID_SCHEMA,
+  }),
+  handler: async (args: { myMapId?: number }) => {
     try {
-      const result = await fetchMapsExternalAPI<Device[]>('/devices');
+      const result = await fetchMapsAPI<Device[]>('/devices', {
+        queryParams: myMapIdQuery(args.myMapId),
+      });
 
       if (result.length === 0) {
         return { content: [{ type: 'text' as const, text: 'No map devices found.' }] };
@@ -367,15 +644,7 @@ export const listMapDevicesTool = {
         ],
       };
     } catch (error) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Error listing map devices: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
+      return errorResult('listing map devices', error);
     }
   },
 };
@@ -397,13 +666,17 @@ export const getMapDevicePointsTool = {
       .number()
       .optional()
       .describe('Unix timestamp — only return points after this time'),
+    limit: z.number().optional().describe('Maximum number of points to return (default 10000)'),
+    offset: z.number().optional().describe('Number of points to skip (default 0)'),
   }),
-  handler: async (args: { id: number; pruneBefore?: number }) => {
+  handler: async (args: { id: number; pruneBefore?: number; limit?: number; offset?: number }) => {
     try {
       const queryParams: Record<string, string> = {};
       if (args.pruneBefore !== undefined) queryParams['pruneBefore'] = String(args.pruneBefore);
+      if (args.limit !== undefined) queryParams['limit'] = String(args.limit);
+      if (args.offset !== undefined) queryParams['offset'] = String(args.offset);
 
-      const result = await fetchMapsExternalAPI<DevicePoint[]>(`/devices/${args.id}`, {
+      const result = await fetchMapsAPI<DevicePoint[]>(`/devices/${args.id}`, {
         queryParams,
       });
 
@@ -423,15 +696,7 @@ export const getMapDevicePointsTool = {
         ],
       };
     } catch (error) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Error getting device points: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
+      return errorResult('getting device points', error);
     }
   },
 };
@@ -473,7 +738,7 @@ export const addMapDevicePointTool = {
       if (args.battery !== undefined) body.battery = args.battery;
       if (args.accuracy !== undefined) body.accuracy = args.accuracy;
 
-      const result = await fetchMapsExternalAPI<{ deviceId: number; pointId: number }>('/devices', {
+      const result = await fetchMapsAPI<{ deviceId: number; pointId: number }>('/devices', {
         method: 'POST',
         body,
       });
@@ -487,15 +752,7 @@ export const addMapDevicePointTool = {
         ],
       };
     } catch (error) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Error adding device point: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
+      return errorResult('adding device point', error);
     }
   },
 };
@@ -509,16 +766,19 @@ export const updateMapDeviceTool = {
     idempotentHint: true,
     openWorldHint: false,
   },
-  description: "Update a device's display color.",
+  description: "Update a device's display color and/or name. At least one must be provided.",
   inputSchema: z.object({
     id: z.number().describe('Device ID'),
-    color: z.string().describe("New color (e.g. '#ff0000')"),
+    color: z.string().optional().describe("New color (e.g. '#ff0000')"),
+    name: z.string().optional().describe('New device name (user agent)'),
   }),
-  handler: async (args: { id: number; color: string }) => {
+  handler: async (args: { id: number; color?: string; name?: string }) => {
     try {
-      const result = await fetchMapsExternalAPI<Device>(`/devices/${args.id}`, {
+      // The controller types both as non-nullable strings and ignores empty ones,
+      // so always send both and let it skip whatever the caller left out.
+      const result = await fetchMapsAPI<Device>(`/devices/${args.id}`, {
         method: 'PUT',
-        body: { color: args.color },
+        body: { color: args.color ?? '', name: args.name ?? '' },
       });
 
       return {
@@ -527,15 +787,7 @@ export const updateMapDeviceTool = {
         ],
       };
     } catch (error) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Error updating device ${args.id}: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
+      return errorResult(`updating device ${args.id}`, error);
     }
   },
 };
@@ -556,25 +808,157 @@ export const deleteMapDeviceTool = {
   }),
   handler: async (args: { id: number }) => {
     try {
-      await fetchMapsExternalAPI(`/devices/${args.id}`, { method: 'DELETE' });
+      await fetchMapsAPI(`/devices/${args.id}`, { method: 'DELETE' });
       return {
         content: [{ type: 'text' as const, text: `Device ${args.id} deleted.` }],
       };
     } catch (error) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Error deleting device ${args.id}: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
+      return errorResult(`deleting device ${args.id}`, error);
     }
   },
 };
 
-// ── Tracks Tools (Internal API) ─────────────────────────────────────────────
+// ── Device Sharing Tools ────────────────────────────────────────────────────
+
+export const shareMapDeviceTool = {
+  name: 'share_map_device',
+  title: 'Share Map Device',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
+  description:
+    'Share a GPS device via a public link, limited to a time window. Returns the share token.',
+  inputSchema: z.object({
+    id: z.number().describe('Device ID to share'),
+    timestampFrom: z.number().describe('Unix timestamp — start of the shared time window'),
+    timestampTo: z.number().describe('Unix timestamp — end of the shared time window'),
+  }),
+  handler: async (args: { id: number; timestampFrom: number; timestampTo: number }) => {
+    try {
+      const result = await fetchMapsAPI<DeviceShare>(`/devices/${args.id}/share`, {
+        method: 'POST',
+        body: { timestampFrom: args.timestampFrom, timestampTo: args.timestampTo },
+      });
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Device ${args.id} shared.\n\n${formatDeviceShare(result)}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return errorResult(`sharing device ${args.id}`, error);
+    }
+  },
+};
+
+export const listSharedMapDevicesTool = {
+  name: 'list_shared_map_devices',
+  title: 'List Shared Map Devices',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  description:
+    'List device shares that have been added to a custom map. Requires myMapId — the default map holds no device shares.',
+  inputSchema: z.object({
+    myMapId: z.number().describe('Custom map ID to list device shares from'),
+  }),
+  handler: async (args: { myMapId: number }) => {
+    try {
+      const result = await fetchMapsAPI<DeviceShare[]>('/devices/s/', {
+        queryParams: { myMapId: String(args.myMapId) },
+      });
+
+      if (result.length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: `No shared devices on map ${args.myMapId}.` }],
+        };
+      }
+
+      const formatted = result.map(formatDeviceShare).join('\n');
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Shared devices on map ${args.myMapId} (${result.length}):\n\n${formatted}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return errorResult('listing shared devices', error);
+    }
+  },
+};
+
+export const removeMapDeviceShareTool = {
+  name: 'remove_map_device_share',
+  title: 'Remove Map Device Share',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  description: 'Revoke a device share by its token.',
+  inputSchema: z.object({
+    token: z.string().describe('Share token to revoke'),
+  }),
+  handler: async (args: { token: string }) => {
+    try {
+      await fetchMapsAPI(`/devices/s/${encodeURIComponent(args.token)}`, { method: 'DELETE' });
+      return {
+        content: [{ type: 'text' as const, text: `Device share ${args.token} removed.` }],
+      };
+    } catch (error) {
+      return errorResult(`removing device share ${args.token}`, error);
+    }
+  },
+};
+
+export const addSharedDeviceToMapTool = {
+  name: 'add_shared_device_to_map',
+  title: 'Add Shared Device To Map',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  description: 'Add a shared device (by token) to a custom map so its track shows up there.',
+  inputSchema: z.object({
+    token: z.string().describe('Device share token'),
+    targetMapId: z.number().describe('ID of the custom map to add the shared device to'),
+  }),
+  handler: async (args: { token: string; targetMapId: number }) => {
+    try {
+      const result = await fetchMapsAPI<string>(
+        `/devices/s/${encodeURIComponent(args.token)}/map-link/${args.targetMapId}`,
+        { method: 'POST' }
+      );
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Shared device added to map ${args.targetMapId} (${result}).`,
+          },
+        ],
+      };
+    } catch (error) {
+      return errorResult(`adding shared device to map ${args.targetMapId}`, error);
+    }
+  },
+};
+
+// ── Tracks Tools ─────────────────────────────────────────────
 
 export const listMapTracksTool = {
   name: 'list_map_tracks',
@@ -706,7 +1090,7 @@ export const updateMapTrackTool = {
   },
 };
 
-// ── Photos Tools (Internal API) ─────────────────────────────────────────────
+// ── Photos Tools ─────────────────────────────────────────────
 
 export const listMapPhotosTool = {
   name: 'list_map_photos',
@@ -903,7 +1287,285 @@ export const resetMapPhotoCoordsTool = {
   },
 };
 
-// ── My Maps Tools (Internal API) ────────────────────────────────────────────
+export const getMapPhotoJobStatusTool = {
+  name: 'get_map_photo_job_status',
+  title: 'Get Map Photo Job Status',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  description:
+    'Get the status of the background job that scans photos for GPS coordinates. Useful after uploading photos to see whether geolocation has finished.',
+  inputSchema: z.object({}),
+  handler: async () => {
+    try {
+      const result = await fetchMapsAPI<Record<string, unknown>>('/photos/backgroundJobStatus');
+
+      const lines = Object.entries(result).map(([k, v]) => `- ${k}: ${JSON.stringify(v)}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text:
+              lines.length > 0
+                ? `Photo background job status:\n\n${lines.join('\n')}`
+                : 'No photo background job status reported.',
+          },
+        ],
+      };
+    } catch (error) {
+      return errorResult('getting photo background job status', error);
+    }
+  },
+};
+
+// ── Contacts Tools ──────────────────────────────────────────────────────────
+
+export const listMapContactsTool = {
+  name: 'list_map_contacts',
+  title: 'List Map Contacts',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  description: 'List address book contacts that carry a geographic address, as shown on the map.',
+  inputSchema: z.object({
+    myMapId: MY_MAP_ID_SCHEMA,
+  }),
+  handler: async (args: { myMapId?: number }) => {
+    try {
+      const result = await fetchMapsAPI<Contact[]>('/contacts', {
+        queryParams: myMapIdQuery(args.myMapId),
+      });
+
+      if (result.length === 0) {
+        return { content: [{ type: 'text' as const, text: 'No contacts with addresses found.' }] };
+      }
+
+      const formatted = result.map(formatContact).join('\n');
+      return {
+        content: [
+          { type: 'text' as const, text: `Map contacts (${result.length}):\n\n${formatted}` },
+        ],
+      };
+    } catch (error) {
+      return errorResult('listing map contacts', error);
+    }
+  },
+};
+
+export const searchMapContactsTool = {
+  name: 'search_map_contacts',
+  title: 'Search Map Contacts',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  description:
+    'Search address book contacts by name, to find the bookid/uri/uid needed to place a contact on the map.',
+  inputSchema: z.object({
+    query: z.string().describe('Search term matched against contact display names'),
+  }),
+  handler: async (args: { query: string }) => {
+    try {
+      const result = await fetchMapsAPI<Contact[]>('/contacts-search', {
+        queryParams: { query: args.query },
+      });
+
+      if (result.length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: `No contacts matching "${args.query}".` }],
+        };
+      }
+
+      const formatted = result
+        .map((c) => `- **${c.FN}** — UID: ${c.UID} | Book ID: ${c.BOOKID} | URI: ${c.URI}`)
+        .join('\n');
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Contacts matching "${args.query}" (${result.length}):\n\n${formatted}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return errorResult(`searching contacts for "${args.query}"`, error);
+    }
+  },
+};
+
+export const placeMapContactTool = {
+  name: 'place_map_contact',
+  title: 'Place Map Contact',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  description:
+    "Set a contact's geographic address and coordinates so it appears on the map. Use search_map_contacts to look up bookid, uri and uid.",
+  inputSchema: z.object({
+    bookid: z.string().describe('Address book ID'),
+    uri: z.string().describe('Contact URI (e.g. "abc123.vcf")'),
+    uid: z.string().describe('Contact UID'),
+    lat: z.number().optional().describe('Latitude'),
+    lng: z.number().optional().describe('Longitude'),
+    address_string: z
+      .string()
+      .optional()
+      .describe('Full address as a single string, used instead of the individual fields'),
+    attraction: z.string().optional().describe('Point of interest name'),
+    house_number: z.string().optional().describe('House number'),
+    road: z.string().optional().describe('Street'),
+    postcode: z.string().optional().describe('Postal code'),
+    city: z.string().optional().describe('City'),
+    state: z.string().optional().describe('State or region'),
+    country: z.string().optional().describe('Country'),
+    type: z.string().optional().describe("Address type (e.g. 'HOME', 'WORK')"),
+    myMapId: MY_MAP_ID_SCHEMA,
+  }),
+  handler: async (args: {
+    bookid: string;
+    uri: string;
+    uid: string;
+    lat?: number;
+    lng?: number;
+    address_string?: string;
+    attraction?: string;
+    house_number?: string;
+    road?: string;
+    postcode?: string;
+    city?: string;
+    state?: string;
+    country?: string;
+    type?: string;
+    myMapId?: number;
+  }) => {
+    try {
+      const { bookid, uri, ...rest } = args;
+      const body: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(rest)) {
+        if (value !== undefined) body[key] = value;
+      }
+
+      const result = await fetchMapsAPI<string>(
+        `/contacts/${encodeURIComponent(bookid)}/${encodeURIComponent(uri)}`,
+        { method: 'PUT', body }
+      );
+
+      if (result !== 'EDITED') {
+        return errorResult(`placing contact ${args.uid}`, new Error(result));
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Contact ${args.uid} placed${args.lat !== undefined && args.lng !== undefined ? ` at ${args.lat}, ${args.lng}` : ''}.`,
+          },
+        ],
+      };
+    } catch (error) {
+      return errorResult(`placing contact ${args.uid}`, error);
+    }
+  },
+};
+
+export const addContactToMapTool = {
+  name: 'add_contact_to_map',
+  title: 'Add Contact To Map',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  description: 'Copy a contact into a custom map so it shows up as a pin on that map.',
+  inputSchema: z.object({
+    bookid: z.string().describe('Address book ID'),
+    uri: z.string().describe('Contact URI (e.g. "abc123.vcf")'),
+    myMapId: z.number().describe('ID of the custom map to add the contact to'),
+  }),
+  handler: async (args: { bookid: string; uri: string; myMapId: number }) => {
+    try {
+      const result = await fetchMapsAPI<string>(
+        `/contacts/${encodeURIComponent(args.bookid)}/${encodeURIComponent(args.uri)}/add-to-map/`,
+        { method: 'PUT', body: { myMapId: args.myMapId } }
+      );
+
+      if (result !== 'DONE') {
+        return errorResult(`adding contact to map ${args.myMapId}`, new Error(result));
+      }
+
+      return {
+        content: [
+          { type: 'text' as const, text: `Contact ${args.uri} added to map ${args.myMapId}.` },
+        ],
+      };
+    } catch (error) {
+      return errorResult(`adding contact to map ${args.myMapId}`, error);
+    }
+  },
+};
+
+export const deleteMapContactAddressTool = {
+  name: 'delete_map_contact_address',
+  title: 'Delete Map Contact Address',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  description:
+    'Remove an address and its coordinates from a contact, taking it off the map. The contact itself is kept. Use list_map_contacts to get the exact ADR and GEO values.',
+  inputSchema: z.object({
+    bookid: z.string().describe('Address book ID'),
+    uri: z.string().describe('Contact URI (e.g. "abc123.vcf")'),
+    uid: z.string().describe('Contact UID'),
+    adr: z.string().describe('The ADR value to remove, exactly as returned by list_map_contacts'),
+    geo: z.string().describe('The GEO value to remove, exactly as returned by list_map_contacts'),
+    myMapId: MY_MAP_ID_SCHEMA,
+  }),
+  handler: async (args: {
+    bookid: string;
+    uri: string;
+    uid: string;
+    adr: string;
+    geo: string;
+    myMapId?: number;
+  }) => {
+    try {
+      const body: Record<string, unknown> = { uid: args.uid, adr: args.adr, geo: args.geo };
+      if (args.myMapId !== undefined) body.myMapId = args.myMapId;
+
+      const result = await fetchMapsAPI<string>(
+        `/contacts/${encodeURIComponent(args.bookid)}/${encodeURIComponent(args.uri)}`,
+        { method: 'DELETE', body }
+      );
+
+      if (result !== 'DELETED') {
+        return errorResult(`deleting address of contact ${args.uid}`, new Error(result));
+      }
+
+      return {
+        content: [{ type: 'text' as const, text: `Address removed from contact ${args.uid}.` }],
+      };
+    } catch (error) {
+      return errorResult(`deleting address of contact ${args.uid}`, error);
+    }
+  },
+};
+
+// ── My Maps Tools ────────────────────────────────────────────
 
 export const listMapsTool = {
   name: 'list_maps',
@@ -1060,7 +1722,7 @@ export const deleteMapTool = {
   },
 };
 
-// ── Routing Tool (Internal API) ─────────────────────────────────────────────
+// ── Routing Tool ─────────────────────────────────────────────
 
 export const exportMapRouteTool = {
   name: 'export_map_route',
@@ -1134,7 +1796,7 @@ export const exportMapRouteTool = {
   },
 };
 
-// ── Import/Export Tools (Internal API) ───────────────────────────────────────
+// ── Import/Export Tools ───────────────────────────────────────
 
 export const exportMapFavoritesTool = {
   name: 'export_map_favorites',
@@ -1334,12 +1996,23 @@ export const mapsTools = [
   createMapFavoriteTool,
   updateMapFavoriteTool,
   deleteMapFavoriteTool,
+  renameMapFavoriteCategoryTool,
+  // Favorite category sharing
+  listSharedMapCategoriesTool,
+  shareMapCategoryTool,
+  unshareMapCategoryTool,
+  addSharedCategoryToMapTool,
   // Devices
   listMapDevicesTool,
   getMapDevicePointsTool,
   addMapDevicePointTool,
   updateMapDeviceTool,
   deleteMapDeviceTool,
+  // Device sharing
+  shareMapDeviceTool,
+  listSharedMapDevicesTool,
+  removeMapDeviceShareTool,
+  addSharedDeviceToMapTool,
   // Tracks
   listMapTracksTool,
   getMapTrackTool,
@@ -1349,6 +2022,13 @@ export const mapsTools = [
   listMapPhotosNonlocalizedTool,
   placeMapPhotosTool,
   resetMapPhotoCoordsTool,
+  getMapPhotoJobStatusTool,
+  // Contacts
+  listMapContactsTool,
+  searchMapContactsTool,
+  placeMapContactTool,
+  addContactToMapTool,
+  deleteMapContactAddressTool,
   // My Maps
   listMapsTool,
   createMapTool,

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.4.4</version>
+    <version>0.4.5</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",


### PR DESCRIPTION
Verified our Maps integration against [Nextcloud Maps 1.8.0](https://github.com/nextcloud/maps/releases/tag/v1.8.0). That release is Vue-3 migration / dependencies / bugfixes — **no routes or controller signatures changed**, so nothing in our tooling broke. The review did surface real gaps, which this PR closes.

## `myMapId` scoping

Favorites and devices went through the external `/api/1.0` controllers (`FavoritesApiController`, `DevicesApiController`), which don't accept `myMapId` — custom maps were unreachable from those tools. They now use the internal controllers, a strict superset taking the same parameters plus the optional `myMapId`. `fetchMapsExternalAPI` is gone; `src/client/maps.ts` has a single helper.

Two follow-ons from that migration:
- `update_map_favorite` — the controller types `lat`/`lng` as non-nullable floats, so when the caller omits either one the tool looks up the favorite's current coordinates first, keeping the existing "only provided fields change" contract.
- `list_map_favorites` — the internal route has no `pruneBefore`, so the filter is applied client-side on `date_modified`.

## New tools (15, 25 → 40)

| Area | Tools |
|---|---|
| Favorite categories | `rename_map_favorite_category`, `list_shared_map_categories`, `share_map_category`, `unshare_map_category`, `add_shared_category_to_map` |
| Device sharing | `share_map_device`, `list_shared_map_devices`, `remove_map_device_share`, `add_shared_device_to_map` |
| Contacts | `list_map_contacts`, `search_map_contacts`, `place_map_contact`, `add_contact_to_map`, `delete_map_contact_address` |
| Photos | `get_map_photo_job_status` |

Deliberately skipped: `contacts#getContactLetterAvatar` (binary), `photos#clearCache`, `page#openGeoLink`, options/routing-settings, and all `/s/{token}` public-share routes.

Also: `limit`/`offset` on `get_map_device_points`, `name` on `update_map_device`, and formatters no longer print `acc: nullm` / `bat: null%` or `[object Object]`.

## Verification

- `npm test` — 914 passing (79 in `tools-maps.test.ts`, up from 46); lint and prettier clean.
- Live run against a Maps 1.8.0 install (`docker/installation`, NC 33.0.0, maps 1.8.0, contacts 8.7.6): every one of the 40 tools exercised end-to-end through the built handlers — map created, favorite scoped to it and confirmed absent from the default store, category shared/added-to-map/renamed/unshared, device point logged/shared/added-to-map/revoked/deleted, contact searched/placed/added-to-map/address-removed, then everything cleaned up. No new errors in `nextcloud.log`.

Patch bump to 0.4.5 across both components.

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)