### PR TITLE
fix(mcp): Talk chat endpoints live under api/v1, not api/v4

### DIFF
--- a/mcp-server/src/__tests__/talk.test.ts
+++ b/mcp-server/src/__tests__/talk.test.ts
@@ -490,6 +490,54 @@ describe('Talk Tools', () => {
     });
   });
 
+  // ── Chat endpoint version ───────────────────────────────────────────
+  // Rooms and participants live under api/v4, but the chat endpoints are
+  // api/v1 — calling them under v4 yields a 404 "Invalid query" from Talk.
+
+  describe('chat endpoint version', () => {
+    const chatV1 = 'https://cloud.example.com/ocs/v2.php/apps/spreed/api/v1/chat/abc123';
+
+    function calledUrl(): string {
+      const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      return String(url);
+    }
+
+    it('lists messages from the v1 chat endpoint', async () => {
+      mockOCS([]);
+
+      const { listMessagesTool } = await import('../tools/apps/talk.js');
+      await listMessagesTool.handler({ token: 'abc123' });
+
+      expect(calledUrl().split('?')[0]).toBe(chatV1);
+    });
+
+    it('sends messages to the v1 chat endpoint', async () => {
+      mockOCS({
+        id: 1,
+        actorId: 'testuser',
+        actorDisplayName: 'Test User',
+        message: 'hi',
+        messageParameters: {},
+        timestamp: 1700000000,
+        systemMessage: '',
+      });
+
+      const { sendMessageTool } = await import('../tools/apps/talk.js');
+      await sendMessageTool.handler({ token: 'abc123', message: 'hi' });
+
+      expect(calledUrl()).toBe(chatV1);
+    });
+
+    it('deletes messages via the v1 chat endpoint', async () => {
+      mockOCS({});
+
+      const { deleteMessageTool } = await import('../tools/apps/talk.js');
+      await deleteMessageTool.handler({ token: 'abc123', messageId: 42 });
+
+      expect(calledUrl()).toBe(`${chatV1}/42`);
+    });
+  });
+
   // ── Network errors ──────────────────────────────────────────────────
 
   describe('network errors', () => {

--- a/mcp-server/src/tools/apps/talk.ts
+++ b/mcp-server/src/tools/apps/talk.ts
@@ -195,7 +195,7 @@ export const listMessagesTool = {
         queryParams.lastKnownMessageId = String(args.lastKnownMessageId);
       }
 
-      const data = await fetchOCS<ChatMessage[]>(`${API_V4}/chat/${args.token}`, { queryParams });
+      const data = await fetchOCS<ChatMessage[]>(`${API_V1}/chat/${args.token}`, { queryParams });
       let messages = data.ocs.data ?? [];
 
       if (!args.includeSystemMessages) {
@@ -246,7 +246,7 @@ export const sendMessageTool = {
       if (args.replyTo !== undefined) body.replyTo = String(args.replyTo);
       if (args.silent) body.silent = 'true';
 
-      const data = await fetchOCS<ChatMessage>(`${API_V4}/chat/${args.token}`, {
+      const data = await fetchOCS<ChatMessage>(`${API_V1}/chat/${args.token}`, {
         method: 'POST',
         body,
       });
@@ -444,7 +444,7 @@ export const deleteMessageTool = {
   }),
   handler: async (args: { token: string; messageId: number }) => {
     try {
-      await fetchOCS(`${API_V4}/chat/${args.token}/${args.messageId}`, {
+      await fetchOCS(`${API_V1}/chat/${args.token}/${args.messageId}`, {
         method: 'DELETE',
       });
       return text(`Message ${args.messageId} deleted from conversation ${args.token}.`);


### PR DESCRIPTION
## Description
`talk_list_messages`, `talk_send_message` and `talk_delete_message` request `/ocs/v2.php/apps/spreed/api/v4/chat/{token}`. Talk serves rooms and participants under `api/v4`, but the chat API is `api/v1` — so every chat call returns `404` with OCS statuscode 998 (`Invalid query, please check the syntax`). Polls (`api/v1/poll`), reactions (`api/v1/reaction`) and all room calls were already on the right version.

This PR switches the three chat handlers to `API_V1` (three lines in `talk.ts`) and adds three tests that assert the URL the handlers actually request. The existing Talk tests mock `fetch` and only check the rendered text, which is why the wrong path never failed a test — the new cases fail on v4 and pass on v1.

Verified against a live Nextcloud 33.0.6 / Talk 23.0.8 instance: `talk_list_conversations` worked before and after, `talk_list_messages` went from 404 to returning messages, sending and editing work on the v1 path.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Component
- [x] MCP Server
- [ ] Nextcloud App
- [ ] Documentation
- [ ] CI/CD

## Checklist
- [x] I have tested my changes locally (`npm test` 911/911, `npm run lint` 0 errors, `npx prettier --check src/`, `npm run build`)
- [x] I have added tests for new functionality (3 URL assertions in `src/__tests__/talk.test.ts`)
- [ ] I have updated the documentation if needed (not needed — no user-facing change beyond the tools working)
- [x] My code follows the project's style guidelines

## Related Issues
No existing issue — found while using `talk_list_messages` from Claude Code against a Talk 23 instance.
