### PR TITLE
feat(nextcloud): explicit thinking budget_tokens alongside adaptive mode

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Nextcloud MCP server — files, calendar, contacts, mail, maps, notes, tasks & 120+ more tools",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,7 +18,7 @@
       ]
     }
   ],
-  "version": "0.4.5",
+  "version": "0.4.6",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "remotes": [
     {
@@ -36,7 +36,7 @@
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -64,7 +64,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.4.5",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.4.6",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.4.5</version>
+    <version>0.4.6</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/composer.json
+++ b/nextcloud-app/composer.json
@@ -5,7 +5,7 @@
     "license": "AGPL-3.0-or-later",
     "require": {
         "php": "^8.4",
-        "anthropic-ai/sdk": "^0.40.0",
+        "anthropic-ai/sdk": "^0.43.0",
         "psr/log": "*",
         "symfony/http-client": "^8.0",
         "nyholm/psr7": "^1.8"

--- a/nextcloud-app/composer.lock
+++ b/nextcloud-app/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8252045c2f4a1651eb035dcedcdbc5df",
+    "content-hash": "523b1fe41064b7ccdea3930c9084b43c",
     "packages": [
         {
             "name": "anthropic-ai/sdk",
-            "version": "v0.40.0",
+            "version": "v0.43.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/anthropics/anthropic-sdk-php.git",
-                "reference": "273764dcec650b985422d50a4847993579e513aa"
+                "reference": "475a13451a04e91fd6de235c7b9609cb7c082d92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/anthropics/anthropic-sdk-php/zipball/273764dcec650b985422d50a4847993579e513aa",
-                "reference": "273764dcec650b985422d50a4847993579e513aa",
+                "url": "https://api.github.com/repos/anthropics/anthropic-sdk-php/zipball/475a13451a04e91fd6de235c7b9609cb7c082d92",
+                "reference": "475a13451a04e91fd6de235c7b9609cb7c082d92",
                 "shasum": ""
             },
             "require": {
@@ -34,7 +34,7 @@
                 "friendsofphp/php-cs-fixer": "^3",
                 "google/auth": "^1.49",
                 "guzzlehttp/guzzle": "^7",
-                "mcp/sdk": "^0.5",
+                "mcp/sdk": "^0.7.1",
                 "nyholm/psr7": "^1",
                 "pestphp/pest": "^3",
                 "php-http/mock-client": "^1",
@@ -65,9 +65,9 @@
             "description": "Anthropic PHP SDK",
             "support": {
                 "issues": "https://github.com/anthropics/anthropic-sdk-php/issues",
-                "source": "https://github.com/anthropics/anthropic-sdk-php/tree/v0.40.0"
+                "source": "https://github.com/anthropics/anthropic-sdk-php/tree/v0.43.0"
             },
-            "time": "2026-07-24T16:35:04+00:00"
+            "time": "2026-08-20T18:20:25+00:00"
         },
         {
             "name": "nyholm/psr7",

--- a/nextcloud-app/lib/Command/ConfigureCommand.php
+++ b/nextcloud-app/lib/Command/ConfigureCommand.php
@@ -5,6 +5,7 @@ namespace OCA\AIquila\Command;
 
 use OC\Core\Command\Base;
 use OCA\AIquila\Service\ClaudeModels;
+use OCA\AIquila\Service\ClaudeSDKService;
 use OCA\AIquila\Service\CredentialService;
 use OCA\AIquila\Service\Provider\LLMProviderFactory;
 use OCP\IConfig;
@@ -58,6 +59,12 @@ class ConfigureCommand extends Base {
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Enable adaptive thinking by default (on|off)'
+            )
+            ->addOption(
+                'thinking-budget',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Pin the thinking budget in tokens (>= ' . ClaudeSDKService::MIN_THINKING_BUDGET . ', empty string for adaptive)'
             )
             ->addOption(
                 'timeout',
@@ -207,6 +214,20 @@ class ConfigureCommand extends Base {
             $updated = true;
         }
 
+        // Set the default thinking budget
+        $thinkingBudget = $input->getOption('thinking-budget');
+        if ($thinkingBudget !== null) {
+            // The upper bound is per-request (it depends on max_tokens at send
+            // time), so only the floor can be checked here.
+            if ($thinkingBudget !== '' && (!ctype_digit($thinkingBudget) || (int)$thinkingBudget < ClaudeSDKService::MIN_THINKING_BUDGET)) {
+                $output->writeln('<error>Thinking budget must be at least ' . ClaudeSDKService::MIN_THINKING_BUDGET . ' tokens (or empty to use adaptive thinking)</error>');
+                return 1;
+            }
+            $this->config->setAppValue(self::APP_NAME, 'thinking_budget', $thinkingBudget);
+            $output->writeln('<info>✓ Thinking budget ' . ($thinkingBudget === '' ? 'cleared — using adaptive thinking' : 'updated to: ' . $thinkingBudget . ' tokens') . '</info>');
+            $updated = true;
+        }
+
         // Set timeout
         $timeout = $input->getOption('timeout');
         if ($timeout !== null) {
@@ -240,6 +261,7 @@ class ConfigureCommand extends Base {
         $maxTokens = (string)$provider->getMaxTokens();
         $effort = $this->config->getAppValue(self::APP_NAME, 'effort', '');
         $thinking = in_array($this->config->getAppValue(self::APP_NAME, 'thinking', 'false'), ['true', '1'], true);
+        $thinkingBudget = $this->config->getAppValue(self::APP_NAME, 'thinking_budget', '');
         $timeout = $this->config->getAppValue(self::APP_NAME, 'api_timeout', '30');
 
         $output->writeln('');
@@ -257,6 +279,7 @@ class ConfigureCommand extends Base {
         $output->writeln('  Max Tokens: <comment>' . $maxTokens . '</comment>');
         $output->writeln('  Effort:     <comment>' . ($effort !== '' ? $effort : '(model default)') . '</comment>');
         $output->writeln('  Thinking:   <comment>' . ($thinking ? 'on' : 'off') . '</comment>');
+        $output->writeln('  Budget:     <comment>' . ($thinkingBudget !== '' ? $thinkingBudget . ' tokens' : '(adaptive)') . '</comment>');
         $output->writeln('  Timeout:    <comment>' . $timeout . ' seconds</comment>');
         $output->writeln('');
 

--- a/nextcloud-app/lib/Controller/ConversationController.php
+++ b/nextcloud-app/lib/Controller/ConversationController.php
@@ -15,6 +15,7 @@ use OCA\AIquila\Db\ProjectMapper;
 use OCA\AIquila\Db\ProjectPathMapper;
 use OCA\AIquila\Http\SSEResponse;
 use OCA\AIquila\Service\ClaudeModels;
+use OCA\AIquila\Service\ClaudeSDKService;
 use OCA\AIquila\Service\FileService;
 use OCA\AIquila\Service\FilesService;
 use OCA\AIquila\Service\ImageOptimizer;
@@ -108,7 +109,7 @@ class ConversationController extends Controller {
      *
      * 200: List of conversations
      *
-     * @return JSONResponse<Http::STATUS_OK, list<array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}>, array{}>
+     * @return JSONResponse<Http::STATUS_OK, list<array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool, thinkingBudget: ?int}>, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
@@ -134,7 +135,7 @@ class ConversationController extends Controller {
      * 400: Unknown provider
      * 403: The provider is not permitted for this user
      *
-     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string, errorId: string}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{error: string, errorId: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool, thinkingBudget: ?int}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string, errorId: string}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{error: string, errorId: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
@@ -189,7 +190,7 @@ class ConversationController extends Controller {
      * 403: The provider is not permitted for this user
      * 404: Conversation not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string, errorId: string}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{error: string, errorId: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string, errorId: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool, thinkingBudget: ?int}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string, errorId: string}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{error: string, errorId: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string, errorId: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
@@ -220,6 +221,11 @@ class ConversationController extends Controller {
             if (!$this->resolveProvider($conversation)->getCapabilities()['effort']) {
                 $conversation->setEffort(null);
             }
+
+            // Likewise the budget, which is meaningless without thinking.
+            if (!$this->resolveProvider($conversation)->getCapabilities()['thinking']) {
+                $conversation->setThinkingBudget(null);
+            }
         }
 
         if ($model !== null && $model !== '') {
@@ -240,7 +246,7 @@ class ConversationController extends Controller {
      * 200: Conversation with messages
      * 404: Conversation not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool, messages: list<array{id: int, conversationId: int, role: string, content: string, inputTokens: ?int, outputTokens: ?int, cacheCreationTokens: ?int, cacheReadTokens: ?int, latencyMs: ?int, citations: ?array<string, mixed>, documents: ?array<string, mixed>, createdAt: int, files: list<array{id: int, messageId: int, filePath: string, fileName: string, mimeType: ?string, createdAt: int}>}>}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string, errorId: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool, thinkingBudget: ?int, messages: list<array{id: int, conversationId: int, role: string, content: string, inputTokens: ?int, outputTokens: ?int, cacheCreationTokens: ?int, cacheReadTokens: ?int, latencyMs: ?int, citations: ?array<string, mixed>, documents: ?array<string, mixed>, createdAt: int, files: list<array{id: int, messageId: int, filePath: string, fileName: string, mimeType: ?string, createdAt: int}>}>}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string, errorId: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
@@ -275,17 +281,18 @@ class ConversationController extends Controller {
      * @param int|null $projectId Project ID to link (null to clear)
      * @param string|null $effort Effort override (low…max; empty string clears)
      * @param string|null $thinking Adaptive-thinking override ('on'/'off'; empty string clears)
+     * @param string|null $thinkingBudget Explicit thinking budget in tokens (empty string clears)
      *
      * 200: Updated conversation
-     * 400: Invalid effort or thinking value
+     * 400: Invalid effort, thinking or thinkingBudget value
      * 403: No provider is permitted for this user
      * 404: Conversation not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string, allowed: list<string>}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string, errorId: string}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{error: string, errorId: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool, thinkingBudget: ?int}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string, allowed: list<string>}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string, errorId: string}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{error: string, errorId: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
-    public function update(int $id, string $title = '', ?int $projectId = null, ?string $effort = null, ?string $thinking = null): JSONResponse {
+    public function update(int $id, string $title = '', ?int $projectId = null, ?string $effort = null, ?string $thinking = null, ?string $thinkingBudget = null): JSONResponse {
         if (!$this->providerFactory->hasPermittedProvider($this->userId)) {
             return $this->noProviderAvailable();
         }
@@ -338,6 +345,38 @@ class ConversationController extends Controller {
                 return $this->clientError(400, 'Thinking must be "on", "off" or empty');
             }
             $conversation->setThinking($thinking === '' ? null : $thinking === 'on');
+        }
+
+        if ($thinkingBudget !== null && $thinkingBudget !== '') {
+            // Like effort, an Anthropic concept — do not validate a Hetzner or
+            // Ollama conversation against it.
+            $provider = $this->resolveProvider($conversation);
+            if (!$provider->getCapabilities()['thinking']) {
+                return new JSONResponse([
+                    'error' => $provider->getLabel() . ' does not support a thinking budget',
+                    'errorId' => '',
+                    'allowed' => [],
+                ], 400);
+            }
+
+            if (!ctype_digit($thinkingBudget)) {
+                return $this->clientError(400, 'Thinking budget must be a whole number of tokens');
+            }
+
+            // The API caps thinking and response text against the same
+            // max_tokens, so the budget has to stay strictly below it.
+            $budget = (int)$thinkingBudget;
+            $ceiling = $provider->getMaxTokens($this->userId);
+            if ($budget < ClaudeSDKService::MIN_THINKING_BUDGET || $budget >= $ceiling) {
+                return $this->clientError(400, sprintf(
+                    'Thinking budget must be between %d and %d tokens',
+                    ClaudeSDKService::MIN_THINKING_BUDGET,
+                    $ceiling - 1,
+                ));
+            }
+            $conversation->setThinkingBudget($budget);
+        } elseif ($thinkingBudget === '') {
+            $conversation->setThinkingBudget(null);
         }
 
         $conversation->setUpdatedAt(time());
@@ -843,7 +882,7 @@ class ConversationController extends Controller {
      * 200: The duplicated conversation
      * 404: Conversation not found
      *
-     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string, errorId: string}, array{}>
+     * @return JSONResponse<Http::STATUS_OK, array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool, thinkingBudget: ?int}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{error: string, errorId: string}, array{}>
      */
     #[NoAdminRequired]
     #[OpenAPI]
@@ -1101,6 +1140,9 @@ class ConversationController extends Controller {
         }
         if ($conversation->getThinking() !== null) {
             $options['thinking'] = $conversation->getThinking();
+        }
+        if ($conversation->getThinkingBudget() !== null) {
+            $options['thinking_budget'] = $conversation->getThinkingBudget();
         }
         return $options;
     }

--- a/nextcloud-app/lib/Db/Conversation.php
+++ b/nextcloud-app/lib/Db/Conversation.php
@@ -27,6 +27,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setEffort(?string $effort)
  * @method bool|null getThinking()
  * @method void setThinking(?bool $thinking)
+ * @method int|null getThinkingBudget()
+ * @method void setThinkingBudget(?int $thinkingBudget)
  */
 class Conversation extends Entity implements \JsonSerializable {
     protected string $userId = '';
@@ -39,6 +41,8 @@ class Conversation extends Entity implements \JsonSerializable {
     protected ?int $projectId = null;
     protected ?string $effort = null;
     protected ?bool $thinking = null;
+    /** Explicit thinking budget in tokens; null keeps thinking adaptive. */
+    protected ?int $thinkingBudget = null;
 
     public function __construct() {
         $this->addType('userId', 'string');
@@ -50,10 +54,11 @@ class Conversation extends Entity implements \JsonSerializable {
         $this->addType('projectId', 'integer');
         $this->addType('effort', 'string');
         $this->addType('thinking', 'boolean');
+        $this->addType('thinkingBudget', 'integer');
     }
 
     /**
-     * @return array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool}
+     * @return array{id: int, userId: string, title: ?string, model: string, provider: ?string, createdAt: int, updatedAt: int, projectId: ?int, effort: ?string, thinking: ?bool, thinkingBudget: ?int}
      */
     public function jsonSerialize(): array {
         return [
@@ -67,6 +72,7 @@ class Conversation extends Entity implements \JsonSerializable {
             'projectId' => $this->getProjectId(),
             'effort' => $this->getEffort(),
             'thinking' => $this->getThinking(),
+            'thinkingBudget' => $this->getThinkingBudget(),
         ];
     }
 }

--- a/nextcloud-app/lib/Migration/Version0012Date20260825000000.php
+++ b/nextcloud-app/lib/Migration/Version0012Date20260825000000.php
@@ -1,0 +1,35 @@
+<?php
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace OCA\AIquila\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version0012Date20260825000000 extends SimpleMigrationStep {
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+        $schema = $schemaClosure();
+
+        if (!$schema->hasTable('aiquila_conversations')) {
+            return null;
+        }
+
+        $table = $schema->getTable('aiquila_conversations');
+
+        // Null means "no explicit budget" — thinking stays adaptive.
+        if ($table->hasColumn('thinking_budget')) {
+            return null;
+        }
+
+        $table->addColumn('thinking_budget', Types::INTEGER, [
+            'notnull' => false,
+        ]);
+
+        return $schema;
+    }
+}

--- a/nextcloud-app/lib/Service/ClaudeSDKService.php
+++ b/nextcloud-app/lib/Service/ClaudeSDKService.php
@@ -50,6 +50,10 @@ class ClaudeSDKService implements LLMProviderInterface, ProviderActionsInterface
     private string $appName = 'aiquila';
 
     private const CAPABILITY_CACHE_TTL = 3600; // 1 hour
+    /** Smallest budget the Messages API accepts for thinking type 'enabled'. */
+    public const MIN_THINKING_BUDGET = 1024;
+    /** Bumped whenever the cached capability array grows a key. */
+    private const CAPABILITY_CACHE_PREFIX = 'v2:';
 
     /**
      * Above this max_tokens value, non-streaming requests risk HTTP timeouts
@@ -130,10 +134,12 @@ class ClaudeSDKService implements LLMProviderInterface, ProviderActionsInterface
     /**
      * Resolve model capabilities dynamically via the SDK, with caching and static fallback.
      *
-     * @return array{max_tokens: int, context_window: int, supports_thinking: bool, supports_effort: bool}
+     * @return array{max_tokens: int, context_window: int, supports_thinking: bool, supports_thinking_enabled: bool, supports_effort: bool}
      */
     private function resolveModelCapabilities(string $model, ?string $userId = null): array {
-        $cacheKey = $model;
+        // Versioned so entries written before a shape change are ignored rather
+        // than returned with keys missing.
+        $cacheKey = self::CAPABILITY_CACHE_PREFIX . $model;
         $cached = $this->cache->get($cacheKey);
         if (is_array($cached)) {
             return $cached;
@@ -147,6 +153,7 @@ class ClaudeSDKService implements LLMProviderInterface, ProviderActionsInterface
                 'max_tokens' => $info->maxTokens ?? ClaudeModels::getMaxTokenCeiling($model),
                 'context_window' => $info->maxInputTokens ?? ClaudeModels::getContextWindow($model),
                 'supports_thinking' => $info->capabilities->thinking->supported ?? false,
+                'supports_thinking_enabled' => $info->capabilities->thinking->types->enabled->supported ?? false,
                 'supports_effort' => $info->capabilities->effort->supported ?? false,
             ];
 
@@ -168,6 +175,10 @@ class ClaudeSDKService implements LLMProviderInterface, ProviderActionsInterface
                 'max_tokens' => ClaudeModels::getMaxTokenCeiling($model),
                 'context_window' => ClaudeModels::getContextWindow($model),
                 'supports_thinking' => ClaudeModels::supportsThinking($model),
+                // No static table for per-type support: without a live answer we
+                // only claim adaptive, so an explicit budget is refused rather
+                // than sent to a model that may reject it.
+                'supports_thinking_enabled' => false,
                 'supports_effort' => ClaudeModels::supportsEffort($model),
             ];
         }
@@ -188,6 +199,8 @@ class ClaudeSDKService implements LLMProviderInterface, ProviderActionsInterface
      *   tools          (array)  – Anthropic-format tool definitions
      *   effort         (string) – per-conversation effort override (low…max)
      *   thinking       (bool)   – per-conversation adaptive-thinking override
+     *   thinking_budget (int)   – explicit thinking budget in tokens; switches
+     *                             thinking from adaptive to enabled mode
      */
     /**
      * Model for a single request.
@@ -226,10 +239,20 @@ class ClaudeSDKService implements LLMProviderInterface, ProviderActionsInterface
             $params['metadata'] = ['user_id' => $userHash];
         }
 
-        // Adaptive thinking is opt-in (conversation override or admin default).
-        // "Off" means omitting the param entirely — an explicit
-        // {type: 'disabled'} is rejected with a 400 on Fable 5.
-        if ($caps['supports_thinking'] && $this->resolveThinking($options['thinking'] ?? null)) {
+        // Thinking is opt-in (conversation override or admin default). "Off"
+        // means omitting the param entirely — an explicit {type: 'disabled'}
+        // is rejected with a 400 on Fable 5.
+        //
+        // An explicit budget switches from adaptive to enabled mode, but a
+        // deliberate "thinking off" is the more specific instruction and wins.
+        $thinkingOn = $caps['supports_thinking'] && $this->resolveThinking($options['thinking'] ?? null);
+        $budget = ($options['thinking'] ?? null) === false
+            ? null
+            : $this->resolveThinkingBudget($options, $model, $caps, $params['max_tokens']);
+
+        if ($budget !== null) {
+            $params['thinking'] = ['type' => 'enabled', 'budget_tokens' => $budget];
+        } elseif ($thinkingOn) {
             $params['thinking'] = ['type' => 'adaptive'];
         }
 
@@ -302,6 +325,72 @@ class ClaudeSDKService implements LLMProviderInterface, ProviderActionsInterface
         }
         // Checkboxes have persisted as 'true' or '1' over the app's history.
         return in_array($this->config->getAppValue($this->appName, 'thinking', 'false'), ['true', '1'], true);
+    }
+
+    /**
+     * Resolve an explicit thinking budget: per-request override → admin default
+     * (app config `thinking_budget`, blank = unset) → null, which leaves the
+     * adaptive path in charge.
+     *
+     * A bad per-request value throws, because the caller asked for something
+     * specific and silently ignoring it would hide the mistake. A bad *admin*
+     * value falls through to null instead, so one wrong setting cannot break
+     * every request on the instance.
+     *
+     * @param array{supports_thinking: bool, supports_thinking_enabled: bool, ...} $caps
+     *
+     * @throws \InvalidArgumentException when the request asks for a budget the
+     *                                   model or max_tokens cannot honour
+     */
+    private function resolveThinkingBudget(array $options, string $model, array $caps, int $maxTokens): ?int {
+        $requested = $options['thinking_budget'] ?? null;
+        if ($requested !== null) {
+            $budget = $this->validateThinkingBudget($requested, $maxTokens);
+            if (!$caps['supports_thinking'] || !$caps['supports_thinking_enabled']) {
+                throw new \InvalidArgumentException(
+                    sprintf('Model %s does not support an explicit thinking budget; use adaptive thinking instead.', $model)
+                );
+            }
+            return $budget;
+        }
+
+        $adminDefault = $this->config->getAppValue($this->appName, 'thinking_budget', '');
+        if ($adminDefault === '' || !$caps['supports_thinking'] || !$caps['supports_thinking_enabled']) {
+            return null;
+        }
+        try {
+            return $this->validateThinkingBudget($adminDefault, $maxTokens);
+        } catch (\InvalidArgumentException $e) {
+            $this->logger->warning('AIquila SDK: Ignoring invalid thinking_budget default', [
+                'value' => $adminDefault,
+                'error' => $e->getMessage(),
+            ]);
+            return null;
+        }
+    }
+
+    /**
+     * The API requires a budget of at least MIN_THINKING_BUDGET and strictly
+     * below max_tokens, which caps thinking and response text together.
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function validateThinkingBudget(mixed $value, int $maxTokens): int {
+        if (!is_int($value) && !(is_string($value) && ctype_digit($value))) {
+            throw new \InvalidArgumentException('thinking_budget must be an integer number of tokens.');
+        }
+        $budget = (int)$value;
+        if ($budget < self::MIN_THINKING_BUDGET) {
+            throw new \InvalidArgumentException(
+                sprintf('thinking_budget must be at least %d tokens, got %d.', self::MIN_THINKING_BUDGET, $budget)
+            );
+        }
+        if ($budget >= $maxTokens) {
+            throw new \InvalidArgumentException(
+                sprintf('thinking_budget must be below max_tokens (%d), got %d.', $maxTokens, $budget)
+            );
+        }
+        return $budget;
     }
 
     /**
@@ -639,10 +728,12 @@ class ClaudeSDKService implements LLMProviderInterface, ProviderActionsInterface
     private function cacheModelInfoCapabilities(ModelInfo $info): void {
         $caps = [
             'max_tokens' => $info->maxTokens ?? ClaudeModels::getMaxTokenCeiling($info->id),
+            'context_window' => $info->maxInputTokens ?? ClaudeModels::getContextWindow($info->id),
             'supports_thinking' => $info->capabilities->thinking->supported ?? false,
+            'supports_thinking_enabled' => $info->capabilities->thinking->types->enabled->supported ?? false,
             'supports_effort' => $info->capabilities->effort->supported ?? false,
         ];
-        $this->cache->set($info->id, $caps, self::CAPABILITY_CACHE_TTL);
+        $this->cache->set(self::CAPABILITY_CACHE_PREFIX . $info->id, $caps, self::CAPABILITY_CACHE_TTL);
     }
 
     /**

--- a/nextcloud-app/lib/Service/ClaudeSDKService.php
+++ b/nextcloud-app/lib/Service/ClaudeSDKService.php
@@ -1494,6 +1494,16 @@ class ClaudeSDKService implements LLMProviderInterface, ProviderActionsInterface
                 storage: ProviderSettingsSchema::STORAGE_BOOL,
                 group: ProviderSettingsSchema::GROUP_BASIC,
             ),
+            ProviderSettingsSchema::number(
+                'thinking_budget',
+                'thinking_budget',
+                'Thinking budget (tokens)',
+                'Blank lets Claude decide how long to think (adaptive). A number pins the budget instead: at least '
+                    . self::MIN_THINKING_BUDGET . ' tokens and below max output tokens, which caps thinking and the '
+                    . 'reply together. Only models that support non-adaptive thinking accept this. Overridable per '
+                    . 'conversation with /thinking-budget.',
+                group: ProviderSettingsSchema::GROUP_BASIC,
+            ),
             ProviderSettingsSchema::maxTokens('max_tokens', ClaudeModels::DEFAULT_MAX_TOKENS),
             ProviderSettingsSchema::timeout('api_timeout', 30, 'Shared across all hosted providers.'),
             ProviderSettingsSchema::checkbox(

--- a/nextcloud-app/lib/Service/ClaudeSDKService.php
+++ b/nextcloud-app/lib/Service/ClaudeSDKService.php
@@ -4,7 +4,7 @@
 namespace OCA\AIquila\Service;
 
 use Anthropic\Beta\AnthropicBeta;
-use Anthropic\Beta\Files\FileMetadata;
+use Anthropic\Beta\Files\BetaFileMetadata;
 use Anthropic\Beta\Messages\BetaMetadata;
 use Anthropic\Client;
 use Anthropic\Core\Contracts\BaseStream;
@@ -306,9 +306,9 @@ class ClaudeSDKService implements LLMProviderInterface, ProviderActionsInterface
 
     /**
      * Upload bytes to Anthropic's beta Files API and return the resulting
-     * FileMetadata. Overridable for testing.
+     * BetaFileMetadata. Overridable for testing.
      */
-    protected function callFilesUpload(Client $client, FileParam $file): FileMetadata {
+    protected function callFilesUpload(Client $client, FileParam $file): BetaFileMetadata {
         return $client->beta->files->upload(
             file: $file,
             betas: [AnthropicBeta::FILES_API_2025_04_14],

--- a/nextcloud-app/lib/Service/Provider/ProviderSettingsSchema.php
+++ b/nextcloud-app/lib/Service/Provider/ProviderSettingsSchema.php
@@ -135,6 +135,32 @@ final class ProviderSettingsSchema {
         ];
     }
 
+    /**
+     * A free-form numeric field. `maxTokens()` and `timeout()` stay separate:
+     * they pin their own id and copy, which callers rely on.
+     *
+     * @return array{id: string, title: string, description: string, type: string, scope: string, key: string, default: string, group: string}
+     */
+    public static function number(
+        string $id,
+        string $appKey,
+        string $title,
+        string $description,
+        string $default = '',
+        string $group = self::GROUP_ADVANCED,
+    ): array {
+        return [
+            'id' => $id,
+            'title' => $title,
+            'description' => $description,
+            'type' => self::TYPE_NUMBER,
+            'scope' => self::SCOPE_ADMIN,
+            'key' => $appKey,
+            'default' => $default,
+            'group' => $group,
+        ];
+    }
+
     public static function maxTokens(string $appKey, int $default, string $description = ''): array {
         return [
             'id' => 'max_tokens',

--- a/nextcloud-app/openapi-full.json
+++ b/nextcloud-app/openapi-full.json
@@ -68,7 +68,8 @@
                                             "updatedAt",
                                             "projectId",
                                             "effort",
-                                            "thinking"
+                                            "thinking",
+                                            "thinkingBudget"
                                         ],
                                         "properties": {
                                             "id": {
@@ -108,6 +109,11 @@
                                             },
                                             "thinking": {
                                                 "type": "boolean",
+                                                "nullable": true
+                                            },
+                                            "thinkingBudget": {
+                                                "type": "integer",
+                                                "format": "int64",
                                                 "nullable": true
                                             }
                                         }
@@ -204,7 +210,8 @@
                                         "updatedAt",
                                         "projectId",
                                         "effort",
-                                        "thinking"
+                                        "thinking",
+                                        "thinkingBudget"
                                     ],
                                     "properties": {
                                         "id": {
@@ -244,6 +251,11 @@
                                         },
                                         "thinking": {
                                             "type": "boolean",
+                                            "nullable": true
+                                        },
+                                        "thinkingBudget": {
+                                            "type": "integer",
+                                            "format": "int64",
                                             "nullable": true
                                         }
                                     }
@@ -371,6 +383,7 @@
                                         "projectId",
                                         "effort",
                                         "thinking",
+                                        "thinkingBudget",
                                         "messages"
                                     ],
                                     "properties": {
@@ -411,6 +424,11 @@
                                         },
                                         "thinking": {
                                             "type": "boolean",
+                                            "nullable": true
+                                        },
+                                        "thinkingBudget": {
+                                            "type": "integer",
+                                            "format": "int64",
                                             "nullable": true
                                         },
                                         "messages": {
@@ -622,6 +640,12 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Adaptive-thinking override ('on'/'off'; empty string clears)"
+                                    },
+                                    "thinkingBudget": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Explicit thinking budget in tokens (empty string clears)"
                                     }
                                 }
                             }
@@ -667,7 +691,8 @@
                                         "updatedAt",
                                         "projectId",
                                         "effort",
-                                        "thinking"
+                                        "thinking",
+                                        "thinkingBudget"
                                     ],
                                     "properties": {
                                         "id": {
@@ -708,6 +733,11 @@
                                         "thinking": {
                                             "type": "boolean",
                                             "nullable": true
+                                        },
+                                        "thinkingBudget": {
+                                            "type": "integer",
+                                            "format": "int64",
+                                            "nullable": true
                                         }
                                     }
                                 }
@@ -715,7 +745,7 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid effort or thinking value",
+                        "description": "Invalid effort, thinking or thinkingBudget value",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1168,7 +1198,8 @@
                                         "updatedAt",
                                         "projectId",
                                         "effort",
-                                        "thinking"
+                                        "thinking",
+                                        "thinkingBudget"
                                     ],
                                     "properties": {
                                         "id": {
@@ -1208,6 +1239,11 @@
                                         },
                                         "thinking": {
                                             "type": "boolean",
+                                            "nullable": true
+                                        },
+                                        "thinkingBudget": {
+                                            "type": "integer",
+                                            "format": "int64",
                                             "nullable": true
                                         }
                                     }
@@ -1356,7 +1392,8 @@
                                         "updatedAt",
                                         "projectId",
                                         "effort",
-                                        "thinking"
+                                        "thinking",
+                                        "thinkingBudget"
                                     ],
                                     "properties": {
                                         "id": {
@@ -1396,6 +1433,11 @@
                                         },
                                         "thinking": {
                                             "type": "boolean",
+                                            "nullable": true
+                                        },
+                                        "thinkingBudget": {
+                                            "type": "integer",
+                                            "format": "int64",
                                             "nullable": true
                                         }
                                     }

--- a/nextcloud-app/openapi.json
+++ b/nextcloud-app/openapi.json
@@ -68,7 +68,8 @@
                                             "updatedAt",
                                             "projectId",
                                             "effort",
-                                            "thinking"
+                                            "thinking",
+                                            "thinkingBudget"
                                         ],
                                         "properties": {
                                             "id": {
@@ -108,6 +109,11 @@
                                             },
                                             "thinking": {
                                                 "type": "boolean",
+                                                "nullable": true
+                                            },
+                                            "thinkingBudget": {
+                                                "type": "integer",
+                                                "format": "int64",
                                                 "nullable": true
                                             }
                                         }
@@ -204,7 +210,8 @@
                                         "updatedAt",
                                         "projectId",
                                         "effort",
-                                        "thinking"
+                                        "thinking",
+                                        "thinkingBudget"
                                     ],
                                     "properties": {
                                         "id": {
@@ -244,6 +251,11 @@
                                         },
                                         "thinking": {
                                             "type": "boolean",
+                                            "nullable": true
+                                        },
+                                        "thinkingBudget": {
+                                            "type": "integer",
+                                            "format": "int64",
                                             "nullable": true
                                         }
                                     }
@@ -371,6 +383,7 @@
                                         "projectId",
                                         "effort",
                                         "thinking",
+                                        "thinkingBudget",
                                         "messages"
                                     ],
                                     "properties": {
@@ -411,6 +424,11 @@
                                         },
                                         "thinking": {
                                             "type": "boolean",
+                                            "nullable": true
+                                        },
+                                        "thinkingBudget": {
+                                            "type": "integer",
+                                            "format": "int64",
                                             "nullable": true
                                         },
                                         "messages": {
@@ -622,6 +640,12 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Adaptive-thinking override ('on'/'off'; empty string clears)"
+                                    },
+                                    "thinkingBudget": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Explicit thinking budget in tokens (empty string clears)"
                                     }
                                 }
                             }
@@ -667,7 +691,8 @@
                                         "updatedAt",
                                         "projectId",
                                         "effort",
-                                        "thinking"
+                                        "thinking",
+                                        "thinkingBudget"
                                     ],
                                     "properties": {
                                         "id": {
@@ -708,6 +733,11 @@
                                         "thinking": {
                                             "type": "boolean",
                                             "nullable": true
+                                        },
+                                        "thinkingBudget": {
+                                            "type": "integer",
+                                            "format": "int64",
+                                            "nullable": true
                                         }
                                     }
                                 }
@@ -715,7 +745,7 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid effort or thinking value",
+                        "description": "Invalid effort, thinking or thinkingBudget value",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1168,7 +1198,8 @@
                                         "updatedAt",
                                         "projectId",
                                         "effort",
-                                        "thinking"
+                                        "thinking",
+                                        "thinkingBudget"
                                     ],
                                     "properties": {
                                         "id": {
@@ -1208,6 +1239,11 @@
                                         },
                                         "thinking": {
                                             "type": "boolean",
+                                            "nullable": true
+                                        },
+                                        "thinkingBudget": {
+                                            "type": "integer",
+                                            "format": "int64",
                                             "nullable": true
                                         }
                                     }
@@ -1356,7 +1392,8 @@
                                         "updatedAt",
                                         "projectId",
                                         "effort",
-                                        "thinking"
+                                        "thinking",
+                                        "thinkingBudget"
                                     ],
                                     "properties": {
                                         "id": {
@@ -1396,6 +1433,11 @@
                                         },
                                         "thinking": {
                                             "type": "boolean",
+                                            "nullable": true
+                                        },
+                                        "thinkingBudget": {
+                                            "type": "integer",
+                                            "format": "int64",
                                             "nullable": true
                                         }
                                     }

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",

--- a/nextcloud-app/src/components/ChatInput.vue
+++ b/nextcloud-app/src/components/ChatInput.vue
@@ -124,6 +124,12 @@ const SLASH_COMMANDS = [
 		icon: '🧠',
 		description: 'Toggle adaptive thinking for this conversation (/thinking:on or /thinking:off; no value resets to default)',
 	},
+	{
+		id: 'thinking-budget',
+		label: '/thinking-budget',
+		icon: '🎚️',
+		description: 'Cap thinking at a fixed number of tokens (e.g. /thinking-budget:8000; no value or "off" returns to adaptive)',
+	},
 ]
 
 export default {
@@ -239,6 +245,9 @@ export default {
 				break
 			case 'thinking':
 				this.$emit('command', { type: 'set-thinking', args })
+				break
+			case 'thinking-budget':
+				this.$emit('command', { type: 'set-thinking-budget', args })
 				break
 			}
 		},

--- a/nextcloud-app/src/components/ChatView.vue
+++ b/nextcloud-app/src/components/ChatView.vue
@@ -304,6 +304,9 @@ export default {
 			case 'set-thinking':
 				this.setThinking(args || '')
 				break
+			case 'set-thinking-budget':
+				this.setThinkingBudget(args || '')
+				break
 			case 'add-project':
 				if (args) {
 					const id = parseInt(args, 10)
@@ -359,6 +362,26 @@ export default {
 			} catch (err) {
 				this.noticeIsError = true
 				this.notice = err.response?.data?.error || t('aiquila', 'Failed to set thinking')
+			}
+		},
+		async setThinkingBudget(value) {
+			// "off" reads better than an empty command for "stop capping this".
+			const budget = value === 'off' ? '' : value
+			if (budget !== '' && !/^\d+$/.test(budget)) {
+				this.noticeIsError = true
+				this.notice = t('aiquila', 'Usage: /thinking-budget:8000 or /thinking-budget:off')
+				return
+			}
+			try {
+				const { data } = await updateConversation(this.conversation.id, { thinkingBudget: budget })
+				this.$emit('conversation-updated', data)
+				this.noticeIsError = false
+				this.notice = budget === ''
+					? t('aiquila', 'Thinking budget cleared — back to adaptive thinking for this conversation')
+					: t('aiquila', 'Thinking budget set to {budget} tokens for this conversation — applies to new messages only', { budget })
+			} catch (err) {
+				this.noticeIsError = true
+				this.notice = err.response?.data?.error || t('aiquila', 'Failed to set thinking budget')
 			}
 		},
 		async detachProject() {

--- a/nextcloud-app/tests/Unit/ClaudeSDKServiceAutoStreamTest.php
+++ b/nextcloud-app/tests/Unit/ClaudeSDKServiceAutoStreamTest.php
@@ -82,6 +82,7 @@ class ClaudeSDKServiceAutoStreamTest extends TestCase {
             'max_tokens' => 128000,
             'context_window' => 1000000,
             'supports_thinking' => false,
+            'supports_thinking_enabled' => false,
             'supports_effort' => false,
         ]);
         $this->cacheFactory = $this->createMock(ICacheFactory::class);

--- a/nextcloud-app/tests/Unit/ClaudeSDKServiceCapabilityTest.php
+++ b/nextcloud-app/tests/Unit/ClaudeSDKServiceCapabilityTest.php
@@ -115,7 +115,7 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
                 'image_input' => ['supported' => true],
                 'pdf_input' => ['supported' => true],
                 'structured_outputs' => ['supported' => false],
-                'thinking' => ['supported' => true, 'types' => ['adaptive' => ['supported' => true]]],
+                'thinking' => ['supported' => true, 'types' => ['adaptive' => ['supported' => true], 'enabled' => ['supported' => true]]],
             ],
             new \DateTime(),
             'Claude Opus 4.6',
@@ -161,7 +161,7 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
                 'image_input' => ['supported' => true],
                 'pdf_input' => ['supported' => true],
                 'structured_outputs' => ['supported' => false],
-                'thinking' => ['supported' => true, 'types' => ['adaptive' => ['supported' => true]]],
+                'thinking' => ['supported' => true, 'types' => ['adaptive' => ['supported' => true], 'enabled' => ['supported' => true]]],
             ],
             new \DateTime(),
             'Claude Opus 4.6',
@@ -239,7 +239,7 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
                 'image_input' => ['supported' => true],
                 'pdf_input' => ['supported' => true],
                 'structured_outputs' => ['supported' => false],
-                'thinking' => ['supported' => true, 'types' => ['adaptive' => ['supported' => true]]],
+                'thinking' => ['supported' => true, 'types' => ['adaptive' => ['supported' => true], 'enabled' => ['supported' => true]]],
             ],
             new \DateTime(),
             'Claude Opus 4.7',
@@ -287,7 +287,7 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
                 'image_input' => ['supported' => true],
                 'pdf_input' => ['supported' => true],
                 'structured_outputs' => ['supported' => false],
-                'thinking' => ['supported' => false, 'types' => ['adaptive' => ['supported' => false]]],
+                'thinking' => ['supported' => false, 'types' => ['adaptive' => ['supported' => false], 'enabled' => ['supported' => false]]],
             ],
             new \DateTime(),
             'Claude Haiku 4.5',
@@ -306,7 +306,7 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
     }
 
     /** Build a service for a given model with cached caps and optional admin config. */
-    private function makeServiceForModel(string $model, array $appConfig = []): CapabilityTestableService {
+    private function makeServiceForModel(string $model, array $appConfig = [], bool $supportsEnabledThinking = true): CapabilityTestableService {
         $config = $this->createMock(IConfig::class);
         $config->method('getUserValue')->willReturn('');
         $config->method('getAppValue')
@@ -321,6 +321,7 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
             'max_tokens' => 64000,
             'context_window' => 200000,
             'supports_thinking' => true,
+            'supports_thinking_enabled' => $supportsEnabledThinking,
             'supports_effort' => true,
         ]);
 
@@ -368,6 +369,105 @@ class ClaudeSDKServiceCapabilityTest extends TestCase {
         $service = $this->makeServiceForModel(ClaudeModels::FABLE_5);
         $service->chat([['role' => 'user', 'content' => 'Hi']], null, 'testuser', ['thinking' => true]);
         $this->assertEquals(['type' => 'adaptive'], $service->lastCreateParams['thinking']);
+    }
+
+    public function testExplicitBudgetSwitchesThinkingToEnabledMode(): void {
+        $service = $this->makeServiceForModel(ClaudeModels::FABLE_5);
+        $service->chat([['role' => 'user', 'content' => 'Hi']], null, 'testuser', ['thinking_budget' => 2048]);
+        $this->assertEquals(
+            ['type' => 'enabled', 'budget_tokens' => 2048],
+            $service->lastCreateParams['thinking']
+        );
+    }
+
+    /** A budget implies thinking, so it does not need the adaptive toggle on as well. */
+    public function testExplicitBudgetDoesNotNeedThinkingEnabled(): void {
+        $service = $this->makeServiceForModel(ClaudeModels::FABLE_5, ['thinking' => 'false']);
+        $service->chat([['role' => 'user', 'content' => 'Hi']], null, 'testuser', ['thinking_budget' => 2048]);
+        $this->assertEquals(
+            ['type' => 'enabled', 'budget_tokens' => 2048],
+            $service->lastCreateParams['thinking']
+        );
+    }
+
+    /** "Off" is the more specific instruction and must beat a budget. */
+    public function testExplicitThinkingOffBeatsBudget(): void {
+        $service = $this->makeServiceForModel(ClaudeModels::FABLE_5, ['thinking' => 'true']);
+        $service->chat([['role' => 'user', 'content' => 'Hi']], null, 'testuser', [
+            'thinking' => false,
+            'thinking_budget' => 2048,
+        ]);
+        $this->assertArrayNotHasKey('thinking', $service->lastCreateParams);
+    }
+
+    public function testAdminBudgetDefaultUsedWithoutOverride(): void {
+        $service = $this->makeServiceForModel(ClaudeModels::FABLE_5, ['thinking_budget' => '3000']);
+        $service->chat([['role' => 'user', 'content' => 'Hi']], null, 'testuser');
+        $this->assertEquals(
+            ['type' => 'enabled', 'budget_tokens' => 3000],
+            $service->lastCreateParams['thinking']
+        );
+    }
+
+    public function testBudgetOverrideBeatsAdminDefault(): void {
+        $service = $this->makeServiceForModel(ClaudeModels::FABLE_5, ['thinking_budget' => '3000']);
+        $service->chat([['role' => 'user', 'content' => 'Hi']], null, 'testuser', ['thinking_budget' => 2048]);
+        $this->assertEquals(
+            ['type' => 'enabled', 'budget_tokens' => 2048],
+            $service->lastCreateParams['thinking']
+        );
+    }
+
+    /** One bad admin setting must not break every request on the instance. */
+    public function testInvalidAdminBudgetIsIgnored(): void {
+        $service = $this->makeServiceForModel(ClaudeModels::FABLE_5, ['thinking_budget' => '12', 'thinking' => 'true']);
+        $service->chat([['role' => 'user', 'content' => 'Hi']], null, 'testuser');
+        $this->assertEquals(['type' => 'adaptive'], $service->lastCreateParams['thinking']);
+    }
+
+    /**
+     * chat() reports every failure as an ['error' => …] array rather than
+     * throwing, so a rejected budget must surface the reason there — and the
+     * request must not be sent.
+     */
+    public function testBudgetBelowMinimumIsRejected(): void {
+        $service = $this->makeServiceForModel(ClaudeModels::FABLE_5);
+        $result = $service->chat([['role' => 'user', 'content' => 'Hi']], null, 'testuser', ['thinking_budget' => 500]);
+        $this->assertStringContainsString('at least ' . ClaudeSDKService::MIN_THINKING_BUDGET, $result['error']);
+        $this->assertNull($service->lastCreateParams);
+    }
+
+    /** max_tokens caps thinking and the reply together, so the budget must stay under it. */
+    public function testBudgetAtOrAboveMaxTokensIsRejected(): void {
+        $service = $this->makeServiceForModel(ClaudeModels::FABLE_5);
+        $result = $service->chat([['role' => 'user', 'content' => 'Hi']], null, 'testuser', ['thinking_budget' => 4096]);
+        $this->assertStringContainsString('below max_tokens', $result['error']);
+        $this->assertNull($service->lastCreateParams);
+    }
+
+    public function testNonNumericBudgetIsRejected(): void {
+        $service = $this->makeServiceForModel(ClaudeModels::FABLE_5);
+        $result = $service->chat([['role' => 'user', 'content' => 'Hi']], null, 'testuser', ['thinking_budget' => 'lots']);
+        $this->assertStringContainsString('must be an integer', $result['error']);
+        $this->assertNull($service->lastCreateParams);
+    }
+
+    public function testBudgetRejectedOnAdaptiveOnlyModel(): void {
+        $service = $this->makeServiceForModel(ClaudeModels::FABLE_5, [], false);
+        $result = $service->chat([['role' => 'user', 'content' => 'Hi']], null, 'testuser', ['thinking_budget' => 2048]);
+        $this->assertStringContainsString('does not support an explicit thinking budget', $result['error']);
+        $this->assertNull($service->lastCreateParams);
+    }
+
+    /** Without a live capability answer we only claim adaptive, so a budget is refused. */
+    public function testBudgetRejectedOnStaticFallback(): void {
+        $this->cache->method('get')->willReturn(null);
+        $service = new CapabilityTestableService($this->config, $this->logger, $this->credentials, $this->cacheFactory, $this->requestMetadata);
+        $service->throwOnRetrieveModel(new \RuntimeException('offline'));
+
+        $result = $service->chat([['role' => 'user', 'content' => 'Hi']], null, 'testuser', ['thinking_budget' => 2048]);
+        $this->assertStringContainsString('does not support an explicit thinking budget', $result['error']);
+        $this->assertNull($service->lastCreateParams);
     }
 
     public function testCallCreateStreamForwardsTools(): void {

--- a/nextcloud-app/tests/Unit/ClaudeSDKServiceNativeMcpTest.php
+++ b/nextcloud-app/tests/Unit/ClaudeSDKServiceNativeMcpTest.php
@@ -74,6 +74,7 @@ class ClaudeSDKServiceNativeMcpTest extends TestCase {
         $this->cache->method('get')->willReturn([
             'max_tokens' => 8192,
             'supports_thinking' => false,
+            'supports_thinking_enabled' => false,
             'supports_effort' => false,
         ]);
         $this->cacheFactory = $this->createMock(ICacheFactory::class);

--- a/nextcloud-app/tests/Unit/ConversationControllerThinkingBudgetTest.php
+++ b/nextcloud-app/tests/Unit/ConversationControllerThinkingBudgetTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace OCA\AIquila\Tests\Unit;
+
+use OCA\AIquila\Controller\ConversationController;
+use OCA\AIquila\Db\Conversation;
+use OCA\AIquila\Db\ConversationMapper;
+use OCA\AIquila\Db\MessageFileMapper;
+use OCA\AIquila\Db\MessageMapper;
+use OCA\AIquila\Db\ProjectMapper;
+use OCA\AIquila\Db\ProjectPathMapper;
+use OCA\AIquila\Service\ClaudeModels;
+use OCA\AIquila\Service\ClaudeSDKService;
+use OCA\AIquila\Service\ContextChatService;
+use OCA\AIquila\Service\FileService;
+use OCA\AIquila\Service\FilesService;
+use OCA\AIquila\Service\ImageOptimizer;
+use OCA\AIquila\Service\McpClientService;
+use OCA\AIquila\Service\NativeMcpService;
+use OCA\AIquila\Service\Provider\LLMProviderFactory;
+use OCA\AIquila\Service\Provider\LLMProviderInterface;
+use OCP\BackgroundJob\IJobList;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Covers thinkingBudget validation on ConversationController::update().
+ *
+ * The budget is the only conversation pin with a numeric range, and the range
+ * depends on the provider's max_tokens rather than a static table, so it is
+ * worth pinning down.
+ */
+class ConversationControllerThinkingBudgetTest extends TestCase {
+    private const MAX_TOKENS = 4096;
+
+    private ConversationMapper $mapper;
+    private Conversation $conversation;
+
+    /** @param array<string, bool> $capabilityOverrides */
+    private function makeController(array $capabilityOverrides = []): ConversationController {
+        $this->conversation = new Conversation();
+        $this->conversation->setUserId('testuser');
+        $this->conversation->setModel(ClaudeModels::DEFAULT_MODEL);
+
+        $this->mapper = $this->createMock(ConversationMapper::class);
+        $this->mapper->method('findByIdAndUser')->willReturn($this->conversation);
+        $this->mapper->method('update')->willReturnArgument(0);
+
+        $provider = $this->createMock(LLMProviderInterface::class);
+        $provider->method('getCapabilities')->willReturn(array_merge([
+            'vision' => true,
+            'tools' => true,
+            'streaming' => true,
+            'thinking' => true,
+            'effort' => true,
+            'native_mcp' => true,
+            'documents' => true,
+        ], $capabilityOverrides));
+        $provider->method('getMaxTokens')->willReturn(self::MAX_TOKENS);
+        $provider->method('getLabel')->willReturn('Ollama');
+        $provider->method('getModel')->willReturn(ClaudeModels::DEFAULT_MODEL);
+
+        $factory = $this->createMock(LLMProviderFactory::class);
+        $factory->method('hasPermittedProvider')->willReturn(true);
+        $factory->method('getProvider')->willReturn($provider);
+        $factory->method('getProviderById')->willReturn($provider);
+        $factory->method('getProviderForUser')->willReturn($provider);
+
+        $request = $this->createMock(IRequest::class);
+        $request->method('getParams')->willReturn([]);
+
+        return new ConversationController(
+            'aiquila',
+            $request,
+            $this->mapper,
+            $this->createMock(MessageMapper::class),
+            $this->createMock(MessageFileMapper::class),
+            $this->createMock(ProjectMapper::class),
+            $this->createMock(ProjectPathMapper::class),
+            $factory,
+            $this->createMock(FileService::class),
+            $this->createMock(FilesService::class),
+            $this->createMock(ImageOptimizer::class),
+            $this->createMock(McpClientService::class),
+            $this->createMock(NativeMcpService::class),
+            $this->createMock(IJobList::class),
+            $this->createMock(ContextChatService::class),
+            'testuser',
+            $this->createMock(LoggerInterface::class),
+        );
+    }
+
+    public function testValidBudgetIsStored(): void {
+        $controller = $this->makeController();
+        $response = $controller->update(1, thinkingBudget: '2048');
+
+        $this->assertEquals(200, $response->getStatus());
+        $this->assertSame(2048, $this->conversation->getThinkingBudget());
+    }
+
+    public function testEmptyStringClearsTheBudget(): void {
+        $controller = $this->makeController();
+        $this->conversation->setThinkingBudget(2048);
+
+        $response = $controller->update(1, thinkingBudget: '');
+
+        $this->assertEquals(200, $response->getStatus());
+        $this->assertNull($this->conversation->getThinkingBudget());
+    }
+
+    /** Omitting the param must leave an existing pin alone. */
+    public function testOmittedBudgetLeavesThePinUntouched(): void {
+        $controller = $this->makeController();
+        $this->conversation->setThinkingBudget(2048);
+
+        $controller->update(1, title: 'Renamed');
+
+        $this->assertSame(2048, $this->conversation->getThinkingBudget());
+    }
+
+    public function testBudgetBelowMinimumIsRejected(): void {
+        $controller = $this->makeController();
+        $response = $controller->update(1, thinkingBudget: '512');
+
+        $this->assertEquals(400, $response->getStatus());
+        $this->assertNull($this->conversation->getThinkingBudget());
+    }
+
+    /** The ceiling is the provider's max_tokens, not a static model table. */
+    public function testBudgetAtMaxTokensIsRejected(): void {
+        $controller = $this->makeController();
+        $response = $controller->update(1, thinkingBudget: (string)self::MAX_TOKENS);
+
+        $this->assertEquals(400, $response->getStatus());
+        $this->assertStringContainsString(
+            (string)(self::MAX_TOKENS - 1),
+            $response->getData()['error'],
+        );
+        $this->assertNull($this->conversation->getThinkingBudget());
+    }
+
+    public function testNonNumericBudgetIsRejected(): void {
+        $controller = $this->makeController();
+        $response = $controller->update(1, thinkingBudget: '8k');
+
+        $this->assertEquals(400, $response->getStatus());
+        $this->assertNull($this->conversation->getThinkingBudget());
+    }
+
+    public function testProviderWithoutThinkingIsRejectedFirst(): void {
+        $controller = $this->makeController(['thinking' => false]);
+        $response = $controller->update(1, thinkingBudget: '2048');
+
+        $this->assertEquals(400, $response->getStatus());
+        $this->assertStringContainsString('does not support a thinking budget', $response->getData()['error']);
+        $this->assertNull($this->conversation->getThinkingBudget());
+    }
+
+    public function testMinimumBoundaryIsAccepted(): void {
+        $controller = $this->makeController();
+        $response = $controller->update(1, thinkingBudget: (string)ClaudeSDKService::MIN_THINKING_BUDGET);
+
+        $this->assertEquals(200, $response->getStatus());
+        $this->assertSame(ClaudeSDKService::MIN_THINKING_BUDGET, $this->conversation->getThinkingBudget());
+    }
+}


### PR DESCRIPTION
Closes #294

`buildRequestParams()` hard-coded `{type: 'adaptive'}` whenever the model supported thinking, so there was no way to cap thinking cost or force a deeper reasoning pass. This adds an explicit `budget_tokens` path end to end: request layer, persistence, admin default, occ, and a `/thinking-budget` slash command.

### On the issue's age

#294 was written against `anthropic-ai/sdk` `^0.16.0`; we were pinned to `^0.40.0`. The gap it describes is unchanged, but two things aged well:

- `budget_tokens` was removed in 0.7.0 and re-added on mainline in 0.16.0 — it has now survived 27 more releases, so it is safe to build on.
- The SDK gained a **per-type** capability flag we did not have at 0.16 (`capabilities.thinking.types.enabled.supported`). That replaces the issue's proposal to hand-maintain a model matrix in `ClaudeModels` — the guard reads off the live model-retrieve response instead, with a conservative static fallback.

### Commits

1. **`chore`: bump anthropic-ai/sdk 0.40 → 0.43.** Files/Skills went GA in 0.43, which renamed `Anthropic\Beta\Files\FileMetadata` to `BetaFileMetadata`. Upload behaviour is unchanged — migrating to the GA resource would also drop the beta header from message requests carrying `source.type === 'file'`, which is a behaviour change and does not belong in a dependency bump.
2. **`feat`: forward an explicit thinking budget to the Messages API.** Capability guard, validation, and precedence mirroring `resolveEffort()`. An explicit `thinking: false` still wins over a budget, and still omits the key entirely (an explicit `{type: 'disabled'}` 400s on Fable 5). Also versions the capability cache key — the cached array grew a key — and fixes `cacheModelInfoCapabilities()` omitting `context_window`.
3. **`feat`: persist a per-conversation thinking budget.** Nullable column + migration, alongside the existing effort/thinking pins. The ceiling is the provider's effective `max_tokens`, not the model's static ceiling, so a value accepted here is one the request layer will also accept.
4. **`feat`: `/thinking-budget` command and admin default.** Adds a generic `ProviderSettingsSchema::number()` rather than bending the special-cased `maxTokens()`/`timeout()` helpers.
5. **`test`: cover explicit thinking budgets.** 19 new cases. Includes a first `ConversationController` test — the `/effort` and `/thinking` persistence paths had none.
6. **`chore`: bump to 0.4.6.**

### Verification

- `composer psalm` clean, 603 unit tests pass (up from 584), OpenAPI regenerated, frontend builds.
- Exercised in the dev stack against a live NC33: migration applied, `thinkingBudget` round-trips through the API and the DB, out-of-range and non-numeric values rejected with the accepted range in the message, a non-thinking provider rejected before range validation, switching to such a provider clears the pin, and the occ option accepts/rejects/displays correctly. No new level-3/4 log lines.

### Relationship to #410

This never emits a `disabled` thinking block — omission stays how we express "off" — so it does not collide with #410's Opus 5 effort/thinking-disabled guard. The `supports_thinking_enabled` plumbing is where #410 can hang its own per-mode flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)