### PR TITLE
fix(nextcloud): refresh the Mistral model registry, fix vision, add reasoning

### DIFF
--- a/docs/dev/mistral-provider.md
+++ b/docs/dev/mistral-provider.md
@@ -88,6 +88,65 @@ For an OpenAI-compatible vendor, extend `AbstractOpenAiCompatibleProvider`
 instead of implementing the interface from scratch — see `DeepSeekProvider` and
 [`HetznerProvider`](hetzner-provider.md), which are ~60 lines each.
 
+## Models & reasoning
+
+`nextcloud-app/lib/Service/MistralModels.php` is the static registry. It is only
+a **fallback**: `MistralProvider::listModels()` prefers the live `/v1/models`
+listing and the settings UI renders that when it is reachable.
+
+### Dated IDs, not `-latest` aliases
+
+The registry pins dated model IDs (`mistral-small-2603`, `mistral-large-2512`, …)
+on purpose. It used to pin `-latest` aliases on the assumption that they stay
+current by themselves, which does not survive a family being retired:
+`pixtral-large-2411` was retired on 2026-05-31 and `ministral-8b-2410` on
+2025-12-31, and the app went on pointing its **vision fallback** at Pixtral long
+after the API stopped serving it (#487). Dated IDs can be checked against
+Mistral's published deprecation table; aliases cannot.
+
+Current entries: Mistral Large 3, Medium 3.5, Small 4 and Ministral 3
+(14B/8B/3B). All are natively multimodal, so `supportsVision()` is a lookup over
+the registry plus a family-prefix check — not the old `str_contains(…, 'pixtral')`
+heuristic. `MistralModels::VISION_MODEL` is the model
+`MistralProvider::visionOptions()` swaps in when the configured model cannot take
+image input; since the default (Small 4) is multimodal, it rarely fires.
+
+**When Mistral ships a new generation**, add the dated IDs to the constants,
+`MAX_TOKENS_CEILING`, `VISION_MODELS` and `getAllModels()`, and check the
+deprecation table for anything the app still names.
+
+### Reasoning (`reasoning_effort`)
+
+Mistral Small 4 and Medium 3.5 are hybrid reasoning models. They take a
+`reasoning_effort` request parameter — `high` (think before answering) or `none`
+— which the app exposes through its existing **`effort`** capability, not
+`thinking`/`thinkingBudget`: there is no token budget to set. Resolution order in
+`MistralProvider::resolveEffort()` is conversation override (`/effort`) → user
+setting (`user_effort_mistral`) → admin setting (`effort_mistral`); a value the
+model does not accept falls through rather than 400ing the API, and when nothing
+resolves the parameter is omitted entirely.
+
+Effort vocabularies differ per provider (Anthropic's `low…max` vs Mistral's
+`none`/`high`), so `LLMProviderInterface::getAllowedEfforts()` lets each provider
+own its own table. `ConversationController::update()` validates through it;
+providers without an effort knob return `[]`.
+
+With `reasoning_effort: high` the response shape changes: `message.content`
+becomes a list of chunks (`{type: thinking, thinking: [TextChunk…]}` then
+`{type: text}`) instead of a plain string, and the streaming `delta.content` is a
+chunk list while the model thinks and a string afterwards.
+`extractMessageText()` / `extractThinkingText()` split the two. The reasoning
+trace is **replayed** on assistant turns inside a tool loop —
+`assistantMessageFromToolCalls()` keeps it as a `thinking` block and
+`toMistralMessages()` sends it back — because Mistral's docs are explicit that
+stripping it costs coherence across turns.
+
+> **Known limitation.** Persisted conversation history stores assistant messages
+> as plain text, so a reasoning trace does not survive a page reload; it is only
+> replayed within a single request's agentic loop. The native-MCP Conversations
+> path drops it too (`toConversationInputs()` keeps text/image/document blocks
+> only).
+
 ## Verifying MCP works with Mistral (#136)
 
 The AIquila MCP server is provider-agnostic — it just exposes Nextcloud tools

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiquila-mcp",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila-mcp",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Nextcloud MCP server — files, calendar, contacts, mail, maps, notes, tasks & 120+ more tools",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/scripts/test-mistral-mcp.ts
+++ b/mcp-server/scripts/test-mistral-mcp.ts
@@ -20,7 +20,7 @@
  *
  * Optional env vars:
  *   MCP_URL               Base URL of the MCP server (default: http://localhost:3339)
- *   MISTRAL_MODEL         Model to drive the loop (default: mistral-large-latest)
+ *   MISTRAL_MODEL         Model to drive the loop (default: mistral-large-2512)
  *
  * Usage:
  *   cd mcp-server/scripts
@@ -36,7 +36,7 @@ import * as crypto from 'node:crypto';
 const BASE_URL = (process.env.MCP_URL ?? 'http://localhost:3339').replace(/\/$/, '');
 const NC_USER = process.env.NEXTCLOUD_USER ?? '';
 const NC_PASS = process.env.NEXTCLOUD_PASSWORD ?? '';
-const MODEL = process.env.MISTRAL_MODEL ?? 'mistral-large-latest';
+const MODEL = process.env.MISTRAL_MODEL ?? 'mistral-large-2512';
 const MAX_ITERATIONS = 8;
 
 const REDIRECT_URI = 'https://localhost/callback';

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -18,7 +18,7 @@
       ]
     }
   ],
-  "version": "0.4.6",
+  "version": "0.4.7",
   "websiteUrl": "https://github.com/elgorro/aiquila",
   "remotes": [
     {
@@ -36,7 +36,7 @@
     {
       "registryType": "npm",
       "identifier": "aiquila-mcp",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -64,7 +64,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.4.6",
+      "identifier": "ghcr.io/elgorro/aiquila-mcp:0.4.7",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/mcp-server/src/__tests__/tools-cowork.test.ts
+++ b/mcp-server/src/__tests__/tools-cowork.test.ts
@@ -85,10 +85,10 @@ describe('Cowork Tools', () => {
   describe('create_coworker', () => {
     it('creates from a template via the templates endpoint', async () => {
       mockFetchAiquilaAPI.mockResolvedValue(sampleCoworker);
-      const res = await createCoworkerTool.handler({ templateId: 'classify-images-pixtral' });
+      const res = await createCoworkerTool.handler({ templateId: 'classify-images-mistral' });
       expect(mockFetchAiquilaAPI).toHaveBeenCalledWith('/coworkers/templates', {
         method: 'POST',
-        body: { templateId: 'classify-images-pixtral' },
+        body: { templateId: 'classify-images-mistral' },
       });
       expect(res.content[0].text).toContain('Coworker created');
     });

--- a/mcp-server/src/tools/apps/cowork.ts
+++ b/mcp-server/src/tools/apps/cowork.ts
@@ -172,7 +172,7 @@ export const createCoworkerTool = {
     openWorldHint: false,
   },
   description:
-    'Create a coworker. Provide templateId to start from a built-in template (e.g. "classify-images-claude" or "classify-images-pixtral"), and/or explicit fields to configure a custom one. Fields override template defaults.',
+    'Create a coworker. Provide templateId to start from a built-in template (e.g. "classify-images-claude" or "classify-images-mistral"), and/or explicit fields to configure a custom one. Fields override template defaults.',
   inputSchema: z.object({
     templateId: z
       .string()

--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -36,7 +36,7 @@ AIquila includes a [Model Context Protocol](https://modelcontextprotocol.io) ser
 
 Made possible by [Claude](https://www.anthropic.com/claude) from [Anthropic](https://www.anthropic.com) and the [Nextcloud](https://nextcloud.com) open-source community.
     ]]></description>
-    <version>0.4.6</version>
+    <version>0.4.7</version>
     <licence>AGPL-3.0-or-later</licence>
     <author mail="aiquila@mailbox.org">elgorro</author>
     <documentation>

--- a/nextcloud-app/lib/Controller/ConversationController.php
+++ b/nextcloud-app/lib/Controller/ConversationController.php
@@ -14,7 +14,6 @@ use OCA\AIquila\Db\MessageMapper;
 use OCA\AIquila\Db\ProjectMapper;
 use OCA\AIquila\Db\ProjectPathMapper;
 use OCA\AIquila\Http\SSEResponse;
-use OCA\AIquila\Service\ClaudeModels;
 use OCA\AIquila\Service\ClaudeSDKService;
 use OCA\AIquila\Service\FileService;
 use OCA\AIquila\Service\FilesService;
@@ -313,8 +312,10 @@ class ConversationController extends Controller {
         }
 
         if ($effort !== null && $effort !== '') {
-            // Effort is an Anthropic concept; validating a Hetzner or Ollama
-            // conversation against Anthropic's table produced nonsense advice.
+            // Effort vocabularies differ per provider (Anthropic's low…max,
+            // Mistral's none/high), so validate against the provider that owns
+            // the conversation — checking a Mistral conversation against
+            // Anthropic's table produced nonsense advice.
             $provider = $this->resolveProvider($conversation);
             if (!$provider->getCapabilities()['effort']) {
                 return new JSONResponse([
@@ -324,9 +325,9 @@ class ConversationController extends Controller {
                 ], 400);
             }
 
-            $model = ClaudeModels::resolveModel($conversation->getModel());
-            if (!ClaudeModels::isAllowedEffort($model, $effort)) {
-                $allowed = ClaudeModels::getAllowedEfforts($model);
+            $model = $conversation->getModel();
+            $allowed = $provider->getAllowedEfforts($model);
+            if (!in_array($effort, $allowed, true)) {
                 return new JSONResponse([
                     'error' => $allowed === []
                         ? 'Model ' . $model . ' does not support effort'

--- a/nextcloud-app/lib/Service/ClaudeSDKService.php
+++ b/nextcloud-app/lib/Service/ClaudeSDKService.php
@@ -1555,6 +1555,13 @@ class ClaudeSDKService implements LLMProviderInterface, ProviderActionsInterface
         ]);
     }
 
+    /**
+     * @return list<string>
+     */
+    public function getAllowedEfforts(string $model): array {
+        return ClaudeModels::getAllowedEfforts(ClaudeModels::resolveModel($model));
+    }
+
     public function getConfiguration(): array {
         return [
             'api_key' => $this->config->getAppValue($this->appName, 'api_key', ''),

--- a/nextcloud-app/lib/Service/CoworkerService.php
+++ b/nextcloud-app/lib/Service/CoworkerService.php
@@ -56,9 +56,9 @@ class CoworkerService {
                 'provider' => 'anthropic',
             ]),
             array_merge($shared, [
-                'id' => 'classify-images-pixtral',
-                'title' => 'Classify images — Pixtral',
-                'description' => 'Tag images in a folder using Mistral Pixtral, nightly.',
+                'id' => 'classify-images-mistral',
+                'title' => 'Classify images — Mistral vision',
+                'description' => 'Tag images in a folder using Mistral vision, nightly.',
                 'provider' => 'mistral',
             ]),
         ];

--- a/nextcloud-app/lib/Service/MistralModels.php
+++ b/nextcloud-app/lib/Service/MistralModels.php
@@ -10,42 +10,109 @@ namespace OCA\AIquila\Service;
  *
  * Static fallback list + per-model output ceilings, mirroring ClaudeModels.
  * MistralProvider prefers the live /v1/models listing and only falls back here.
- * Mistral models have no "thinking"/"effort" knobs, so those capabilities are
- * intentionally absent.
+ *
+ * ## Why dated IDs, not `-latest` aliases
+ *
+ * This registry used to pin `mistral-large-latest`, `pixtral-large-latest` and
+ * friends on the assumption that aliases stay current by themselves. They do
+ * not survive a family being retired: `pixtral-large-2411` was retired on
+ * 2026-05-31 and `ministral-8b-2410` on 2025-12-31, which left the vision
+ * fallback pointing at a model the API no longer serves. Dated IDs fail loudly
+ * against Mistral's published deprecation table instead of silently, and the
+ * live /v1/models call already covers "what is actually available today".
+ *
+ * ## Reasoning
+ *
+ * Mistral Small 4 and Medium 3.5 are hybrid reasoning models driven by the
+ * `reasoning_effort` request parameter (`none` / `high`) — see ALLOWED_EFFORTS.
+ * There is no thinking *budget*, so those models map onto the app's `effort`
+ * capability, not `thinking`/`thinkingBudget`.
  */
 class MistralModels {
 
-    // ── Model ID constants (latest aliases stay current automatically) ──────
+    // ── Model ID constants ──────────────────────────────────────────────────
 
-    /** Most capable text model. */
-    public const LARGE = 'mistral-large-latest';
+    /** Mistral Large 3 — flagship, 256k context, multimodal. */
+    public const LARGE = 'mistral-large-2512';
 
-    /** Cost-effective general model. */
-    public const SMALL = 'mistral-small-latest';
+    /** Mistral Medium 3.5 — frontier-class multimodal, hybrid reasoning. */
+    public const MEDIUM = 'mistral-medium-3505';
 
-    /** Multimodal (vision) model. */
-    public const PIXTRAL = 'pixtral-large-latest';
+    /** Mistral Small 4 — cost-effective multimodal, hybrid reasoning. */
+    public const SMALL = 'mistral-small-2603';
 
-    /** Fast/cheap model. */
-    public const MINISTRAL = 'ministral-8b-latest';
+    /** Ministral 3 14B — compact multimodal. */
+    public const MINISTRAL_14B = 'ministral-3-14b-2512';
+
+    /** Ministral 3 8B — efficient multimodal. */
+    public const MINISTRAL_8B = 'ministral-3-8b-2512';
+
+    /** Ministral 3 3B — smallest multimodal. */
+    public const MINISTRAL_3B = 'ministral-3-3b-2512';
 
     // ── Application defaults ────────────────────────────────────────────────
 
-    public const DEFAULT_MODEL      = self::SMALL;
+    public const DEFAULT_MODEL = self::SMALL;
     public const DEFAULT_MAX_TOKENS = 8192;
+
+    /**
+     * Model used when the configured one cannot accept image input. Every
+     * current generalist model is multimodal, so this fallback rarely fires;
+     * it exists for models the live listing surfaces that we do not know.
+     */
+    public const VISION_MODEL = self::SMALL;
 
     // ── Per-model output token ceilings ─────────────────────────────────────
 
+    /**
+     * Mistral publishes context windows, not output ceilings, so these stay at
+     * the conservative values the app has always used rather than being
+     * invented from the context size.
+     */
     private const MAX_TOKENS_CEILING = [
-        self::LARGE     => 131072,
-        self::SMALL     => 32768,
-        self::PIXTRAL   => 131072,
-        self::MINISTRAL => 32768,
+        self::LARGE         => 131072,
+        self::MEDIUM        => 131072,
+        self::SMALL         => 32768,
+        self::MINISTRAL_14B => 32768,
+        self::MINISTRAL_8B  => 32768,
+        self::MINISTRAL_3B  => 32768,
     ];
 
     /** Models capable of image (vision) input. */
     private const VISION_MODELS = [
-        self::PIXTRAL => true,
+        self::LARGE         => true,
+        self::MEDIUM        => true,
+        self::SMALL         => true,
+        self::MINISTRAL_14B => true,
+        self::MINISTRAL_8B  => true,
+        self::MINISTRAL_3B  => true,
+    ];
+
+    /**
+     * Families whose members are all multimodal. Lets a newer dated ID coming
+     * back from the live /v1/models listing be recognised before this registry
+     * catches up.
+     */
+    private const VISION_PREFIXES = [
+        'mistral-large-',
+        'mistral-medium-',
+        'mistral-small-',
+        'ministral-3-',
+    ];
+
+    // ── Reasoning effort ────────────────────────────────────────────────────
+
+    /**
+     * Every `reasoning_effort` value any model accepts; used for settings
+     * validation. `high` returns a thinking chunk ahead of the answer, `none`
+     * suppresses it.
+     */
+    public const ALL_EFFORTS = ['none', 'high'];
+
+    /** Models that accept `reasoning_effort`; others reject it with a 400. */
+    private const ALLOWED_EFFORTS = [
+        self::SMALL  => self::ALL_EFFORTS,
+        self::MEDIUM => self::ALL_EFFORTS,
     ];
 
     /**
@@ -57,11 +124,32 @@ class MistralModels {
     }
 
     /**
-     * Whether a model accepts image input. Latest-suffixed pixtral variants and
-     * any model whose id contains "pixtral" are treated as vision-capable.
+     * Whether a model accepts image input.
      */
     public static function supportsVision(string $model): bool {
-        return (self::VISION_MODELS[$model] ?? false) || str_contains($model, 'pixtral');
+        if (self::VISION_MODELS[$model] ?? false) {
+            return true;
+        }
+        foreach (self::VISION_PREFIXES as $prefix) {
+            if (str_starts_with($model, $prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * `reasoning_effort` values the API accepts for a model; empty if the model
+     * has no reasoning mode.
+     *
+     * @return list<string>
+     */
+    public static function getAllowedEfforts(string $model): array {
+        return self::ALLOWED_EFFORTS[$model] ?? [];
+    }
+
+    public static function isAllowedEffort(string $model, string $effort): bool {
+        return in_array($effort, self::getAllowedEfforts($model), true);
     }
 
     /**
@@ -73,9 +161,11 @@ class MistralModels {
     public static function getAllModels(): array {
         return [
             self::LARGE,
-            self::PIXTRAL,
+            self::MEDIUM,
             self::SMALL,
-            self::MINISTRAL,
+            self::MINISTRAL_14B,
+            self::MINISTRAL_8B,
+            self::MINISTRAL_3B,
         ];
     }
 }

--- a/nextcloud-app/lib/Service/Provider/AbstractOpenAiCompatibleProvider.php
+++ b/nextcloud-app/lib/Service/Provider/AbstractOpenAiCompatibleProvider.php
@@ -140,6 +140,16 @@ abstract class AbstractOpenAiCompatibleProvider implements LLMProviderInterface 
         ]);
     }
 
+    /**
+     * OpenAI-compatible endpoints expose no portable effort knob; subclasses
+     * with one override this.
+     *
+     * @return list<string>
+     */
+    public function getAllowedEfforts(string $model): array {
+        return [];
+    }
+
     /** Model id offered when nothing is configured; used by the schema default. */
     abstract protected function defaultModel(): string;
 

--- a/nextcloud-app/lib/Service/Provider/LLMProviderInterface.php
+++ b/nextcloud-app/lib/Service/Provider/LLMProviderInterface.php
@@ -67,6 +67,18 @@ interface LLMProviderInterface {
     public function getCapabilities(): array;
 
     /**
+     * Effort values this provider accepts for $model, in the provider's own
+     * vocabulary (Anthropic's low…max, Mistral's none/high, …); empty when the
+     * model — or the provider — has no effort knob.
+     *
+     * Callers must not validate one provider's effort against another's table;
+     * that is what this exists for.
+     *
+     * @return list<string>
+     */
+    public function getAllowedEfforts(string $model): array;
+
+    /**
      * List available model IDs for the configured key, or null on error
      * (caller falls back to the static registry).
      *

--- a/nextcloud-app/lib/Service/Provider/MistralProvider.php
+++ b/nextcloud-app/lib/Service/Provider/MistralProvider.php
@@ -95,6 +95,16 @@ class MistralProvider implements LLMProviderInterface {
                 MistralModels::DEFAULT_MODEL,
                 'Used for every request unless a conversation pins a different one.',
             ),
+            ProviderSettingsSchema::select(
+                'effort',
+                'effort_mistral',
+                'Default reasoning effort',
+                'Only Mistral Small 4 and Medium 3.5 reason. "high" makes the model think before answering (more tokens); "none" keeps it direct. Blank leaves the parameter off entirely. Overridable per conversation with /effort.',
+                array_merge([''], MistralModels::ALL_EFFORTS),
+                group: ProviderSettingsSchema::GROUP_BASIC,
+                scope: ProviderSettingsSchema::SCOPE_BOTH,
+                userKey: 'user_effort_mistral',
+            ),
             ProviderSettingsSchema::maxTokens('max_tokens_mistral', MistralModels::DEFAULT_MAX_TOKENS),
             ProviderSettingsSchema::timeout('api_timeout', 30, 'Shared across all hosted providers.'),
             ProviderSettingsSchema::text(
@@ -112,8 +122,36 @@ class MistralProvider implements LLMProviderInterface {
             'vision' => true,
             'tools' => true,
             'streaming' => true,
+            'effort' => true,
             'native_mcp' => true,
         ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getAllowedEfforts(string $model): array {
+        return MistralModels::getAllowedEfforts($model);
+    }
+
+    /**
+     * Resolve `reasoning_effort` for a request: conversation override → user
+     * setting → admin setting. Values the model does not accept fall through
+     * to the next level; null means "omit the parameter".
+     */
+    private function resolveEffort(string $model, ?string $override, ?string $userId): ?string {
+        $candidates = [$override];
+        if ($userId !== null) {
+            $candidates[] = $this->config->getUserValue($userId, self::APP_NAME, 'user_effort_mistral', '');
+        }
+        $candidates[] = $this->config->getAppValue(self::APP_NAME, 'effort_mistral', '');
+
+        foreach ($candidates as $candidate) {
+            if (is_string($candidate) && $candidate !== '' && MistralModels::isAllowedEffort($model, $candidate)) {
+                return $candidate;
+            }
+        }
+        return null;
     }
 
     public function listModels(?string $userId = null): ?array {
@@ -204,7 +242,7 @@ class MistralProvider implements LLMProviderInterface {
     private function visionOptions(?string $userId): array {
         return MistralModels::supportsVision($this->getModel($userId))
             ? []
-            : ['model' => MistralModels::PIXTRAL];
+            : ['model' => MistralModels::VISION_MODEL];
     }
 
     public function askWithDocument(string $prompt, string $documentData, string $mediaType, string $title = '', ?string $userId = null, bool $cacheDoc = true, bool $citations = true, ?string $fileId = null): array {
@@ -234,7 +272,7 @@ class MistralProvider implements LLMProviderInterface {
             return ['error' => 'Mistral returned no choices'];
         }
         return [
-            'response' => (string)($choice['message']['content'] ?? ''),
+            'response' => $this->extractMessageText($choice['message']['content'] ?? ''),
             'usage' => $this->extractUsage($data['usage'] ?? []),
             'citations' => [],
         ];
@@ -256,7 +294,8 @@ class MistralProvider implements LLMProviderInterface {
             $this->accumulateUsage($total, $data['usage'] ?? []);
             $choice = $data['choices'][0] ?? [];
             $message = $choice['message'] ?? [];
-            $text = (string)($message['content'] ?? '');
+            $text = $this->extractMessageText($message['content'] ?? '');
+            $thinking = $this->extractThinkingText($message['content'] ?? '');
             $toolCalls = $message['tool_calls'] ?? [];
             $finalText = $text;
 
@@ -264,7 +303,7 @@ class MistralProvider implements LLMProviderInterface {
                 return ['response' => $text, 'usage' => $this->finalizeUsage($total), 'citations' => []];
             }
 
-            $messages[] = $this->assistantMessageFromToolCalls($text, $toolCalls);
+            $messages[] = $this->assistantMessageFromToolCalls($text, $toolCalls, $thinking);
             $messages[] = ['role' => 'user', 'content' => $this->executeToolCalls($toolCalls, $toolExecutor)];
         }
 
@@ -290,6 +329,7 @@ class MistralProvider implements LLMProviderInterface {
             $body = $this->buildBody($messages, $system, $userId, $options, true);
 
             $text = '';
+            $thinking = '';
             /** @var array<int, array{id: string, name: string, arguments: string}> $toolAcc */
             $toolAcc = [];
             $finishReason = null;
@@ -325,8 +365,11 @@ class MistralProvider implements LLMProviderInterface {
                             continue;
                         }
                         $delta = $choice['delta'] ?? [];
-                        $deltaText = $delta['content'] ?? null;
-                        if (is_string($deltaText) && $deltaText !== '') {
+                        // With reasoning on, `content` is a chunk list while the
+                        // model thinks and a plain string afterwards.
+                        $thinking .= $this->extractThinkingText($delta['content'] ?? '');
+                        $deltaText = $this->extractMessageText($delta['content'] ?? '');
+                        if ($deltaText !== '') {
                             $text .= $deltaText;
                             yield ['type' => 'text_delta', 'text' => $deltaText];
                         }
@@ -366,7 +409,7 @@ class MistralProvider implements LLMProviderInterface {
                 return;
             }
 
-            $messages[] = $this->assistantMessageFromToolCalls($text, $toolCalls);
+            $messages[] = $this->assistantMessageFromToolCalls($text, $toolCalls, $thinking);
             foreach ($toolCalls as $tc) {
                 yield ['type' => 'tool_use', 'id' => $tc['id'], 'name' => $tc['function']['name'], 'input' => $this->decodeArguments($tc['function']['arguments'])];
             }
@@ -442,7 +485,7 @@ class MistralProvider implements LLMProviderInterface {
 
                     switch ($event['type'] ?? '') {
                         case 'message.output.delta':
-                            $text = $this->extractDeltaText($event['content'] ?? '');
+                            $text = $this->extractMessageText($event['content'] ?? '');
                             if ($text !== '') {
                                 yield ['type' => 'text_delta', 'text' => $text];
                             }
@@ -550,8 +593,9 @@ class MistralProvider implements LLMProviderInterface {
      * Build a Conversations API request body from app-format messages.
      */
     private function buildConversationBody(array $messages, ?string $system, array $tools, ?string $userId, array $options, bool $stream): array {
+        $model = $this->getModel($userId);
         $body = [
-            'model' => $this->getModel($userId),
+            'model' => $model,
             'inputs' => $this->toConversationInputs($messages),
             'tools' => $tools,
             'stream' => $stream,
@@ -561,6 +605,10 @@ class MistralProvider implements LLMProviderInterface {
             $body['instructions'] = $system;
         }
         $completionArgs = ['max_tokens' => $this->getMaxTokens($userId)];
+        $effort = $this->resolveEffort($model, $options['effort'] ?? null, $userId);
+        if ($effort !== null) {
+            $completionArgs['reasoning_effort'] = $effort;
+        }
         foreach (['temperature', 'top_p'] as $key) {
             if (array_key_exists($key, $options)) {
                 $completionArgs[$key] = $options[$key];
@@ -670,12 +718,14 @@ class MistralProvider implements LLMProviderInterface {
     }
 
     /**
-     * Extract plain text from a message.output.delta `content` field, which may
-     * be a string or an array of content chunks.
+     * Extract the answer text from a `content` field. Mistral returns a plain
+     * string normally, but a list of chunks when reasoning is on (and for
+     * Conversations API deltas). ThinkChunks are skipped here — they are
+     * carried separately by extractThinkingText().
      *
      * @param mixed $content
      */
-    private function extractDeltaText($content): string {
+    private function extractMessageText($content): string {
         if (is_string($content)) {
             return $content;
         }
@@ -689,6 +739,27 @@ class MistralProvider implements LLMProviderInterface {
             return $text;
         }
         return '';
+    }
+
+    /**
+     * Extract the reasoning trace from a `content` field: the concatenated text
+     * of every ThinkChunk (`{type: thinking, thinking: [TextChunk, …]}`).
+     *
+     * @param mixed $content
+     */
+    private function extractThinkingText($content): string {
+        if (!is_array($content)) {
+            return '';
+        }
+        $text = '';
+        foreach ($content as $part) {
+            if (!is_array($part) || ($part['type'] ?? '') !== 'thinking') {
+                continue;
+            }
+            $inner = $part['thinking'] ?? '';
+            $text .= is_string($inner) ? $inner : $this->extractMessageText($inner);
+        }
+        return $text;
     }
 
     /**
@@ -722,6 +793,10 @@ class MistralProvider implements LLMProviderInterface {
         ];
         if ($stream) {
             $body['stream'] = true;
+        }
+        $effort = $this->resolveEffort($model, $options['effort'] ?? null, $userId);
+        if ($effort !== null) {
+            $body['reasoning_effort'] = $effort;
         }
         foreach (['temperature', 'top_p'] as $key) {
             if (array_key_exists($key, $options)) {
@@ -841,9 +916,15 @@ class MistralProvider implements LLMProviderInterface {
             $toolUses = array_values(array_filter($content, fn($b) => is_array($b) && ($b['type'] ?? '') === 'tool_use'));
             if ($role === 'assistant' && $toolUses !== []) {
                 $text = '';
+                $thinking = '';
                 foreach ($content as $b) {
-                    if (is_array($b) && ($b['type'] ?? '') === 'text') {
+                    if (!is_array($b)) {
+                        continue;
+                    }
+                    if (($b['type'] ?? '') === 'text') {
                         $text .= $b['text'] ?? '';
+                    } elseif (($b['type'] ?? '') === 'thinking') {
+                        $thinking .= is_string($b['thinking'] ?? '') ? $b['thinking'] : '';
                     }
                 }
                 $toolCalls = [];
@@ -854,7 +935,16 @@ class MistralProvider implements LLMProviderInterface {
                         'function' => ['name' => $b['name'] ?? '', 'arguments' => json_encode($b['input'] ?? new \stdClass())],
                     ];
                 }
-                $out[] = ['role' => 'assistant', 'content' => $text, 'tool_calls' => $toolCalls];
+                $out[] = [
+                    'role' => 'assistant',
+                    'content' => $thinking === ''
+                        ? $text
+                        : [
+                            ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => $thinking]]],
+                            ['type' => 'text', 'text' => $text],
+                        ],
+                    'tool_calls' => $toolCalls,
+                ];
                 continue;
             }
 
@@ -928,9 +1018,16 @@ class MistralProvider implements LLMProviderInterface {
 
     /**
      * Build an app-format assistant message from streamed/returned tool calls.
+     *
+     * $thinking is the reasoning trace, kept as its own block: Mistral's docs
+     * are explicit that stripping it before replaying an assistant turn costs
+     * coherence across turns, so toMistralMessages() sends it straight back.
      */
-    private function assistantMessageFromToolCalls(string $text, array $toolCalls): array {
+    private function assistantMessageFromToolCalls(string $text, array $toolCalls, string $thinking = ''): array {
         $assistantContent = [];
+        if ($thinking !== '') {
+            $assistantContent[] = ['type' => 'thinking', 'thinking' => $thinking];
+        }
         if ($text !== '') {
             $assistantContent[] = ['type' => 'text', 'text' => $text];
         }

--- a/nextcloud-app/package.json
+++ b/nextcloud-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiquila",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Claude AI Integration for Nextcloud",
   "type": "module",
   "main": "src/main.js",

--- a/nextcloud-app/src/components/ChatInput.vue
+++ b/nextcloud-app/src/components/ChatInput.vue
@@ -116,7 +116,7 @@ const SLASH_COMMANDS = [
 		id: 'effort',
 		label: '/effort',
 		icon: '⚡',
-		description: 'Set effort for this conversation (low, medium, high, xhigh, max — e.g. /effort:high; no value resets to default)',
+		description: 'Set effort for this conversation — allowed values depend on the provider and model (e.g. /effort:high; no value resets to default)',
 	},
 	{
 		id: 'thinking',

--- a/nextcloud-app/tests/Unit/MistralProviderTest.php
+++ b/nextcloud-app/tests/Unit/MistralProviderTest.php
@@ -3,6 +3,7 @@
 namespace OCA\AIquila\Tests\Unit;
 
 use OCA\AIquila\Service\CredentialService;
+use OCA\AIquila\Service\MistralModels;
 use OCA\AIquila\Service\Provider\MistralProvider;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
@@ -199,12 +200,90 @@ class MistralProviderTest extends TestCase {
 
     public function testListModels(): void {
         $this->client->method('get')->willReturn($this->jsonResponse([
-            'data' => [['id' => 'mistral-small-latest'], ['id' => 'mistral-large-latest']],
+            'data' => [['id' => MistralModels::SMALL], ['id' => MistralModels::LARGE]],
         ]));
 
         $models = $this->provider->listModels('u');
-        $this->assertContains('mistral-large-latest', $models);
-        $this->assertContains('mistral-small-latest', $models);
+        $this->assertContains(MistralModels::LARGE, $models);
+        $this->assertContains(MistralModels::SMALL, $models);
+    }
+
+    public function testVisionFallbackTargetsACurrentModel(): void {
+        $captured = null;
+        $this->client->method('post')->willReturnCallback(function (string $url, array $opts) use (&$captured) {
+            $captured = json_decode($opts['body'], true);
+            return $this->jsonResponse(['choices' => [['message' => ['content' => 'a cat']]]]);
+        });
+
+        // Default model is Small 4, which is multimodal: no swap.
+        $this->provider->askWithImage('what is this?', 'AAAA', 'image/png', 'u');
+        $this->assertSame(MistralModels::DEFAULT_MODEL, $captured['model']);
+
+        // supportsVision() must not resurrect the retired pixtral heuristic.
+        $this->assertFalse(MistralModels::supportsVision('pixtral-large-latest'));
+        $this->assertTrue(MistralModels::supportsVision(MistralModels::DEFAULT_MODEL));
+        $this->assertSame(MistralModels::VISION_MODEL, MistralModels::SMALL);
+    }
+
+    public function testReasoningEffortIsSentOnlyForModelsThatAcceptIt(): void {
+        $captured = null;
+        $this->client->method('post')->willReturnCallback(function (string $url, array $opts) use (&$captured) {
+            $captured = json_decode($opts['body'], true);
+            return $this->jsonResponse(['choices' => [['message' => ['content' => 'ok']]]]);
+        });
+
+        // No effort requested → parameter omitted entirely.
+        $this->provider->chat([['role' => 'user', 'content' => 'hi']], null, 'u');
+        $this->assertArrayNotHasKey('reasoning_effort', $captured);
+
+        // Small 4 reasons.
+        $this->provider->chat([['role' => 'user', 'content' => 'hi']], null, 'u', ['effort' => 'high']);
+        $this->assertSame('high', $captured['reasoning_effort']);
+
+        // Ministral does not: the value is dropped rather than 400ing the API.
+        $this->provider->chat([['role' => 'user', 'content' => 'hi']], null, 'u', [
+            'effort' => 'high',
+            'model' => MistralModels::MINISTRAL_8B,
+        ]);
+        $this->assertArrayNotHasKey('reasoning_effort', $captured);
+
+        // Anthropic's vocabulary is not Mistral's.
+        $this->provider->chat([['role' => 'user', 'content' => 'hi']], null, 'u', ['effort' => 'xhigh']);
+        $this->assertArrayNotHasKey('reasoning_effort', $captured);
+    }
+
+    public function testAllowedEffortsAreProviderScoped(): void {
+        $this->assertTrue($this->provider->getCapabilities()['effort']);
+        $this->assertSame(['none', 'high'], $this->provider->getAllowedEfforts(MistralModels::MEDIUM));
+        $this->assertSame([], $this->provider->getAllowedEfforts(MistralModels::MINISTRAL_3B));
+    }
+
+    public function testReasoningChunkListContentIsFlattenedToTheAnswer(): void {
+        $this->client->method('post')->willReturn($this->jsonResponse([
+            'choices' => [[
+                'message' => ['content' => [
+                    ['type' => 'thinking', 'thinking' => [['type' => 'text', 'text' => 'let me think']]],
+                    ['type' => 'text', 'text' => '42'],
+                ]],
+                'finish_reason' => 'stop',
+            ]],
+        ]));
+
+        $result = $this->provider->chat([['role' => 'user', 'content' => 'q']], null, 'u');
+        $this->assertSame('42', $result['response']);
+    }
+
+    public function testStreamedThinkingChunksAreNotEmittedAsAnswerText(): void {
+        $sse = "data: {\"choices\":[{\"delta\":{\"content\":[{\"type\":\"thinking\",\"thinking\":[{\"type\":\"text\",\"text\":\"hmm\"}]}]}}]}\n"
+            . "data: {\"choices\":[{\"delta\":{\"content\":\"Answer\"},\"finish_reason\":\"stop\"}]}\n"
+            . "data: [DONE]\n";
+        $this->client->method('post')->willReturn($this->sseResponse($sse));
+
+        $events = iterator_to_array($this->provider->chatWithToolsStream([['role' => 'user', 'content' => 'hi']], [], fn() => [], null, 'u'));
+
+        $deltas = array_values(array_filter($events, fn($e) => $e['type'] === 'text_delta'));
+        $this->assertCount(1, $deltas);
+        $this->assertSame('Answer', $deltas[0]['text']);
     }
 
     public function testNativeMcpWithoutConnectorsYieldsError(): void {


### PR DESCRIPTION
Closes #487

`MistralModels` was written against Mistral's 2024/25 lineup and had gone stale to the point of being broken: `pixtral-large-latest` (retired 2026-05-31) was the forced vision fallback for every image request, and `ministral-8b-latest` (retired 2025-12-31) was still offered in the model list.

## What changed

**Registry** — dated IDs for the current lineup (Large 3 `mistral-large-2512`, Medium 3.5 `mistral-medium-3505`, Small 4 `mistral-small-2603`, Ministral 3 14B/8B/3B) instead of `-latest` aliases. The alias assumption is exactly what let the old entries rot silently; dated IDs can be checked against Mistral's published deprecation table, and the live `/v1/models` call already covers "what is available today". Default model becomes Small 4.

**Vision** — `supportsVision()` drops the `str_contains(…, 'pixtral')` heuristic (every current generalist model is natively multimodal) for a registry lookup plus a family-prefix check, and `visionOptions()` falls back to a model that still exists.

**Reasoning** — Small 4 and Medium 3.5 take `reasoning_effort` (`none`/`high`), mapped onto the app's existing `effort` capability rather than `thinking` (there is no token budget). Resolution: conversation override → user setting → admin setting, with values the model does not accept dropped rather than sent. With reasoning on the response `content` is a chunk list instead of a string in both the blocking and streaming paths, so text extraction goes through `extractMessageText()`; the reasoning trace is kept separately and replayed on assistant turns inside a tool loop, which Mistral's docs require for coherence.

**Effort vocabularies** — `ConversationController::update()` validated every provider's effort against `ClaudeModels`, which does not describe Mistral. Added `LLMProviderInterface::getAllowedEfforts()` so each provider owns its table; the OpenAI-compatible base returns `[]`, covering DeepSeek/Local/Hetzner.

**Also** — renamed the `classify-images-pixtral` coworker template (read-only seed data, no migration), and bumped both components to 0.4.7.

## Verification

- `composer psalm` clean, 608 PHP tests pass (5 new), 914 MCP-server tests pass, lint + prettier clean.
- Deployed to the dev stack and checked at runtime: capabilities report `effort: true`, the schema exposes the effort select with `["", "none", "high"]`, the default model resolves to `mistral-small-2603`, Ministral reports no efforts, Claude's `low…max` table is untouched, and no new ERROR/FATAL lines in `nextcloud.log`.
- Not exercised: live chat/vision/reasoning calls against the Mistral API — no key available in this environment.

## Known limitation

Persisted history stores assistant messages as plain text, so a reasoning trace does not survive a page reload; it is only replayed within a single request's agentic loop. Documented in `docs/dev/mistral-provider.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)